### PR TITLE
Translate remaining bug tracker settings docs

### DIFF
--- a/src/content/docs/bug-tracker-settings/bug-tracker-settings.md
+++ b/src/content/docs/bug-tracker-settings/bug-tracker-settings.md
@@ -7,12 +7,13 @@ updated: '2025-09-18'
 sourceUrl: 'https://help.testim.io/docs/bug-tracker-settings'
 keywords:
   - Testim
-  - バグトラッカー
-  - issue
-  - Jira
-  - Trello
-  - Slack
-  - GitHub
+  - バグトラッカー設定
+  - バグ報告
+  - issue管理
+  - Jira連携
+  - Trello連携
+  - Slack連携
+  - GitHub連携
 ---
 
 # バグトラッカー設定
@@ -29,7 +30,7 @@ bug や issue を tracking system に報告する方法はいくつかありま�
 
 ![失敗した実行から Create issue を選択](/images/bug-tracker-settings/bug-tracker-settings/78599fb-tagtestwithcreateissue.png)
 
-- [Testim Extension](/docs/testim-extension-overview) を使うと、issue を [Screenshot](/docs/testim-extension-capture-screenshot) または [Video & Bug Scenario](/docs/testim-extension-capture-video-bug-scenario) としてキャプチャし、**Publish** をクリックして送信できます。
+- [Testim Chrome Extension](/docs/testim-extension-overview) を使うと、issue を [Screenshot](/docs/testim-extension-capture-screenshot) または [Video & Bug Scenario](/docs/testim-extension-capture-video-bug-scenario) としてキャプチャし、**Publish** をクリックして送信できます。
 
 ![Testim Extension から bug を Publish](/images/bug-tracker-settings/bug-tracker-settings/23ee812-publishbug.png)
 

--- a/src/content/docs/bug-tracker-settings/connecting-testim-to-github.md
+++ b/src/content/docs/bug-tracker-settings/connecting-testim-to-github.md
@@ -7,12 +7,13 @@ updated: '2025-09-18'
 sourceUrl: 'https://help.testim.io/docs/connecting-testim-to-github'
 keywords:
   - Testim
+  - GitHub連携
   - GitHub Issues
-  - GitHub
   - バグトラッカー
-  - issue
-  - Bug Tracker
-  - Settings
+  - バグ報告
+  - issue作成
+  - 接続設定
+  - 不具合管理
 ---
 
 # TestimとGitHubの連携

--- a/src/content/docs/bug-tracker-settings/connecting-testim-to-jira.md
+++ b/src/content/docs/bug-tracker-settings/connecting-testim-to-jira.md
@@ -1,60 +1,38 @@
 ---
 title: TestimとJiraの連携
-description: TestimとJiraを連携してバグレポートを自動化する方法を説明します。統合設定、課題の作成、テスト結果とJiraチケットの連携方法を網羅しています。
+description: Testim から Jira に bug を公開するための接続手順を説明します。Bug ticket に含まれる内容と Jira への初回接続フローを確認できます。
 category: 統合
 order: 12034
 updated: '2025-09-18'
 sourceUrl: 'https://help.testim.io/docs/connecting-testim-to-jira'
 keywords:
-  - testim
-  - jira
+  - Testim
+  - Jira連携
+  - バグ報告
   - バグトラッカー
-  - 課題管理
-  - 統合設定
+  - Jira issue
+  - 不具合チケット
+  - 接続設定
 ---
 
 # TestimとJiraの連携
 
-Jiraは、プロジェクト管理と課題追跡のための強力なツールです。TestimとJiraを連携することで、テスト失敗時に自動的にJiraの課題を作成し、効率的にバグを追跡できます。
+Testim は、新しい Bug ticket を作成します。これには、bug の詳細な説明、bug の再現手順、screen resolution と browser、bug の screenshot が含まれます。次の screenshot は、説明や screenshot などを含む、実際に作成された Bug Ticket の例です。詳細については、[Bug Reporting](/docs/bug-reporting) を参照してください。
 
-## Jira連携の設定
+![Jira に作成された Bug Ticket の例](/images/bug-tracker-settings/connecting-testim-to-jira/6290943-image.png)
 
-1. Testimにログインします
-2. **Settings（設定）** > **Integration（統合）** に移動します
-3. **Jira**セクションを見つけます
-4. **Connect（接続）** をクリックします
-5. Jiraの認証情報を入力します：
-   - **Jira URL**: JiraインスタンスのURL（例：`https://your-company.atlassian.net`）
-   - **Email**: Jiraアカウントのメールアドレス
-   - **API Token**: JiraのAPIトークン（[Atlassianアカウント設定](https://id.atlassian.com/manage-profile/security/api-tokens)で生成）
-6. **Connect（接続）** をクリックして接続を完了します
+Testim を Jira に接続するには、まず Jira に login する必要があります。初回の handshake が確立されると、その後は接続を再設定しなくても Jira に issue を作成できるようになります。
 
-## Jira課題の作成
+## TestimをJiraに接続する
 
-テスト失敗時にJira課題を作成するには：
+1. `Settings > Bug Tracker` に移動します。
+2. Jira が選択されており、すでに Jira に logged in していることを確認します。
+3. `Host` field に Jira site の URL を入力します。たとえば `https://<yourcompany>.atlassian.net` です。
 
-1. テスト結果画面を開きます
-2. 失敗したステップを選択します
-3. **Create Bug（バグを作成）** ボタンをクリックします
-4. **Jira**を選択します
-5. 課題の詳細を入力します：
-   - **Project（プロジェクト）**: Jiraプロジェクトを選択
-   - **Issue Type（課題タイプ）**: バグ、タスクなどを選択
-   - **Summary（要約）**: 課題のタイトル
-   - **Description（説明）**: 詳細な説明（自動的にテスト情報が含まれます）
-6. **Create（作成）** をクリックします
+![Jira の Host field](/images/bug-tracker-settings/connecting-testim-to-jira/f26f1c9-jira1.PNG)
 
-作成されたJira課題には、以下の情報が自動的に含まれます：
-- テスト名
-- 失敗したステップ
-- スクリーンショット
-- エラーメッセージ
-- テスト実行へのリンク
+logged in していない場合は、**Log in** リンクをクリックして Jira に login します。
 
-## トラブルシューティング
+4. **Select** をクリックします。**Select** ボタンは **Selected** に置き換わります。
 
-接続に問題がある場合は、以下を確認してください：
-
-- Jira URLが正しいか（`https://`を含む完全なURL）
-- APIトークンが有効か
-- Jiraアカウントに課題を作成する権限があるか
+![Jira 接続後に Selected が表示された状態](/images/bug-tracker-settings/connecting-testim-to-jira/ac0f29a-jira2.png)

--- a/src/content/docs/bug-tracker-settings/connecting-testim-to-slack.md
+++ b/src/content/docs/bug-tracker-settings/connecting-testim-to-slack.md
@@ -9,10 +9,12 @@ keywords:
   - Testim
   - Slack連携
   - バグトラッカー
-  - Slack
-  - channel
-  - Bug Reporting
+  - バグ報告
+  - Slack channel
+  - 接続設定
+  - アクセス権限
   - プロ機能
+  - 不具合通知
 ---
 
 # TestimとSlackの連携

--- a/src/content/docs/bug-tracker-settings/connecting-testim-to-trello.md
+++ b/src/content/docs/bug-tracker-settings/connecting-testim-to-trello.md
@@ -1,58 +1,40 @@
 ---
 title: TestimとTrelloの連携
-description: >-
-  TestimとTrelloを連携してバグレポートをTrelloカードとして管理する方法を説明します。統合設定、カード作成、テスト結果の追跡方法を網羅しています。
+description: Testim から Trello に bug を公開するための接続手順を説明します。Testim Automate への認可と Trello への初回接続フローを確認できます。
 category: 統合
 order: 12035
 updated: '2025-09-18'
 sourceUrl: 'https://help.testim.io/docs/connecting-testim-to-trello'
 keywords:
-  - trello
+  - Testim
+  - Trello連携
+  - バグ報告
   - バグトラッカー
-  - カード管理
-  - 統合設定
+  - Trelloカード
+  - 接続設定
+  - 不具合管理
 ---
 
 # TestimとTrelloの連携
 
-Trelloは、カンバンボードを使用したプロジェクト管理ツールです。TestimとTrelloを連携することで、テスト失敗時に自動的にTrelloカードを作成し、視覚的にバグを管理できます。
+Testim は、新しい bug ticket を作成します。これには、bug の詳細な説明、bug の再現手順、screen resolution と browser、bug の screenshot が含まれます。Testim を Trello に接続するには、以下で説明するように access permission を Testim Automate に付与する必要があります。
 
-## Trello連携の設定
+## TestimをTrelloに接続する
 
-1. Testimにログインします
-2. **Settings（設定）** > **Integration（統合）** に移動します
-3. **Trello**セクションを見つけます
-4. **Connect（接続）** をクリックします
-5. Trelloの認証画面が表示されます
-6. **Allow（許可）** をクリックしてTestimにアクセスを許可します
-7. 接続が完了します
+1. `Settings > Bug Tracker` に移動します。
+2. **Trello** ロゴをクリックします。
+3. **Log in** リンクをクリックします。
 
-## Trelloカードの作成
+![Trello の Log in リンク](/images/bug-tracker-settings/connecting-testim-to-trello/7e41e35-trello1.png)
 
-テスト失敗時にTrelloカードを作成するには：
+次の notice が表示されます。
 
-1. テスト結果画面を開きます
-2. 失敗したステップを選択します
-3. **Create Bug（バグを作成）** ボタンをクリックします
-4. **Trello**を選択します
-5. カードの詳細を入力します：
-   - **Board（ボード）**: Trelloボードを選択
-   - **List（リスト）**: リストを選択（例：To Do、Bugs）
-   - **Title（タイトル）**: カードのタイトル
-   - **Description（説明）**: 詳細な説明（自動的にテスト情報が含まれます）
-6. **Create（作成）** をクリックします
+![Trello の認可 notice](/images/bug-tracker-settings/connecting-testim-to-trello/cea3497-trello2.PNG)
 
-作成されたTrelloカードには、以下の情報が自動的に含まれます：
-- テスト名
-- 失敗したステップ
-- スクリーンショット
-- エラーメッセージ
-- テスト実行へのリンク
+4. **Log in** をクリックし、アカウントに login します。
 
-## トラブルシューティング
+次の notice が表示されます。
 
-接続に問題がある場合は、以下を確認してください：
+![Trello へのアクセス許可 notice](/images/bug-tracker-settings/connecting-testim-to-trello/7fdec49-trello3.PNG)
 
-- Trelloアカウントが有効か
-- Testimに必要な権限が付与されているか
-- 選択したボードへのアクセス権限があるか
+5. **Allow** をクリックします。


### PR DESCRIPTION
## Summary
- align the remaining bug tracker settings pages with their source docs
- restore missing or incorrect source details for Jira and Trello connection steps and image placement
- normalize bug tracker page labels and keywords to match the translation guide

## Validation
- npm run lint:docs
- npm run lint
- npm run test
- npm run build