### PR TITLE
docs: refine device management section labels

### DIFF
--- a/src/content/docs/test-management/view-local-connected-mobile-devices.md
+++ b/src/content/docs/test-management/view-local-connected-mobile-devices.md
@@ -1,6 +1,6 @@
 ---
 title: ローカル接続モバイルデバイスの表示
-description: Tricentis Mobile Agentに接続されたローカルモバイルデバイスの表示方法について説明します。
+description: Tricentis Mobile Agent に接続された物理および仮想モバイルデバイスを Local Devices で確認し、UDID をコピーする手順を説明します。
 category: デバイス管理
 order: 11001
 updated: '2025-09-22'
@@ -14,9 +14,9 @@ keywords:
   - モバイルテスト実行端末
 ---
 
-ローカルデバイスセクションでは、Tricentis Mobile Agent（TMA）に接続されているすべての物理および仮想モバイルデバイスを表示できます。モバイルデバイスの追加と管理の詳細については、[Tricentis Mobile Agentの設定](/docs/configure-tricentis-mobile-agent)を参照してください。
+Local Devices セクションでは、Tricentis Mobile Agent（TMA）に接続されているすべての物理および仮想モバイルデバイスを表示できます。モバイルデバイスの追加と管理の詳細については、[Configure Tricentis Mobile Agent](/docs/configure-tricentis-mobile-agent)を参照してください。
 
-## 接続されているローカルデバイスの表示
+## 接続されている Local Devices の表示
 
 :fa-arrow-right: **接続されているデバイスを表示するには:**
 
@@ -28,11 +28,11 @@ keywords:
 
 ![Local Devicesタブに接続済みモバイルデバイスの一覧が表示された画面](/images/test-management/view-local-connected-mobile-devices/6f8b3e6-local_devices.png)
 
-### デバイスUDIDのコピー
+### デバイス UDID のコピー
 
-デバイスUDIDを簡単にコピーして、たとえばCLIを通じて特定のデバイスでテストを実行するために使用できます。
+device UDID は簡単にコピーでき、たとえば CLI を通じて特定のデバイスでテストを実行するために使用できます。
 
-:fa-arrow-right: **デバイスUDIDをコピーするには:**
+:fa-arrow-right: **デバイス UDID をコピーするには:**
 
 1. UDIDにカーソルを合わせます。\
    コピーアイコンが表示されます。


### PR DESCRIPTION
## Summary
- align the device management page wording with source labels such as Local Devices and UDID
- keep the existing source-parity structure, images, and steps unchanged
- tighten the description and related internal link text for this section-only update

## Validation
- npm run lint:docs -- --section='device managment'
- npm run lint:docs
- npm run lint
- npm run test
- npm run build