### PR TITLE
docs: restore Grid Management source parity

### DIFF
--- a/src/content/docs/grid-management/bitbucket-integration.md
+++ b/src/content/docs/grid-management/bitbucket-integration.md
@@ -1,98 +1,81 @@
 ---
-title: Bitbucket統合
+title: Bitbucket Integration
 description: >-
-  TestimとBitbucketを統合してバージョン管理とCI/CDパイプラインを連携させる方法を説明します。リポジトリ接続、Bitbucket
-  Pipelines設定、自動テスト実行を網羅しています。
+  Bitbucket repository と Testim branch を自動で mirror する Bitbucket
+  integration の有効化手順と、branch / Pull Request / merge の挙動を説明します。
 category: 統合
 order: 12032
 updated: '2025-09-22'
 sourceUrl: 'https://help.testim.io/docs/bitbucket-integration'
 keywords:
   - Bitbucket
-  - バージョン管理
-  - CI/CD
-  - パイプライン
+  - branch
+  - Pull Request
+  - merge
+  - version control
 ---
 
-# Bitbucket統合
+Bitbucket branch を Testim 上で管理できます。
 
-[Bitbucket](https://bitbucket.org/)は、Gitベースのバージョン管理システムおよびCI/CDプラットフォームです。TestimとBitbucketを統合することで、コード変更に合わせて自動的にテストを実行できます。
+Bitbucket は、Mercurial または Git revision control system を使う source code と development project のための Atlassian 製 web ベース version control repository hosting service です。Testim の Bitbucket integration を使用すると、Bitbucket で行った version control 操作を Testim 側へ自動で mirror できます。その結果、Testim の test version を Bitbucket 側の version と一致させられます。Bitbucket で作成した branch は、同じ名前で Testim にも自動作成されます。Bitbucket で branch を merge すると、Testim 側の branch も自動で merge されます。Testim branch の詳細は [こちら](/docs/version-control-branches) を参照してください。
 
-## Bitbucket統合の設定
+## Bitbucket integration を設定する
 
-### 1. Bitbucketリポジトリの準備
+この手順は一度だけ実行すれば十分です。
 
-1. Bitbucketアカウントにログインします
-2. Testimテストを管理するリポジトリを作成または選択します
+:fa-arrow-right: **Bitbucket integration を有効にするには:**
 
-### 2. Testim CLIのセットアップ
+1. Testim で **Settings** > **Integration** tab に移動します。
+2. Bitbucket の下にある **login** link をクリックします。
 
-Bitbucket Pipelinesで Testim CLIを使用するには、以下の手順に従います：
+![Bitbucket integration の login link を表示している Settings > Integration 画面](/images/grid-management/bitbucket-integration/6b41669-Screen_Shot_2020-12-31_at_11.48.08.png)
 
-#### `bitbucket-pipelines.yml` の作成
+3. **Grant Access** button をクリックします。
 
-リポジトリのルートに以下の内容で `bitbucket-pipelines.yml` を作成します：
+![Bitbucket 側で Grant Access button をクリックする画面](/images/grid-management/bitbucket-integration/a509649-Screen_Shot_2020-12-31_at_11.36.31.png)
 
-```yaml
-image: node:14
+4. 接続する repository を選択します。この操作には repository に対する admin access が必要です。
+5. 必要な action の checkbox を選択します。
 
-pipelines:
-  default:
-    - step:
-        name: Testim Tests
-        script:
-          - npm install -g @testim/testim-cli
-          - testim --token "$TESTIM_TOKEN" --project "$TESTIM_PROJECT" --grid "Testim Grid"
-        services:
-          - docker
-```
+   * **Create**: Bitbucket で branch が作成されるたびに、同じ branch が Testim にも作成されます。
+   * **Merge**: Bitbucket branch が merge されるたびに、Testim でも test が自動で merge されます。
 
-### 3. 環境変数の設定
+![Bitbucket integration で Create と Merge の checkbox を選択する画面](/images/grid-management/bitbucket-integration/58d1cac-Screen_Shot_2020-12-31_at_11.49.03.png)
 
-1. Bitbucketリポジトリの **Settings（設定）** > **Repository variables（リポジトリ変数）** に移動します
-2. 以下の変数を追加します：
-   - `TESTIM_TOKEN`: Testimのアクセストークン
-   - `TESTIM_PROJECT`: TestimプロジェクトID
-3. **Secured（保護）** にチェックを入れて変数を保護します
+## Bitbucket を Testim と一緒に使う
 
-## カスタマイズ
+この時点で、Testim project / repository は Bitbucket repository を mirror します。そのため、新しい branch の作成や Pull Request の作成と merge は Bitbucket 側だけで行います。
 
-### 特定のブランチでのみ実行
+### 新しい branch の例
 
-```yaml
-pipelines:
-  branches:
-    master:
-      - step:
-          name: Testim Tests
-          script:
-            - npm install -g @testim/testim-cli
-            - testim --token "$TESTIM_TOKEN" --project "$TESTIM_PROJECT" --grid "Testim Grid"
-```
+次の例では、Bitbucket で `demo-bb-integration` という新しい branch を作成しています。
 
-### 並列実行
+![Bitbucket で demo-bb-integration branch を作成した画面](/images/grid-management/bitbucket-integration/e44f3b2-create1.PNG)
 
-```yaml
-pipelines:
-  default:
-    - parallel:
-        - step:
-            name: Testim Tests - Suite 1
-            script:
-              - npm install -g @testim/testim-cli
-              - testim --token "$TESTIM_TOKEN" --project "$TESTIM_PROJECT" --suite "Suite 1"
-        - step:
-            name: Testim Tests - Suite 2
-            script:
-              - npm install -g @testim/testim-cli
-              - testim --token "$TESTIM_TOKEN" --project "$TESTIM_PROJECT" --suite "Suite 2"
-```
+同じ branch が Testim にも自動作成されます。この branch は Master から fork され、Master に含まれていたすべての test を持ちます。
 
-## トラブルシューティング
+![Testim に同じ branch が自動作成された画面](/images/grid-management/bitbucket-integration/79fbdde-branchintestim.png)
 
-パイプラインが失敗する場合は、以下を確認してください：
+:::info
+Bitbucket で branch を作成した場合、Testim の同名 branch は常に Master branch を基準に作成されます。両側で branch 構造を mirror したい場合は、Pull Request の基準 branch を別 branch ではなく Master branch にしてください。
+:::
 
-- Testim CLIが正しくインストールされているか
-- 環境変数が正しく設定されているか
-- Testimトークンが有効か
-- 選択したグリッドが利用可能か
+### Pull Request と merge
+
+次の例では、Bitbucket である file を変更し、新しい branch (`pr-branch`) 上で Pull Request を開始しています。
+
+:::info
+Bitbucket では Pull Request なしで merge することもできますが、Testim に mirror されるのは Pull Request の一部として行われた merge のみです。
+:::
+
+![Bitbucket で Pull Request を作成した画面](/images/grid-management/bitbucket-integration/dd5c4c5-pullrequest.PNG)
+
+同じ branch が Testim にも自動作成されます。
+
+![Testim に pr-branch が自動作成された画面](/images/grid-management/bitbucket-integration/4bf04a3-pr2.png)
+
+Testim 側に branch が作成された後は、その branch で test を更新し、code 変更を反映することもできます。準備ができたら、Bitbucket で Pull Request を merge します。
+
+![Bitbucket で Pull Request を merge する直前の画面](/images/grid-management/bitbucket-integration/edde410-pr3.PNG)
+
+同じ merge が Testim にも反映され、`pr-branch` に含まれていた test と変更内容が Testim の Master branch に merge されます。

--- a/src/content/docs/grid-management/browserstack-integration-1.md
+++ b/src/content/docs/grid-management/browserstack-integration-1.md
@@ -1,73 +1,69 @@
 ---
-title: BrowserStack統合
+title: BrowserStack Integration
 description: >-
-  TestimとBrowserStackを統合してクラウドベースのブラウザおよびモバイルデバイスでテストを実行する方法を説明します。設定手順、認証情報の管理、実行方法を網羅しています。
+  Testim で BrowserStack Grid を追加し、CLI、CI、Scheduler、Test Plan、Test
+  Editor からテストを実行する方法を説明します。
 category: 統合
 order: 12027
 updated: '2025-09-22'
 sourceUrl: 'https://help.testim.io/docs/browserstack-integration-1'
 keywords:
   - BrowserStack
-  - クラウドグリッド
-  - ブラウザテスト
-  - モバイルテスト
+  - Grid
+  - CLI
+  - Scheduler
+  - Test Plan
 ---
 
-# BrowserStack統合
+Testim で作成したテストを BrowserStack 上で実行できます。
 
-[BrowserStack](https://www.browserstack.com/)は、クラウドベースのブラウザおよびモバイルデバイスでテストを実行できるプラットフォームです。TestimとBrowserStackを統合することで、BrowserStackの広範なブラウザとデバイスのカバレッジを活用できます。
+この記事では、Testim 上で BrowserStack を設定する方法と、テストを実行する方法を説明します。
 
-## 前提条件
+## BrowserStack Grid を追加する
 
-- 有効なBrowserStackアカウント
-- BrowserStackのユーザー名とアクセスキー
+:fa-arrow-right: **BrowserStack Grid を追加するには:**
 
-## BrowserStack統合の設定
+1. [Adding a grid](/docs/grid-management#adding-a-grid) の手順に従い、**Grid Type** で **Browserstack** を選択します。
+2. **Next** をクリックします。
+3. 次の field を入力します。
 
-1. Testimにログインします
-2. **Settings（設定）** > **Integration（統合）** に移動します
-3. **BrowserStack**セクションを見つけます
-4. 以下の情報を入力します：
-   - **Username（ユーザー名）**: BrowserStackのユーザー名
-   - **Access Key（アクセスキー）**: BrowserStackのアクセスキー
-5. **Connect（接続）** をクリックします
+* **Name**: 実行時に使用する Grid 名
+* **Host**: BrowserStack の host name
+* **Port**: BrowserStack の port
+* **Username**: BrowserStack の user name
+* **Password/access key**: 接続に使用する BrowserStack access key または password
 
-## BrowserStackでテストを実行する
+![BrowserStack Grid の接続情報を設定する画面](/images/grid-management/browserstack-integration-1/be4fb2b-Jul-24-2021_08-13-41.gif)
 
-### エディタから実行
+## Grid で実行する方法
 
-1. テストエディタを開きます
-2. **Run（実行）** ボタンをクリックします
-3. **Grid（グリッド）** ドロップダウンから **BrowserStack** を選択します
-4. 実行したいブラウザまたはデバイスを選択します
-5. **Run（実行）** をクリックしてテストを開始します
+次のいずれかの方法で、テストをリモート実行できます。
 
-### CLIから実行
+[CLI](/docs/the-command-line-cli) / [CI](/docs/integrate-testim-to-your-ci)
 
-```bash
-testim --grid browserstack --browser chrome --token <your-token>
-```
+Grid 名を指定して `--grid` parameter を追加します。
 
-### モバイルテストの実行
+[Scheduler](/docs/scheduler)
 
-BrowserStackでモバイルテストを実行する場合：
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
 
-```bash
-testim --grid browserstack --device "iPhone 13" --os-version "15.0" --token <your-token>
-```
+[Test Plan](/docs/test-plans)
 
-### 追加オプション
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
 
-BrowserStackの追加オプション（タイムゾーン、画面解像度など）については、[SauceLabs/BrowserStackオプション](saucelabs-browserstack-options)を参照してください。
+### editor から実行する
 
-## BrowserStackでの結果確認
+Test Editor から直接 Grid 上でテストを実行できます。
 
-テスト実行後、Testim上で結果を確認できます。また、BrowserStackダッシュボードでも詳細なログ、スクリーンショット、ビデオを確認できます。
+* **Run** ボタンの横にある options arrow をクリックします。
+* **Run on a grid** をクリックします。
 
-## トラブルシューティング
+その実行で configuration / Grid / base url を変更したい場合は **Edit** をクリックします。
 
-接続に問題がある場合は、以下を確認してください：
+![Test Editor から BrowserStack Grid を選んで実行する画面](/images/grid-management/browserstack-integration-1/0ca9bb7-Jul-21-2021_13-11-22.gif)
 
-- BrowserStackのユーザー名とアクセスキーが正しいか
-- BrowserStackアカウントがアクティブで、利用可能な並列実行枠があるか
-- 選択したブラウザ/デバイスがBrowserStackで利用可能か
+テスト実行に追加 option を渡したい場合は、[Test capabilities for SauceLabs & BrowserStack in CLI](/docs/saucelabs-browserstack-options) を参照してください。
+
+:::info
+`--grid` parameter は、旧来の host / port parameter を置き換えます。
+:::

--- a/src/content/docs/grid-management/browserstack-integration-copy.md
+++ b/src/content/docs/grid-management/browserstack-integration-copy.md
@@ -1,113 +1,71 @@
 ---
-title: SauceLabs/BrowserStackオプション
+title: LambdaTest Integration
 description: >-
-  SauceLabsおよびBrowserStackで利用可能な高度な設定オプションを説明します。タイムゾーン、画面解像度、デバイス設定、その他のカスタマイズ方法を網羅しています。
+  Testim で LambdaTest Grid を追加し、CLI、CI、Scheduler、Test Plan、Test
+  Editor から実行する方法を説明します。
 category: 統合
 order: 12028
 updated: '2025-09-22'
 sourceUrl: 'https://help.testim.io/docs/browserstack-integration-copy'
 keywords:
-  - SauceLabs
-  - BrowserStack
-  - 設定オプション
-  - カスタマイズ
+  - LambdaTest
+  - Grid
+  - CLI
+  - Scheduler
+  - Test Plan
 ---
 
-# SauceLabs/BrowserStackオプション
+Testim で作成したテストを LambdaTest 上で実行できます。
 
-SauceLabsおよびBrowserStackでテストを実行する際、様々な追加オプションを設定してテスト環境をカスタマイズできます。
+この記事では、Testim 上で LambdaTest を設定する方法と、テストを実行する方法を説明します。
 
-## 共通オプション
+:::info
+LambdaTest integration では、Testim は現在 [selenium testing](https://www.lambdatest.com/support/docs/getting-started-with-lambdatest-automation/) のみをサポートしています。[Hyper Execute](https://www.lambdatest.com/support/docs/getting-started-with-hyperexecute/) を含むそれ以外の option はサポートしていません。
+:::
 
-### タイムゾーン設定
+## LambdaTest Grid を追加する
 
-テストを特定のタイムゾーンで実行するには、設定ファイルまたはCLIで指定できます：
+:fa-arrow-right: **LambdaTest Grid を追加するには:**
 
-```javascript
-// 設定ファイル
-{
-  "gridOptions": {
-    "timezone": "America/New_York"
-  }
-}
-```
+1. [Adding a grid](/docs/grid-management#adding-a-grid) の手順に従い、**Grid Type** で **LambdaTest** を選択します。
+2. **Next** をクリックします。
+3. 次の field を入力します。
 
-```bash
-# CLI
-testim --grid saucelabs --browser chrome --grid-options '{"timezone":"America/New_York"}' --token <your-token>
-```
+* **Name**: 実行時に使用する Grid 名
+* **Host**: LambdaTest の host name（例: `hub.lambdatest.com`）
+* **Port**: LambdaTest の port。既定値は `443`
+* **Username**: LambdaTest の user name
+* **Password/access key**: 接続に使用する LambdaTest access key または password
 
-### 画面解像度
+![LambdaTest Grid の接続情報を設定する画面](/images/grid-management/browserstack-integration-copy/9301458-gridmanagement.gif)
 
-画面解像度を指定するには：
+## Grid で実行する方法
 
-```javascript
-// 設定ファイル
-{
-  "gridOptions": {
-    "screenResolution": "1920x1080"
-  }
-}
-```
+次のいずれかの方法で、テストをリモート実行できます。
 
-### デバイス名とバージョン
+[CLI](/docs/the-command-line-cli) / [CI](/docs/integrate-testim-to-your-ci)
 
-モバイルテストの場合、デバイス名とOSバージョンを指定できます：
+Grid 名を指定して `--grid` parameter を追加します。
 
-```bash
-testim --grid browserstack --device "iPhone 13" --os-version "15.0" --token <your-token>
-```
+[Scheduler](/docs/scheduler)
 
-## SauceLabs固有のオプション
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
 
-### ビデオ録画の無効化
+[Test Plan](/docs/test-plans)
 
-```javascript
-{
-  "gridOptions": {
-    "recordVideo": false
-  }
-}
-```
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
 
-### スクリーンショットの無効化
+### editor から実行する
 
-```javascript
-{
-  "gridOptions": {
-    "recordScreenshots": false
-  }
-}
-```
+Test Editor から直接 Grid 上でテストを実行できます。
 
-## BrowserStack固有のオプション
+* **Run** ボタンの横にある options arrow をクリックします。
+* **Run on a grid** をクリックします。
 
-### ローカルテスト
+その実行で configuration / Grid / base url を変更したい場合は **Edit** をクリックします。
 
-BrowserStack Localを使用してローカル環境のアプリケーションをテストするには：
+![Test Editor から LambdaTest Grid を選んで実行する画面](/images/grid-management/browserstack-integration-copy/2b9a380-lambdagrid.gif)
 
-```javascript
-{
-  "gridOptions": {
-    "local": true,
-    "localIdentifier": "my-tunnel"
-  }
-}
-```
-
-### ネットワークログ
-
-```javascript
-{
-  "gridOptions": {
-    "networkLogs": true
-  }
-}
-```
-
-## 詳細情報
-
-各プラットフォームで利用可能なすべてのオプションについては、以下を参照してください：
-
-- [SauceLabs Capabilities](https://docs.saucelabs.com/dev/test-configuration-options/)
-- [BrowserStack Capabilities](https://www.browserstack.com/automate/capabilities)
+:::info
+`--grid` parameter は、旧来の host / port parameter を置き換えます。
+:::

--- a/src/content/docs/grid-management/custom-capabilities.md
+++ b/src/content/docs/grid-management/custom-capabilities.md
@@ -1,87 +1,87 @@
 ---
-title: カスタムテスト機能
-description: すべてのグリッドで高度なテスト構成（機能）を追加する方法
+title: Custom Test Capabilities
+description: >-
+  すべての Grid で利用できる advanced test parameter を Custom capabilities として作成、
+  テストへ追加し、CLI や Scheduler で利用する方法を説明します。
 category: 統合
 order: 12029
 updated: '2024-11-21'
 sourceUrl: 'https://help.testim.io/docs/custom-capabilities'
 keywords:
-  - カスタム機能
-  - テスト設定
-  - グリッド設定
+  - Custom capabilities
+  - Grid
   - BrowserStack
   - SauceLabs
   - Appium
-  - デバイス設定
-  - カスタムケイパビリティ
-  - テスト環境
-  - 詳細設定
+  - CLI
+  - Scheduler
 ---
 
-すべてのグリッドで高度なテスト構成（機能）を追加する方法
+すべての Grid で advanced test configuration（capabilities）を追加する方法を説明します。
 
-カスタム機能を使用すると、利用可能なすべてのグリッドで幅広い高度なテストパラメータを追加できます。これらはJSONオブジェクトを使用してキーと値のペアとしてエンコードされます。
+Custom capabilities を使用すると、利用可能なすべての Grid に対して幅広い advanced test parameter を追加できます。これらは JSON object の key-value pair として記述します。
 
-例えば、デバイスのシステム言語やタイムゾーン:
+たとえば、device の system language や time zone を次のように指定できます。
 
 ```json
 {
-    "appium:language": "en",
-    "appium:timeZone": "Europe/London"
+  "appium:language": "en",
+  "appium:timeZone": "Europe/London"
 }
 ```
 
-この例では、英語をシステム言語、ロンドンをタイムゾーンとしてテスト自動化セッションを開始するようドライバーに指示しています。
+この例では、system language を English、time zone を London にして test automation session を開始するよう driver へ指示しています。
 
-## 利用可能な機能
+## 利用可能な capabilities
 
-幅広い機能から選択できます。その可用性は、テストを実行するグリッドによって異なるため、開始する前にグリッドでサポートされている内容を必ず確認してください。
+多数の capability から選択できます。利用可否はテストを実行する Grid に依存するため、開始前に対象 Grid が何をサポートしているかを確認してください。
 
-Testimのテスト構成で既に定義されている一部の機能は上書きできないことに注意してください。これらの機能には以下が含まれます:
+Testim の test configuration で既に定義されている一部 capability は上書きできません。対象には次のものが含まれます。
 
-- `platformName`/`platform`
+- `platformName` / `platform`
 - `app`/`bundleId`/`appPackage`
 - `chromiumOptions.extensions`
 
-## カスタム機能の作成
+## Custom capabilities を作成する
 
-すべてのカスタム機能は、**Custom capabilities**の下のRunsページで作成および保存されます。新しいカスタム機能を作成するには、次の手順に従います:
+すべての Custom capabilities は **Runs** page の **Custom capabilities** で作成および保存されます。新しい Custom capability を作成するには、次の手順に従います。
 
-1. **Custom capabilities**に移動し、**+**を選択します。
-2. Monaco Code Editorで、テストに追加したい機能の名前を入力し始めます。エディターは自動的に利用可能なキーを提案して入力します。
-3. キーを選択し、その値を定義します。
-4. **Save**を選択します。
-5. カスタム機能に名前を付けます。
+1. **Custom capabilities** に移動し、**+** を選択します。
+2. Monaco Code Editor で、テストへ追加したい capability 名の入力を開始します。editor は利用可能な key を自動提案して補完します。
+3. key を選択し、value を定義します。
+4. **Save** を選択します。
+5. Custom capability に名前を付けます。
 
-## テストにカスタム機能を追加
+## テストに Custom capabilities を追加する
 
-カスタム機能を作成したら、テストに追加します。そのためには、次の手順に従います:
+Custom capabilities を作成したら、次の手順でテストに追加します。
 
-1. テストライブラリからテストを開きます。
-2. 右上隅の**Show step properties**を選択します。
-3. **Custom capabilities**リストから、先ほど作成したカスタム機能を選択します。
-4. 事前にカスタム機能を作成していない場合は、**Add new one**を選択します。Custom capabilitiesページにリダイレクトされ、上記の手順に従って新しい機能を作成できます。
-5. テストを実行します。
+1. test library から test を開きます。
+2. 右上の **Show step properties** を選択します。
+3. **Custom capabilities** list から、先ほど作成した Custom capability を選択します。
+4. 事前に Custom capability を作成していない場合は **Add new one** を選択します。**Custom capabilities** page へ移動し、上記手順で新しい capability を作成できます。
+5. test を実行します。
 
-## CLIでカスタム機能を使用
+## CLI で Custom capabilities を使う
 
-コマンドラインインターフェース（CLI）を使用して、カスタム機能でテストを実行できます。そのためには、次の2つのパラメータのいずれかを使用します:
+command line interface (CLI) では、Custom capabilities 付きでテストを実行できます。次の 2 つの parameter のいずれかを使用します。
 
-- `--custom-capabilities-name` - Testimで事前に作成したカスタム機能を追加します。
-- `--custom-capabilities-file` - JSONファイルとしてローカルに作成したカスタム機能を追加します。
+- `--custom-capabilities-name`: Testim 上で事前に作成した Custom capability を追加します。
+- `--custom-capabilities-file`: local で JSON file として作成した Custom capability を追加します。
 
-これら2つのパラメータを同時に使用することはできません。
+この 2 つの parameter は同時には使用できません。
 
-> 📘
-> SaucelabsおよびBrowserStackグリッドでCLIを使用して機能を操作する方法について詳しく知りたい場合は、[CLIでのSaucelabs & BrowserStackのテスト機能](/docs/saucelabs-browserstack-options)を確認してください。
+:::info
+CLI を使って SauceLabs / BrowserStack Grid で capability を扱う方法の詳細は、[Test capabilities for SauceLabs & BrowserStack in CLI](/docs/saucelabs-browserstack-options) を参照してください。
+:::
 
-## カスタム機能を使用したテストのスケジュール設定
+## Custom capabilities を使ってテストを schedule する
 
-テストにカスタム機能を追加したら、[テストをスケジュール](/docs/scheduler-mobile)できます。
+Custom capability をテストへ追加したら、[テストを schedule](/docs/scheduler-mobile) できます。
 
-スケジュールされたテスト実行でカスタム機能を上書きすることもできます。そのためには、次の手順に従います:
+scheduled test run で Custom capabilities を上書きすることもできます。手順は次のとおりです。
 
-1. 通常どおりテストのスケジュール設定を開始します。
-2. スケジューラー設定で、**What to run on**に移動し、**Override custom capabilities**を選択します。
-3. 新しいカスタム機能を選択します。これらのカスタム機能は、テストの元のカスタム機能を変更することなく、このスケジュールされた実行にのみ追加されます。
-4. **Save**を選択します。
+1. 通常どおり test の scheduling を開始します。
+2. scheduler 設定の **What to run on** で **Override custom capabilities** を選択します。
+3. 新しい Custom capabilities を選択します。これらは、元の Custom capabilities を変更せず、この scheduled run にだけ追加されます。
+4. **Save** を選択します。

--- a/src/content/docs/grid-management/custom-grid.md
+++ b/src/content/docs/grid-management/custom-grid.md
@@ -1,73 +1,64 @@
 ---
-title: カスタムグリッド
+title: Custom Grid
 description: >-
-  Testimで独自のSelenium
-  GridやAppiumグリッドを使用する方法を説明します。ローカルまたはプライベートグリッドの設定、接続方法、トラブルシューティングを網羅しています。
+  Testim で独自の Selenium Grid を設定し、CLI、CI、Scheduler、Test Plan、
+  Test Editor からリモート実行する方法を説明します。
 category: 統合
 order: 12025
 updated: '2025-09-22'
 sourceUrl: 'https://help.testim.io/docs/custom-grid'
 keywords:
-  - カスタムグリッド
+  - Custom Grid
   - Selenium Grid
-  - Appium
-  - プライベートグリッド
-  - ローカルグリッド
+  - Grid
+  - CLI
+  - Scheduler
+  - Test Plan
 ---
 
-# カスタムグリッド
+独自の Selenium Grid 上でテストを実行できます。
 
-Testimでは、独自のSelenium GridまたはAppiumグリッドを使用してテストを実行できます。これにより、ローカル環境やプライベートネットワーク内のグリッドでテストを実行できるようになります。
+この記事では、Testim 上で独自の Selenium Grid を設定する方法を説明します。
 
-## カスタムグリッドの設定
+## Custom Grid を追加する
 
-### 1. グリッドの準備
+:fa-arrow-right: **Custom Grid を追加するには:**
 
-カスタムグリッドを使用する前に、以下を確認してください：
+1. [Adding a grid](/docs/grid-management#adding-a-grid) の手順に従い、**Grid Type** で **Custom Grid** を選択します。
+2. **Next** をクリックします。
+3. **Name** field に、利用する Selenium Grid の名前を入力します。
+4. **Host** field に、Selenium Grid の host name または IP address を入力します。
+5. **Port** field に、Selenium Grid の port を入力します。
 
-- Selenium Grid 3.x以上またはAppium Serverが稼働していること
-- グリッドがTestimから到達可能なネットワーク上にあること
-- 適切なブラウザドライバーまたはモバイルデバイスが設定されていること
+:::info
+ローカルで実行する場合でも、Testim はテスト結果を表示して保存するために browser へ接続する必要があります。network から [https://services.testim.io/](https://services.testim.io/) へアクセスできることを確認してください。
+:::
 
-### 2. Testimでのグリッド設定
+![Custom Grid の Name、Host、Port を設定する画面](/images/grid-management/custom-grid/caabeca-2023-03-19_17-44-02.gif)
 
-1. Testimにログインします
-2. **Settings（設定）** > **Grids（グリッド）** に移動します
-3. **Add Custom Grid（カスタムグリッドを追加）** をクリックします
-4. 以下の情報を入力します：
-   - **Grid Name（グリッド名）**: グリッドを識別するための名前
-   - **Grid URL（グリッドURL）**: グリッドのエンドポイントURL（例：`http://localhost:4444/wd/hub`）
-5. **Save（保存）** をクリックします
+## Grid で実行する方法
 
-## カスタムグリッドでテストを実行する
+次のいずれかの方法で、テストをリモート実行できます。
 
-### エディタから実行
+[CLI](/docs/the-command-line-cli) / [CI](/docs/integrate-testim-to-your-ci)
 
-1. テストエディタを開きます
-2. **Run（実行）** ボタンをクリックします
-3. **Grid（グリッド）** ドロップダウンからカスタムグリッドを選択します
-4. **Run（実行）** をクリックしてテストを開始します
+Grid 名を指定して `--grid` parameter を追加します。
 
-### CLIから実行
+[Scheduler](/docs/scheduler)
 
-```bash
-testim --grid "Custom Grid Name" --token <your-token> --project <project-id>
-```
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
 
-## トラブルシューティング
+[Test Plan](/docs/test-plans)
 
-### 接続エラー
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
 
-グリッドに接続できない場合：
+### editor から実行する
 
-- グリッドURLが正しいか確認してください
-- Testimからグリッドへのネットワーク接続を確認してください
-- ファイアウォール設定を確認してください
+Test Editor から直接 Grid 上でテストを実行できます。
 
-### セッション開始エラー
+* **Run** ボタンの横にある options arrow をクリックします。
+* **Run on a grid** をクリックします。
 
-セッションを開始できない場合：
+その実行で configuration / Grid / base url を変更したい場合は **Edit** をクリックします。
 
-- グリッドに利用可能なノードがあるか確認してください
-- 要求されたブラウザ/デバイスがグリッドで利用可能か確認してください
-- グリッドのログを確認してエラーの詳細を調べてください
+![Test Editor から Run on a grid を選択している画面](/images/grid-management/custom-grid/0ca9bb7-Jul-21-2021_13-11-22.gif)

--- a/src/content/docs/grid-management/grid-management.md
+++ b/src/content/docs/grid-management/grid-management.md
@@ -1,143 +1,124 @@
 ---
-title: グリッド管理
+title: Grid Management
 description: >-
-  Testimで利用可能な様々なテスト実行グリッドの概要を説明します。Testimグリッド、クラウドプロバイダー、カスタムグリッドの選択と設定方法を網羅しています。
+  Grid を使ってリモートでテストを実行する方法、利用できる web/mobile
+  Grid の種類、追加手順、実行方法を説明します。
 category: 統合
 order: 12022
 updated: '2025-09-22'
 sourceUrl: 'https://help.testim.io/docs/grid-management'
 keywords:
-  - グリッド管理
-  - テスト実行環境
+  - Grid Management
   - Testim Grid
-  - ブラウザグリッド
-  - モバイルグリッド
-  - クラウドグリッド
+  - Virtual Mobile Grid
+  - Tricentis Device Cloud
+  - SauceLabs
+  - BrowserStack
+  - LambdaTest
+  - HeadSpin
 ---
 
-# グリッド管理
+SauceLabs、BrowserStack、LambdaTest、HeadSpin などを含む各種 Grid を使って、テストをリモート実行する方法を説明します。
 
-Testimでは、様々なグリッド（テスト実行環境）を使用してテストを実行できます。各グリッドには独自の特徴と利点があり、プロジェクトのニーズに合わせて選択できます。
+:::info{title="これは Pro 機能です"}
+この機能は Professional plan のプロジェクトでのみ利用できます。Professional plan の詳細は [こちら](https://www.testim.io/pricing/) を参照してください。
+:::
 
-## 利用可能なグリッド
+web テストをリモートで実行するには Selenium Grid が必要です。mobile テストを実行するには HeadSpin が必要です。
 
-### 1. Testim Grid（推奨）
+:::info
+Testim Grid の browser 数や browser 種類を変更したい場合は、サポートチームに連絡してください。
+:::
 
-Testimが提供するマネージドグリッドです。セットアップ不要で、すぐに使い始められます。
+:::info
+VPN などの制限付き環境を使うテストを実行する場合は、Grid から被テスト環境へアクセスできるように Testim-Grid IPs を許可リストへ追加する必要があります。完全な IP 一覧が必要な場合は、サポートチームに連絡してください。
+:::
 
-**特徴：**
-- セットアップ不要
-- 自動スケーリング
-- 常に最新のブラウザバージョン
-- 高速で安定した実行環境
+:::info
+互換性を確保するため、Testim Grid 上の browser version は十分な検証とテストを行ったうえで定期的に更新されます。
 
-**対象：**
-- Webブラウザテスト（Chrome、Firefox、Edge、Safari）
+更新は主に次の 2 条件で実施されます。
 
-### 2. Tricentis Device Cloud（旧Virtual Mobile Grid）
+* 公式の major version リリースから 3 か月以内
+* 重大な security update を含む version
+:::
 
-Tricentisが提供するモバイルデバイスグリッドです。実デバイスでのモバイルテストに最適です。
+## Web Testing Grids
 
-**特徴：**
-- 実デバイスでのテスト実行
-- iOS/Androidの幅広いカバレッジ
-- マネージドサービス（メンテナンス不要）
+web テストには次の Grid を使用できます。
 
-**対象：**
-- モバイルアプリテスト（iOS/Android）
+* **Testim cloud grid**: Testim Cloud Grid は Testim のデフォルト提供で、契約プランに応じて自動的に利用できます。
+* **Local grids**: Selenium Grid を所有している場合は、それを Testim と統合できます。
+* **Third party grid**: Testim は SauceLabs、BrowserStack、LambdaTest などの third party grid と統合できます。
+* **Private grid**: Private grid は、専用利用のために提供される専用 Testim Grid です。Testim Cloud Grid とは異なり、この構成は VPN SITE-TO-SITE に対応しており、任意の IP address で Grid を動かせるため、許可リスト登録が不要になります。専用リソースなので、geolocation や browser version など特定要件に対してより高い制御性を得られます。詳細は Account Executive または Testim サポートチームに問い合わせてください。
 
-### 3. SauceLabs
+## Mobile Testing Grids
 
-[SauceLabs](https://saucelabs.com/)は、クラウドベースのブラウザおよびモバイルテストプラットフォームです。
+mobile テストには次の Grid を使用できます。
 
-**特徴：**
-- 多様なブラウザとデバイスの組み合わせ
-- 自動ビデオ録画とログ
-- グローバルなデータセンター
+* **Virtual Mobile Grid**: Virtual Mobile Grid は、多数の iOS simulator と Android emulator によるテストを可能にします。
+* **Third party grid**: Testim は SauceLabs、BrowserStack、HeadSpin などの third party grid と統合できます。
+* **Tricentis Device Cloud (TDC)**: TDC では、サポート付きで Grid 上の実機 iOS / Android device を利用できます。複数ユーザーで共有する shared device と、自分専用の dedicated private device の両方を提供します。
 
-**対象：**
-- Webブラウザテスト
-- モバイルアプリテスト
+## Adding a grid
 
-### 4. BrowserStack
+:fa-arrow-right: **新しい Grid を追加するには:**
 
-[BrowserStack](https://www.browserstack.com/)は、クラウドベースのブラウザおよびモバイルテストプラットフォームです。
+1. Testim の画面右上で、User Name のイニシャルが表示された丸いアイコンをクリックします。
+2. **Account** の下にある **Grids** をクリックします。
+3. **Add New Grid** をクリックします。
+4. Grid type を選択します。\
+   web 用に選択できるのは次のとおりです。
+   * Custom Grid: 独自の Selenium Grid
+   * Saucelabs
+   * Browserstack
+   * LambdaTest\
+     mobile 用に選択できるのは次のとおりです。
+   * Virtual Mobile Grid
+   * TDC
+   * Saucelabs
+   * Browserstack
+   * Testim HeadSpin Mobile
+5. 各 Grid に対応する項目を入力します。詳細は後続の各記事を参照してください。
+6. **Add** をクリックします。\
+   Grid の編集または削除を行うには、Grid 設定ボックスに hover して目的の操作をクリックします。
 
-**特徴：**
-- 3000以上のブラウザ/デバイスの組み合わせ
-- ローカルテスト機能
-- 詳細なデバッグツール
+:::info
+契約プランに **Testim grid** が含まれている場合、構成は自動的に表示されるはずです。表示されない場合はサポートへ連絡してください。
+:::
 
-**対象：**
-- Webブラウザテスト
-- モバイルアプリテスト
+![Add New Grid 画面で Grid type を選択している様子](/images/grid-management/grid-management/6e57e7a-addgrid.gif)
 
-### 5. Headspin
+## Grid configurations
 
-[Headspin](https://www.headspin.io/)は、世界中に配置された実デバイスへのアクセスを提供します。
+各 Grid の設定方法の詳細は、次の記事を参照してください。
 
-**特徴：**
-- グローバルな実デバイスアクセス
-- パフォーマンス分析機能
-- ネットワーク条件のシミュレーション
+* [Virtual Mobile Grid](/docs/virtual-mobile-grid)
+* [Tricentis Device Cloud (mobile)](/docs/tricentis-device-cloud)
+* [Custom Grid (web only)](/docs/custom-grid)
+* [SauceLabs integration (mobile and web)](/docs/saucelabs-integration)
+* [BrowserStack integration (mobile and web)](/docs/browserstack-integration-1)
+* [Test capabilities for SauceLabs & BrowserStack in CLI (mobile and web)](/docs/saucelabs-browserstack-options)
+* [HeadSpin integration (mobile)](/docs/headspin-integration)
+* [LambdaTest integration (web only)](/docs/browserstack-integration-copy)
 
-**対象：**
-- モバイルアプリテスト
+## Grid で実行する方法
 
-### 6. カスタムグリッド
+次のいずれかの方法で、テストをリモート実行できます。
 
-独自のSelenium GridまたはAppiumグリッドを使用できます。
+[CLI](/docs/the-command-line-cli) / [CI](/docs/integrate-testim-to-your-ci)\
+Grid 名を指定して `--grid` parameter を追加します。
 
-**特徴：**
-- 完全なコントロール
-- プライベートネットワーク内での実行
-- カスタマイズ可能な設定
+[Scheduler](/docs/scheduler)\
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
 
-**対象：**
-- Webブラウザテスト（Selenium Grid）
-- モバイルアプリテスト（Appium）
+[Test Plan](/docs/test-plans)\
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
 
-## グリッドの選択基準
+### editor からの実行 (web)
 
-プロジェクトに適したグリッドを選択する際の考慮事項：
+web テストは Test Editor から直接 Grid 上で実行できます。詳細は [Running a remote web test](/docs/running-tests-overview#running-a-remote-web-test) を参照してください。
 
-### テストタイプ
-- **Webブラウザ**: Testim Grid、SauceLabs、BrowserStack、カスタムグリッド
-- **モバイルアプリ**: Tricentis Device Cloud、SauceLabs、BrowserStack、Headspin、カスタムグリッド
+### editor からの実行 (mobile)
 
-### 予算
-- **コスト重視**: Testim Grid（含まれている場合）、カスタムグリッド
-- **柔軟性重視**: SauceLabs、BrowserStack（従量課金）
-
-### セキュリティ要件
-- **高セキュリティ**: カスタムグリッド（プライベートネットワーク内）
-- **標準**: クラウドプロバイダー（SauceLabs、BrowserStack）
-
-### カバレッジ
-- **広範なブラウザ/デバイス**: SauceLabs、BrowserStack
-- **特定の環境**: Testim Grid、カスタムグリッド
-
-## グリッドの設定
-
-各グリッドの詳細な設定方法については、以下のドキュメントを参照してください：
-
-- [Tricentis Device Cloud](tricentis-device-cloud)
-- [カスタムグリッド](custom-grid)
-- [SauceLabs統合](saucelabs-integration)
-- [BrowserStack統合](browserstack-integration-1)
-- [Headspin統合](headspin-integration)
-- [Bitbucket統合](bitbucket-integration)
-
-## よくある質問
-
-### Q: 複数のグリッドを同時に使用できますか？
-
-はい、テストごとに異なるグリッドを選択できます。また、同じテストを複数のグリッドで実行することも可能です。
-
-### Q: グリッドを切り替えるとテストを修正する必要がありますか？
-
-いいえ、Testimのテストはグリッドに依存しないため、グリッドを切り替えてもテストの修正は不要です。
-
-### Q: ローカル環境のアプリケーションをテストできますか？
-
-はい、カスタムグリッドまたはBrowserStack/SauceLabsのローカルテスト機能を使用できます。
+mobile テストは Test Editor から直接 Grid 上で実行できます。詳細は [Running a remote mobile test](/docs/running-tests-overview#running-a-remote-mobile-test) を参照してください。

--- a/src/content/docs/grid-management/headspin-integration.md
+++ b/src/content/docs/grid-management/headspin-integration.md
@@ -1,53 +1,45 @@
 ---
-title: Headspin統合
+title: HeadSpin Integration
 description: >-
-  TestimとHeadspinを統合してリモートデバイスでモバイルテストを実行する方法を説明します。実デバイスへのアクセス、設定手順、実行方法を網羅しています。
+  Testim で HeadSpin Grid を追加し、HeadSpin API Token を取得して設定する方法を説明します。
 category: 統合
 order: 12031
 updated: '2025-09-22'
 sourceUrl: 'https://help.testim.io/docs/headspin-integration'
 keywords:
   - HeadSpin
-  - モバイルグリッド
-  - リモートデバイス
-  - クラウドデバイス
-  - 統合設定
+  - API Token
+  - Grid
+  - mobile
+  - Testim HeadSpin Mobile
 ---
 
-# Headspin統合
+Testim で作成した mobile テストを HeadSpin 上で実行できます。
 
-[Headspin](https://www.headspin.io/)は、世界中に配置された実デバイスへのアクセスを提供するモバイルテストプラットフォームです。TestimとHeadspinを統合することで、Headspinの実デバイスでモバイルテストを実行できます。
+この記事では、Testim 上で HeadSpin Grid を設定する方法を説明します。
 
-## 前提条件
+## HeadSpin Grid を追加する
 
-- 有効なHeadspinアカウント
-- Testimプロジェクトへのアクセス権限
+:fa-arrow-right: **HeadSpin Grid を追加するには:**
 
-## Headspin統合の設定
+1. [Adding a grid](/docs/grid-management#adding-a-grid) の手順に従い、**Grid Type** で **Testim HeadSpin Mobile** を選択します。
+2. **Next** をクリックします。
+3. 次の field を入力します。
 
-1. Testimにログインします
-2. **Settings（設定）** > **Integration（統合）** に移動します
-3. **Headspin**セクションを見つけます
-4. 以下の情報を入力します：
-   - **API Token（APIトークン）**: HeadspinダッシュボードからAPIトークンを取得して入力
-5. **Connect（接続）** をクリックします
+* **Name**: 実行時に使用する Grid 名
+* **API Token**: HeadSpin 側で生成した API Token。詳細は後述します。
 
-## Headspinでテストを実行する
+![HeadSpin Grid の Name と API Token を設定する画面](/images/grid-management/headspin-integration/29244fe-2023-01-29_17-51-47.gif)
 
-Headspinデバイスでテストを実行するには：
+## HeadSpin API Token を取得する
 
-1. テストエディタを開きます
-2. **Run（実行）** ボタンをクリックします
-3. **Grid（グリッド）** ドロップダウンから **Headspin** を選択します
-4. 実行したいデバイスを選択します
-5. **Run（実行）** をクリックしてテストを開始します
+:fa-arrow-right: **HeadSpin API Token を取得するには:**
 
-### CLIでの実行
+1. HeadSpin account に login します。
+2. 画面右上で user name をクリックします。
 
-CLIからHeadspinデバイスでテストを実行する場合は、`--grid` パラメータを使用します：
+![HeadSpin の user menu を開いた状態](/images/grid-management/headspin-integration/689ab5c-2023-01-29_18-01-05.png)
 
-```bash
-testim --grid headspin --device "iPhone 13" --token <your-token>
-```
-
-これでHeadspin統合が完了し、実デバイスでモバイルテストを実行できるようになります。
+3. **Settings** をクリックします。
+4. **User Settings** の **API Token** section で、既存 token をコピーするか、**+New Token** button をクリックして新規 token を作成します。
+5. API Token をコピーし、Testim の API Token field に貼り付けます。

--- a/src/content/docs/grid-management/saucelabs-browserstack-options.md
+++ b/src/content/docs/grid-management/saucelabs-browserstack-options.md
@@ -1,7 +1,8 @@
 ---
-title: SauceLabs/BrowserStackオプション
+title: Test capabilities for SauceLabs & BrowserStack in CLI
 description: >-
-  SauceLabsおよびBrowserStackで利用可能な拡張実行パラメーターの設定方法について説明します。JSONファイルでのオプション指定やCLIの使用例を提供します。
+  SauceLabs と BrowserStack の Grid で JSON file を使って capability を CLI
+  から渡す方法と、mobile 実行時の override rule を説明します。
 category: 統合
 order: 12030
 updated: '2025-11-21'
@@ -9,15 +10,19 @@ sourceUrl: 'https://help.testim.io/docs/saucelabs-browserstack-options'
 keywords:
   - SauceLabs
   - BrowserStack
-  - 拡張実行パラメーター
-  - grid-options
-  - 設定オプション
-  - カスタマイズ
+  - capability
+  - CLI
+  - sauce-options
+  - browserstack-options
 ---
 
-SauceLabsおよびBrowserStackでテストを実行する際、JSON形式の拡張実行パラメーターを使用して、追加の設定を渡すことができます。
+SauceLabs と BrowserStack の Grid で CLI から capability を設定する方法を説明します。
 
-たとえば、特定の画面解像度やタイムゾーンでテストを実行したい場合は、次のようなJSONファイルを作成します:
+定義済み capability を含む JSON file を使うことで、SauceLabs と BrowserStack へ追加の configuration parameter を渡せます。
+
+たとえば、特定の browser version と time zone でテストを実行したい場合は、次の手順に従います。
+
+1. 次の JSON file を作成します。
 
 ```json
 {
@@ -26,42 +31,38 @@ SauceLabsおよびBrowserStackでテストを実行する際、JSON形式の拡�
 }
 ```
 
-CLIでこの設定を使用するには、次のオプションを追加します:
+2. CLI では次を追加します: **--sauce-options  "\<aboveConfigFileName>.json"**
 
-```shell
-testim --grid saucelabs --browser chrome --grid-options '{"screenResolution":"2560x1600","timeZone":"New_York"}'
-```
+capability は次のような用途に利用できます。
 
-拡張実行パラメーターは、次のようなユースケースに使用できます:
+* device allocation の制御
+* Appium version の制御
+* auto alert approval の制御
+* Grid 側で取得する data の制御
+* video の無効化
+* network log の無効化
+* build / project option capability を使った custom test result mapping
+* reset strategy の制御
 
-- デバイスの割り当て方法の制御
-- 使用するAppiumバージョンの制御
-- 自動アラート承認の有効化/無効化
-- グリッド側で取得するデータ量の制御（動画やネットワークログなど）
-- 動画の有効/無効の切り替え
-- ネットワークログの有効/無効の切り替え
-- ビルドやプロジェクトに応じたカスタムテスト結果マッピング
-- リセット戦略の制御
+## capability の override rule (mobile)
 
-## モバイル向けの拡張実行パラメーターの上書きルール
+JSON capability file の設定は、次の設定を上書きします。
 
-モバイル向けのJSON拡張実行パラメーターを使用すると、次の設定が上書きされます:
+* CLI flag (`deviceName`, `osVersion`)
+* Mobile Config
+* `autoGrantPermissions`、`AutoAcceptAlerts`、video capturing 無効化などの default value
 
-- CLIフラグ（`deviceName`、`osVersion`）
-- モバイル構成（Mobile Config）
-- デフォルト値（`autoGrantPermissions`、`AutoAcceptAlerts`、動画キャプチャの有効/無効 など）
-
-> 📘 `platformVersion` の扱い
->
-> `platformVersion` ケイパビリティは検証され、使用すべきAppiumバージョンを決定するために使用されます。たとえば、クライアントがAppiumバージョン`1.22.2`と `platformVersion` `17.2`（iOS）の組み合わせを指定した場合、自動的にAppium 2が使用され、同時にその旨の警告が表示されます（これは、モバイル構成やCLIフラグの `osVersion` ロジックと同様です）。
+:::info{title="PlatformVersion capabilities"}
+`platformVersion` capability は検証され、使用すべき Appium version を決定するために使われます。たとえば client が Appium version `1.22.2` と、iOS 実行で `platformVersion` `17.2` を要求した場合、自動的に Appium 2 が使用され、その旨の warning が表示されます。これは mobile config / CLI flag の `osVersion` logic と同様です。
+:::
 
 ## SauceLabs
 
-**Webでの利用:**
+### SauceLabs を web で使用する場合
 
-CLIに次のオプションを追加します: **--sauce-options  "config_saucelabs.json"**
+CLI に次を追加します: **--sauce-options  "config_saucelabs.json"**
 
-設定ファイルの例:
+file の例:
 
 ```json
 {
@@ -69,86 +70,86 @@ CLIに次のオプションを追加します: **--sauce-options  "config_saucel
   "browserVersion": "latest",
   "platformName": "Windows 10",
   "sauce:options": {
-      "screenResolution": "1920x1080",
-      "extendedDebugging": true
+    "screenResolution": "1920x1080",
+    "extendedDebugging": true
   }
 }
 ```
 
-SauceLabsで利用できるケイパビリティの詳細は、公式ドキュメントを参照してください:  
+parameter の詳細は、SauceLabs の公式ドキュメントを参照してください。\
 [https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options](https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options)
 
-**モバイルでの利用:**
+### SauceLabs を mobile で使用する場合
 
-- AppiumのW3Cフォーマット（接頭辞なし）を使用し、SauceLabsオプションを指定します。
+* prefix なしの W3C format で Appium capability と SauceLabs option を指定します。
 
 [Appium caps](https://saucelabs.com/resources/blog/appium-desired-capabilities-tutorial)
 
 [Appium versions](https://docs.saucelabs.com/mobile-apps/automated-testing/appium/appium-versions/#virtual-devices)
 
-[Saucelabs options](https://docs.saucelabs.com/dev/test-configuration-options/#mobile-app-appium-capabilities-sauce-specific--optional)
+[SauceLabs options](https://docs.saucelabs.com/dev/test-configuration-options/#mobile-app-appium-capabilities-sauce-specific--optional)
 
 ```json
 {
-"deviceName": "Samsung Galaxy S10+",
-"platformVersion": "12",
-"autoGrantPermissions": false,
-"sauce:options": {
+  "deviceName": "Samsung Galaxy S10+",
+  "platformVersion": "12",
+  "autoGrantPermissions": false,
+  "sauce:options": {
     "build": "build from json file",
     "name": "test json file caps"
-}
+  }
 }
 ```
 
 ## BrowserStack
 
-**Webでの利用:**
+### BrowserStack を web で使用する場合
 
-CLIに次のオプションを追加します: **--browserstack-options "config_browserstack.json"**  
-以下はサポートされる代表的なオーバーライドパラメーターの例です:
+CLI に次を追加します: **--browserstack-options "config_browserstack.json"**\
+次はサポートされる代表的な override parameter の例です。
 
 ```json
 {
-    "project": "my project",
-    "build": "build 4.5",
-    "browserstack.debug": false,
-    "browserstack.console": "info",
-    "browserstack.networkLogs": true,
-    "browserstack.video": false,
-    "browserstack.timezone": "New_York",
-    "browserstack.selenium_version": "3.5.2",
-    "browser_version": 61,
-    "resolution": "2048x1536"
+  "project": "my project",
+  "build": "build 4.5",
+  "browserstack.debug": false,
+  "browserstack.console": "info",
+  "browserstack.networkLogs": true,
+  "browserstack.video": false,
+  "browserstack.timezone": "New_York",
+  "browserstack.selenium_version": "3.5.2",
+  "browser_version": 61,
+  "resolution": "2048x1536"
 }
 ```
 
-BrowserStackで利用できるケイパビリティの詳細は、公式ドキュメントを参照してください:  
+parameter の詳細は、BrowserStack の公式ドキュメントを参照してください。\
 [https://www.browserstack.com/automate/capabilities](https://www.browserstack.com/automate/capabilities)
 
-**モバイルでの利用:**
+### BrowserStack を mobile で使用する場合
 
-- Appiumの拡張実行パラメーターには、接頭辞なしのW3Cケイパビリティ形式を使用します。
-- BrowserStack側の拡張実行パラメーターには、レガシー（Wire JSON）形式を使用します。
+* Appium capability には、prefix なしの W3C capability format を使用します。
+* BrowserStack capability には、legacy (Wire JSON) format を使用します。
 
-[Appium caps](https://www.browserstack.com/docs/appium/debug-failed-tests/appium-logs)
+[Appium caps](https://www.browserstack.com/docs/app-automate/appium/debug-failed-tests/appium-logs)
 
-[Browserstack options](https://www.browserstack.com/app-automate/capabilities?tag=jsonwire) JSON File Example:
+[BrowserStack options](https://www.browserstack.com/app-automate/capabilities?tag=jsonwire) JSON File Example:
 
 ```json
 {
-// project と build を修正する必要があります（W3C形式では projectName, buildName に変更）
-"project": "json-project-test",
-"build": "json-build-test",
-"platformVersion": "12",
-"deviceName": " Google Pixel 7",
-"browserstack.debug": false,
-"browserstack.console": "info",
-"browserstack.networkLogs": true,
-"browserstack.video": false
+  // project と build は修正が必要です（W3C format では projectName と buildName へ変更）
+  "project": "json-project-test",
+  "build": "json-build-test",
+  "platformVersion": "12",
+  "deviceName": " Google Pixel 7",
+  "browserstack.debug": false,
+  "browserstack.console": "info",
+  "browserstack.networkLogs": true,
+  "browserstack.video": false
 }
 ```
 
-> 🚧 BrowserStackの証明書エラーについて
->
-> Android 13.0以降を使用するデバイスでテストしている場合、証明書の問題によりターゲットデバイスがオフラインのように見えることがあります。この問題の詳細および解決方法については、BrowserStackのドキュメントを参照してください:  
-> [https://www.browserstack.com/docs/appium/troubleshooting/networklogs-acceptinsecurecerts-issues](https://www.browserstack.com/docs/appium/troubleshooting/networklogs-acceptinsecurecerts-issues)
+:::warning{title="BrowserStack certificate error"}
+Android version 13.0 以上の device でテストしている場合、certificate issue により target device が offline のように見えることがあります。詳細と解決方法は BrowserStack の関連ドキュメントを参照してください。\
+[https://www.browserstack.com/docs/appium/troubleshooting/networklogs-acceptinsecurecerts-issues](https://www.browserstack.com/docs/appium/troubleshooting/networklogs-acceptinsecurecerts-issues)
+:::

--- a/src/content/docs/grid-management/saucelabs-integration.md
+++ b/src/content/docs/grid-management/saucelabs-integration.md
@@ -1,65 +1,65 @@
 ---
-title: SauceLabs統合
+title: SauceLabs Integration
 description: >-
-  TestimとSauceLabsを統合してクラウドベースのブラウザおよびモバイルデバイスでテストを実行する方法を説明します。設定手順、認証情報の管理、実行方法を網羅しています。
+  Testim で SauceLabs Grid を追加し、CLI、CI、Scheduler、Test Plan、Test
+  Editor からテストを実行する方法を説明します。
 category: 統合
 order: 12026
 updated: '2025-09-22'
 sourceUrl: 'https://help.testim.io/docs/saucelabs-integration'
 keywords:
   - SauceLabs
-  - クラウドグリッド
-  - ブラウザテスト
-  - モバイルテスト
+  - Grid
+  - CLI
+  - Scheduler
+  - Test Plan
 ---
 
-# SauceLabs統合
+Testim で作成したテストを SauceLabs の browser と mobile device 上で実行できます。
 
-[SauceLabs](https://saucelabs.com/)は、クラウドベースのブラウザおよびモバイルデバイスでテストを実行できるプラットフォームです。TestimとSauceLabsを統合することで、SauceLabsの広範なブラウザとデバイスのカバレッジを活用できます。
+この記事では、Testim 上で SauceLabs を設定する方法と、テストを実行する方法を説明します。
 
-## 前提条件
+## SauceLabs Grid を追加する
 
-- 有効なSauceLabsアカウント
-- SauceLabsのユーザー名とアクセスキー
+:fa-arrow-right: **SauceLabs Grid を追加するには:**
 
-## SauceLabs統合の設定
+1. [Adding a grid](/docs/grid-management#adding-a-grid) の手順に従い、**Grid Type** で **Saucelabs** を選択します。
+2. **Next** をクリックします。
+3. 次の field を入力します。
 
-1. Testimにログインします
-2. **Settings（設定）** > **Integration（統合）** に移動します
-3. **SauceLabs**セクションを見つけます
-4. 以下の情報を入力します：
-   - **Username（ユーザー名）**: SauceLabsのユーザー名
-   - **Access Key（アクセスキー）**: SauceLabsのアクセスキー
-5. **Connect（接続）** をクリックします
+* **Name**: 実行時に使用する Grid 名
+* **Saucelabs User**: 接続に使用する SauceLabs key
+* **Saucelabs key**: 接続に使用する SauceLabs key
+* **Host**: SauceLabs の host name
+* **Port**: SauceLabs の port
 
-## SauceLabsでテストを実行する
+![SauceLabs Grid の接続情報を設定する画面](/images/grid-management/saucelabs-integration/be4fb2b-Jul-24-2021_08-13-41.gif)
 
-### エディタから実行
+## Grid で実行する方法
 
-1. テストエディタを開きます
-2. **Run（実行）** ボタンをクリックします
-3. **Grid（グリッド）** ドロップダウンから **SauceLabs** を選択します
-4. 実行したいブラウザまたはデバイスを選択します
-5. **Run（実行）** をクリックしてテストを開始します
+次のいずれかの方法で、テストをリモート実行できます。
 
-### CLIから実行
+[CLI](/docs/the-command-line-cli) / [CI](/docs/integrate-testim-to-your-ci)
 
-```bash
-testim --grid saucelabs --browser chrome --token <your-token>
-```
+Grid 名を指定して `--grid` parameter を追加します。
 
-### 追加オプション
+[Scheduler](/docs/scheduler)
 
-SauceLabsの追加オプション（タイムゾーン、画面解像度など）については、[SauceLabs/BrowserStackオプション](saucelabs-browserstack-options)を参照してください。
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
 
-## SauceLabsでの結果確認
+[Test Plan](/docs/test-plans)
 
-テスト実行後、Testim上で結果を確認できます。また、SauceLabsダッシュボードでも詳細なログ、スクリーンショット、ビデオを確認できます。
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
 
-## トラブルシューティング
+### Editor から実行する
 
-接続に問題がある場合は、以下を確認してください：
+Test Editor から直接 Grid 上でテストを実行できます。
 
-- SauceLabsのユーザー名とアクセスキーが正しいか
-- SauceLabsアカウントがアクティブか
-- 選択したブラウザ/デバイスがSauceLabsで利用可能か
+* **Run** ボタンの横にある options arrow をクリックします。
+* **Run on a grid** をクリックします。
+
+その実行で configuration / Grid / base url を変更したい場合は **Edit** をクリックします。
+
+![Test Editor から SauceLabs Grid を選んで実行する画面](/images/grid-management/saucelabs-integration/0ca9bb7-Jul-21-2021_13-11-22.gif)
+
+テスト実行に追加 option を渡したい場合は、[Test capabilities for SauceLabs & BrowserStack in CLI](/docs/saucelabs-browserstack-options) を参照してください。

--- a/src/content/docs/grid-management/tricentis-device-cloud.md
+++ b/src/content/docs/grid-management/tricentis-device-cloud.md
@@ -1,8 +1,8 @@
 ---
 title: Tricentis Device Cloud
 description: >-
-  Tricentis Device Cloud（旧Testim Virtual Mobile
-  Grid）を使用してクラウド上の実デバイスでモバイルテストを実行する方法を説明します。
+  Tricentis Device Cloud の無料 trial 開始手順と、TDC 対応 mobile
+  configuration を使って CLI、CI、Scheduler、Test Plan から実行する方法を説明します。
 category: 統合
 order: 12023
 updated: '2025-09-22'
@@ -11,60 +11,53 @@ keywords:
   - Tricentis Device Cloud
   - TDC
   - Tricentis
-  - モバイルグリッド
-  - クラウドデバイス
+  - Device Management
+  - Real Devices Cloud
+  - mobile configuration
 ---
 
-# Tricentis Device Cloud
+Testim Mobile は Tricentis Device Cloud (TDC) と組み合わせることで、サポート付きで Grid 上の実機 iOS / Android device を利用できます。さらに、machine learning を活用した analytics により、mobile app の usability や performance に関する insight も得られます。
 
-Tricentis Device Cloud（旧Testim Virtual Mobile Grid）は、クラウド上の実デバイスでモバイルテストを実行できるTricentisのマネージドサービスです。
+TDC では、複数ユーザーで共有する shared device と、自分専用の dedicated private device の両方が提供されます。Tricentis Device Cloud は特別な integration を必要とせず、Company Owner または Project Owner として申し込める無料 trial も含まれています。trial を開始すると、その shared resource はすぐに [Device Management](/docs/view-local-connected-mobile-devices) で利用できるようになります。trial 期間中は、Android と iOS の shared trial device を使用できます。
 
-## 概要
+## 無料の Tricentis Device Cloud trial を開始する
 
-Tricentis Device Cloudを使用すると、以下のことが可能になります：
+Company Owner または Project Owner は、Tricentis Device Cloud の無料 trial を開始できます。無料 trial をスキップして有償版へ進みたい場合は、[contact us](https://www.testim.io/contact-us/) を参照してください。
 
-- 様々なiOSおよびAndroidデバイスでテストを実行
-- デバイスのセットアップやメンテナンスの手間を削減
-- スケーラブルなテスト実行環境を利用
-- 実デバイス上での正確なテスト結果を取得
+:fa-arrow-right: **無料の Tricentis Device Cloud trial を開始するには:**
 
-## 利用可能なデバイス
+1. **Device Management > Real Devices Cloud** tab に移動します。
+2. **Start A Trial** をクリックします。
 
-Tricentis Device Cloudでは、以下のデバイスが利用可能です：
+![Real Devices Cloud tab で Start A Trial をクリックする画面](/images/grid-management/tricentis-device-cloud/c299505-image_4.png)
 
-- **iOS**: 最新のiPhoneおよびiPadモデル
-- **Android**: 主要メーカーの最新デバイス（Samsung、Google Pixelなど）
+数秒後に trial が **activated** され、次の通知が表示されます。
 
-利用可能なデバイスの完全なリストは、Testimのデバイス選択画面で確認できます。
+![Tricentis Device Cloud trial が有効化された通知](/images/grid-management/tricentis-device-cloud/0012b7c-trialactive.png)
 
-## Tricentis Device Cloudでテストを実行する
+次に、メイン navigation menu の **Device Management** link へ移動します。\
+**Tricentis Device Cloud Shared** 画面で、trial 期間中に利用できる device を確認できます。
 
-### エディタから実行
+![Tricentis Device Cloud Shared 画面に trial device 一覧が表示されている様子](/images/grid-management/tricentis-device-cloud/b81b106-image_3.png)
 
-1. テストエディタを開きます
-2. **Run（実行）** ボタンをクリックします
-3. **Grid（グリッド）** ドロップダウンから **Tricentis Device Cloud** を選択します
-4. 実行したいデバイスとOSバージョンを選択します
-5. **Run（実行）** をクリックしてテストを開始します
+## Tricentis Device Cloud でテストを実行する
 
-### CLIから実行
+Tricentis Device Cloud でテストを実行する前に、TDC と互換性のある mobile configuration を作成しておく必要があります。
 
-```bash
-testim --grid "tricentis-device-cloud" --device "iPhone 14" --os-version "16.0" --token <your-token>
-```
+[Configuration Library - Mobile](/docs/configuration-library-mobile)
 
-### スケジューラから実行
+![TDC 用 mobile configuration の設定例](/images/grid-management/tricentis-device-cloud/6773dc8-config.png)
 
-1. **Scheduler（スケジューラ）** に移動します
-2. スケジュールを作成または編集します
-3. **Grid（グリッド）** として **Tricentis Device Cloud** を選択します
-4. テストを実行するデバイスを選択します
-5. スケジュールを保存して有効化します
+次のいずれかの方法で、テストをリモート実行できます。
 
-## 制限事項
+[CLI](/docs/the-command-line-cli) / [CI](/docs/integrate-testim-to-your-ci)
 
-- Tricentis Device Cloudは、Testimプランに応じて利用可能です
-- 同時実行数は契約プランによって異なります
-- 一部の地域では利用できない場合があります
+Grid 名を指定して `--grid` parameter を追加します。
 
-詳細については、Tricentisサポートにお問い合わせください。
+[Scheduler](/docs/scheduler-mobile)
+
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
+
+[Test Plan](/docs/test-plans-mobile)
+
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。

--- a/src/content/docs/grid-management/virtual-mobile-grid.md
+++ b/src/content/docs/grid-management/virtual-mobile-grid.md
@@ -1,8 +1,8 @@
 ---
-title: Virtual Mobile Grid（VMG）
+title: Virtual Mobile Grid
 description: >-
-  Testim Virtual Mobile
-  Grid（VMG）を使用してクラウド上の実デバイスでモバイルテストを実行する詳細な手順を説明します。デバイス選択、アプリアップロード、テスト実行方法を網羅しています。
+  Virtual Mobile Grid の trial 開始手順、実行前の前提条件、CLI、CI、Scheduler、Test
+  Plan、Test Editor からの実行方法、および app の差し替え方法を説明します。
 category: 統合
 order: 12024
 updated: '2025-09-22'
@@ -10,141 +10,126 @@ sourceUrl: 'https://help.testim.io/docs/virtual-mobile-grid'
 keywords:
   - Virtual Mobile Grid
   - VMG
-  - モバイルテスト
-  - クラウドデバイス
+  - Mobile Apps Library
+  - Device Management
+  - mobile configuration
+  - app-id
 ---
 
-# Virtual Mobile Grid（VMG）
+Virtual Mobile Grid (VMG) は、多数の iOS simulator と Android emulator を対象にテストできる Grid です。利用可能なさまざまな virtual device を使うことで、接続と設定を簡素化し、品質を高められます。
 
-> **注意**: Virtual Mobile Grid（VMG）は現在、**Tricentis Device Cloud**に名称変更されています。最新情報については、[Tricentis Device Cloud](/docs/tricentis-device-cloud)を参照してください。
+* 利用可能な virtual device を使って接続と設定を簡素化し、品質を向上できます。
+* 異なる device で parallel run を行い、テスト実行をスケールできます。
 
-Virtual Mobile Grid（VMG）は、Testimが提供するクラウドベースのモバイルデバイステスト環境です。実デバイスでモバイルアプリケーションをテストできます。
+Virtual Mobile Grid はテストの記録にも実行にも使用できます。また、[Mobile Apps Library](/docs/mobile-apps) と接続されています。つまり、mobile app を使うテストを Virtual Mobile Grid で実行する前に、その app を Mobile Apps Library へ追加しておく必要があります。
 
-## 概要
+Virtual Mobile Grid に特別な integration は不要です。有償 customer には license に含まれています。Community license でも、Company Owner または Project Owner であれば無料 trial に登録できます。trial を開始すると、Virtual Mobile Grid はすぐに [Device Management](/docs/view-local-connected-mobile-devices) で利用可能になります。trial 期間中は Android と iOS のさまざまな virtual device を使用できます。
 
-VMGを使用すると、以下のことが可能になります：
+:::warning{title="Test Compatibility"}
+Virtual Mobile Grid で実行できるのは、virtual device で動作するように compile された iOS application のみです。
+:::
 
-- iOSおよびAndroidの実デバイスでテストを実行
-- デバイスの購入、セットアップ、メンテナンスが不要
-- 複数のデバイスでの並列実行
-- 様々なOSバージョンとデバイスモデルのカバレッジ
+:::info{title="OS Compatibility"}
+Virtual Mobile Grid は x86_64 Android build のみをサポートします。
+:::
 
-## 利用可能なデバイス
+## 無料の Virtual Mobile Grid trial を開始する
 
-VMGでは、以下のデバイスが利用可能です：
+Community license を利用している場合、Company Owner または Project Owner として Virtual Mobile Grid の無料 trial を開始できます。trial 期間は 14 日間です。trial 中は、全 project を通して iOS / Android それぞれ 1 実行ずつ実行できます。無料 trial をスキップして直接有償版へ進みたい場合は、[contact us](https://www.testim.io/contact-us/) を参照してください。
 
-### iOS
-- iPhone（複数モデル）
-- iPad（複数モデル）
-- 様々なiOSバージョン
+:fa-arrow-right: **無料の Virtual Mobile Grid trial を開始するには:**
 
-### Android
-- Samsung Galaxy シリーズ
-- Google Pixel シリーズ
-- その他主要メーカーのデバイス
-- 様々なAndroidバージョン
+1. **Device Management** 画面へ移動し、**Virtual Mobile Grid** tab を開いて **Start A Trial** をクリックします。
 
-利用可能なデバイスの完全なリストは、Testimのデバイス選択画面で確認できます。
+![Device Management で Virtual Mobile Grid trial を開始する画面](/images/grid-management/virtual-mobile-grid/52a46cf-image.png)
 
-## VMGでのテスト実行
+数秒後に trial が **activated** され、次の通知が表示されます。
 
-### 1. アプリケーションのアップロード
+![Virtual Mobile Grid trial が有効化された通知](/images/grid-management/virtual-mobile-grid/6ab7015-image_1.png)
 
-VMGでテストを実行する前に、テスト対象のアプリをアップロードする必要があります：
+**Virtual Mobile Grid** 画面では、trial 期間中に利用できる device を確認できます。
 
-1. **Mobile Apps（モバイルアプリ）** セクションに移動します
-2. **Upload App（アプリをアップロード）** をクリックします
-3. `.ipa`（iOS）または `.apk`（Android）ファイルを選択します
-4. アプリがアップロードされるまで待ちます
+## Virtual Mobile Grid でテストを実行する
 
-### 2. テストの作成
+Virtual Mobile Grid でテストを実行する前に、次を確認してください。
 
-1. **New Test（新規テスト）** をクリックします
-2. **Mobile Test（モバイルテスト）** を選択します
-3. **Grid（グリッド）** として **Virtual Mobile Grid** を選択します
-4. テスト対象のデバイスとOSバージョンを選択します
-5. アップロードしたアプリを選択します
-6. テストの記録を開始します
+* **Mobile Configuration**: Virtual Mobile Grid と互換性のある mobile configuration を作成しておきます。[Configuration Library - Mobile](/docs/configuration-library-mobile) を参照してください。この configuration は CLI / CI、Scheduler、Test Plan からの実行に使用できます。
 
-### 3. テストの実行
+![Virtual Mobile Grid 向け mobile configuration の設定例](/images/grid-management/virtual-mobile-grid/07dd385-image_2.png)
 
-#### エディタから実行
+* **Apps Library**: テスト対象 app を Apps Library に追加しておきます。[Mobile Apps](/docs/mobile-apps) を参照してください。すでに ***"From Device"*** option で選択した app を使ってテストを記録済みの場合は、テストの **Setup Step** の **Properties** pane で **change app** link をクリックし、From Library option を選択します。
 
-1. テストエディタを開きます
-2. **Run（実行）** ボタンをクリックします
-3. **Grid（グリッド）** が **Virtual Mobile Grid** に設定されていることを確認します
-4. デバイスとアプリを選択します
-5. **Run（実行）** をクリックしてテストを開始します
+### テストをリモート実行する
 
-#### CLIから実行
+Virtual Mobile Grid 用に設定した configuration を使うことで、次のいずれかの方法でテストをリモート実行できます。
 
-```bash
-testim --grid "virtual-mobile-grid" \
-  --device "iPhone 14" \
-  --os-version "16.0" \
-  --app-id <your-app-id> \
-  --token <your-token> \
-  --project <project-id>
-```
+:::info
+[Mobile Apps Library](/docs/mobile-apps) に対象の mobile app があることを確認してください。
+:::
 
-#### スケジューラから実行
+[CLI](/docs/the-command-line-cli) / [CI](/docs/integrate-testim-to-your-ci)
 
-1. **Scheduler（スケジューラ）** に移動します
-2. スケジュールを作成または編集します
-3. **Grid（グリッド）** として **Virtual Mobile Grid** を選択します
-4. デバイス、OSバージョン、アプリを選択します
-5. スケジュールを保存して有効化します
+Grid 名を指定して `--grid` parameter を追加します。
 
-## ベストプラクティス
+[Scheduler](/docs/scheduler-mobile)
 
-### アプリのバージョン管理
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
 
-- アプリの新しいバージョンを定期的にアップロードします
-- 古いバージョンを削除して、ストレージを管理します
-- アプリ名に明確なバージョン番号を付けます
+[Test Plan](/docs/test-plans-mobile)
 
-### デバイス選択
+**Grid** field で、どの Grid 上でテストを実行するかを選択します。
 
-- 対象ユーザーが使用している主要なデバイスをカバーします
-- 古いOSバージョンと最新バージョンの両方でテストします
-- 画面サイズの異なるデバイスでテストします
+[Remote Run through the Editor](/docs/running-tests-overview#running-a-remote-mobile-test)
 
-### パフォーマンス最適化
+**Run on a grid** option で **Virtual Mobile Grid** と該当する configuration を選択します。
 
-- 不要な待機時間を減らします
-- 並列実行を活用してテスト時間を短縮します
-- テストを適切にグループ化します
+![Remote Run through the Editor で Virtual Mobile Grid を選択している画面](/images/grid-management/virtual-mobile-grid/81f27e0-image_3.png)
 
-## トラブルシューティング
+### From Device で記録した app を変更する
 
-### アプリのアップロードに失敗する
+***"From Device"*** option で選択した app を使ってテストを記録済みの場合は、次の方法で app を差し替えます。
 
-- アプリファイルのサイズを確認します（制限あり）
-- ファイル形式が正しいか確認します（`.ipa`または`.apk`）
-- ネットワーク接続を確認します
+#### Editor から変更する
 
-### デバイスに接続できない
+:fa-arrow-right: **Editor から app を変更するには:**
 
-- 選択したデバイスが利用可能か確認します
-- 同時実行の制限に達していないか確認します
-- Testimサポートに連絡してデバイスの状態を確認します
+1. **Setup Step** で **Show Properties** をクリックします。
+2. **Properties** pane の **Application name** の下にある **Change app** link をクリックします。
+3. From **Library option** を選択し、一覧から該当する app を選びます。
+4. **Done** をクリックします。
 
-### テストが不安定
+![Setup Step の Properties から app を差し替える画面](/images/grid-management/virtual-mobile-grid/87bb169-changeappgif.gif)
 
-- デバイス固有の問題かどうかを確認するため、複数のデバイスでテストします
-- 待機時間を調整します
-- ネットワーク状態を確認します
+#### CLI から変更する
 
-## 制限事項
+CLI でテストを実行する場合は、テスト記録時に使われた既定の app Id を、Mobile Apps Library にある別の app Id で上書きできます。
 
-- VMGは契約プランに応じて利用可能です
-- 同時実行数はプランによって異なります
-- 一部の地域では利用できない場合があります
+:fa-arrow-right: **既定の app ID を上書きするには:**
 
-詳細については、Tricentisサポートにお問い合わせください。
+1. **Settings > CLI** へ移動します。
+2. **Grid** drop-down menu で **Virtual Mobile Grid** を選択します。
+3. command example を command prompt へコピーします。
+4. **Mobile Apps Library** へ移動します。
+5. 対象の app を選択し、**Copy ID** button をクリックします。
+6. command prompt で、コピーした ID を続けて `--app-id` flag を追加します。
+7. CLI command を実行します。
 
-## 関連ドキュメント
+#### scheduler から変更する
 
-- [モバイルテストの記録](/docs/recording-a-mobile-test)
-- [モバイルアプリの管理](/docs/mobile-apps)
-- [モバイルテストスケジューラ](/docs/scheduler-mobile)
+:fa-arrow-right: **scheduler で既定の app を上書きするには:**
+
+1. **Runs > Scheduled Runs** へ移動します。
+2. 対象の scheduler を開きます。
+3. **What to run on** で **Override application** checkbox を選択します。
+4. **Select from library** で対象 application を選択します。
+5. **Save** をクリックします。
+
+#### test plan から変更する
+
+:fa-arrow-right: **test plan で既定の app を上書きするには:**
+
+1. **Test List > Plans** へ移動します。
+2. 対象の test plan を開きます。
+3. **What to run on** で **Override application** checkbox を選択します。
+4. **Select from library** で対象 application を選択します。
+5. **Save** をクリックします。


### PR DESCRIPTION
## Summary
- replace summary-style Grid Management docs with source-faithful Japanese translations based on each `sourceUrl`
- restore full procedures, callouts, image placement, and `/docs/{slug}` internal links across the section
- correct the LambdaTest page content and keep Grid Management anchor targets consistent

## Validation
- npm run lint:docs
- npm run lint
- npm run test
- npm run build