### PR TITLE
feat: コードブロックテーマを github-dark-dimmed に変更（#95）

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -91,7 +91,7 @@ export default defineConfig({
       rehypeWrapTable,
     ],
     shikiConfig: {
-      theme: 'dracula',
+      theme: 'github-dark-dimmed',
       wrap: true,
       transformers: [{
         name: 'code-title',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -202,7 +202,7 @@
   }
   .docs-prose pre {
     @apply mt-8 overflow-x-auto rounded-2xl border border-slate-900/10 bg-slate-950 p-5 text-sm text-slate-100 shadow-lg;
-    background-image: radial-gradient(circle at top left, rgba(37, 99, 235, 0.3), transparent);
+    background-image: radial-gradient(circle at top left, rgba(37, 99, 235, 0.06), transparent);
   }
   .docs-prose pre code {
     @apply bg-transparent p-0 text-[13px] leading-6 text-slate-100;


### PR DESCRIPTION
## Summary

- `astro.config.mjs`: Shiki テーマを `dracula` → `github-dark-dimmed` に変更
- `src/styles/global.css`: ブルーグラデーションオーバーレイの不透明度を `0.3` → `0.06` に削減

Dracula テーマは彩度が高く長時間閲覧で目が疲れやすいため、GitHub 設計チームが長時間閲覧向けに最適化した `github-dark-dimmed` に切り替え。オーバーレイも Dracula 向けに設計されたものを新テーマに合わせて大幅に薄くした。

## Test plan

- [x] `npm run build` でビルドエラーなし
- [ ] `http://localhost:4321/docs/custom-code` でコードブロック表示を確認

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)