### PR TITLE
Use document.updated_at for source-date resolution

### DIFF
--- a/docs/DOCS_DATE_TRACKING.md
+++ b/docs/DOCS_DATE_TRACKING.md
@@ -45,7 +45,7 @@ HTML の metadata `updatedAt` は技術的に取得しやすい絶対日付で�
 - メタデータ更新とコンテンツ更新が別タイミングで行われる可能性がある
 - 一部ページでは `updatedAt` が変わっても本文が変わっていないことがある
 
-`check:updates` の出力ステータスは `outdated / up-to-date / newer / fetch-error / ignored-exception / source-date-divergence / missing-date / missing-source-date` を区別します。`ignored-exception` は例外レジストリの `ignoredSourceDate` と `comparisonSourceDate` が一致した場合だけ適用されます。`source-date-divergence` は metadata `updatedAt` と表示日付の不一致を signal として残しますが、actionable 判定自体は `comparisonSourceDate` で行います。`missing-date` と `missing-source-date` は error state であり、update candidate には含めません。
+`check:updates` の出力ステータスは `outdated / up-to-date / newer / fetch-error / ignored-exception / source-date-divergence / missing-date / missing-source-date` を区別します。`ignored-exception` は例外レジストリの `ignoredSourceDate` と `comparisonSourceDate` が一致した場合だけ適用されます。`source-date-divergence` は「現在の判定に使う source date」と表示日付が食い違う場合だけ signal にします。`document.updated_at` が取れるページでは `documentDisplayDivergence` を使い、`metadataDisplayDivergence` は diagnostic-only です。`document.updated_at` が取れない場合のみ metadata/display の乖離を fallback signal として扱います。`missing-date` と `missing-source-date` は error state であり、update candidate には含めません。
 
 ### 実運用での対応
 
@@ -86,7 +86,7 @@ HTML の metadata `updatedAt` は技術的に取得しやすい絶対日付で�
 - `reason`
 - `reviewedAt`
 
-同じ source date の間だけ例外として扱い、英語原文の日付が進んだら再度 `outdated` として surfaced する。
+同じ source date の間だけ例外として扱い、英語原文の日付が進んだら再度 `outdated` として surfaced する。`ignoredSourceDate` には `comparisonSourceDate`、つまり通常は `document.updated_at` を `Asia/Tokyo` で日付化した値を入れる。
 
 ## スクリプト使用方法
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -78,7 +78,7 @@ npm run check:updates
 
 各ファイルの `sourceUrl` にアクセスし、まず `script#ssr-props` 内の `document.updated_at` を page-specific な source date として解決する。`document.updated_at` が取れない場合は既存の metadata / 表示相対日付へ fallback する。同時に actionable 判定用の `comparisonSourceDate` を計算し、`document.updated_at` が無い場合のみ `updatedAt` と表示相対日付の乖離を見て表示相対日付を優先する。
 
-運用上は原文追従を基本にし、実質変更なしのページは [`scripts/config/date-exceptions.json`](./config/date-exceptions.json) で管理する。`outdated` と `newer` は別々に扱い、`newer` は warning review に回す。`source-date-divergence` は metadata `updatedAt` と表示日付が食い違うページを分離して報告する signal で、`needsUpdate` 判定自体は `comparisonSourceDate` に従う。`ignored-exception` も `comparisonSourceDate` 基準で適用する。`missing-date` と `missing-source-date` は error state であり、update candidate には含めない。
+運用上は原文追従を基本にし、実質変更なしのページは [`scripts/config/date-exceptions.json`](./config/date-exceptions.json) で管理する。`outdated` と `newer` は別々に扱い、`newer` は warning review に回す。`source-date-divergence` は「現在の判定に使う source date」と表示日付が食い違うページだけを分離して報告する signal で、`document.updated_at` が取れる場合は `documentDisplayDivergence`、取れない場合だけ metadata/display の fallback divergence を使う。`metadataDisplayDivergence` は diagnostic-only とし、`needsUpdate` 判定自体は `comparisonSourceDate` に従う。`ignored-exception` も `comparisonSourceDate` 基準で適用する。`missing-date` と `missing-source-date` は error state であり、update candidate には含めない。
 
 **出力**: `docs-update-status.json`。更新必要ありの場合は終了コード `1`
 
@@ -265,7 +265,7 @@ npm run update:dates:apply          # 実際にファイルを更新
 node scripts/update_dates_from_english.mjs --pattern="overview"
 ```
 
-`updated` は原文追従を正とし、実質変更なしと判断したページは例外レジストリに寄せる。自動更新で書き込む日付は `comparisonSourceDate` を使い、`document.updated_at` を優先する。乖離している `metadataUpdatedAt` は signal として保持する。
+`updated` は原文追従を正とし、実質変更なしと判断したページは例外レジストリに寄せる。自動更新で書き込む日付は `comparisonSourceDate` を使い、通常は `document.updated_at` を `Asia/Tokyo` で日付化した値を採用する。`metadataUpdatedAt` の乖離は diagnostic として保持するが、`document.updated_at` と表示日付が一致している限り top-level signal には昇格しない。
 
 ---
 

--- a/scripts/__tests__/check_outdated_docs.test.mjs
+++ b/scripts/__tests__/check_outdated_docs.test.mjs
@@ -16,6 +16,8 @@ describe('classifyDateStatus', () => {
         resolvedSourceDate: '2025-09-19',
         comparisonSourceDate: '2025-09-19',
         exceptionApplied: false,
+        metadataDisplayDivergence: false,
+        documentDisplayDivergence: false,
         sourceDateDivergence: false,
       },
     });
@@ -33,6 +35,8 @@ describe('classifyDateStatus', () => {
         resolvedSourceDate: '2025-09-19',
         comparisonSourceDate: '2025-09-19',
         exceptionApplied: true,
+        metadataDisplayDivergence: false,
+        documentDisplayDivergence: false,
         sourceDateDivergence: false,
       },
     });
@@ -50,6 +54,8 @@ describe('classifyDateStatus', () => {
         resolvedSourceDate: '2025-10-01',
         comparisonSourceDate: '2025-10-01',
         exceptionApplied: false,
+        metadataDisplayDivergence: false,
+        documentDisplayDivergence: false,
         sourceDateDivergence: false,
       },
     });
@@ -68,11 +74,33 @@ describe('classifyDateStatus', () => {
         resolvedSourceDate: '2026-02-11',
         comparisonSourceDate: '2025-09-19',
         exceptionApplied: false,
+        metadataDisplayDivergence: true,
+        documentDisplayDivergence: false,
         sourceDateDivergence: true,
       },
     });
 
     assert.equal(result.status, 'source-date-divergence');
+    assert.equal(result.comparisonStatus, 'up-to-date');
+    assert.equal(result.needsUpdate, false);
+    assert.equal(result.daysBehind, null);
+  });
+
+  it('does not surface divergence when only metadata differs from the displayed document date', () => {
+    const result = classifyDateStatus({
+      localDate: '2025-09-19',
+      source: {
+        fetchError: null,
+        resolvedSourceDate: '2025-09-19',
+        comparisonSourceDate: '2025-09-19',
+        exceptionApplied: false,
+        metadataDisplayDivergence: true,
+        documentDisplayDivergence: false,
+        sourceDateDivergence: false,
+      },
+    });
+
+    assert.equal(result.status, 'up-to-date');
     assert.equal(result.comparisonStatus, 'up-to-date');
     assert.equal(result.needsUpdate, false);
     assert.equal(result.daysBehind, null);

--- a/scripts/__tests__/source_pages.test.mjs
+++ b/scripts/__tests__/source_pages.test.mjs
@@ -97,7 +97,7 @@ describe('resolveSourcePageInfo', () => {
     assert.equal(result.contentRootExtractable, true);
   });
 
-  it('marks divergence and applies exceptions only for the comparison source date', () => {
+  it('marks fallback divergence and applies exceptions only for the comparison source date', () => {
     const now = new Date('2026-03-19T00:00:00Z');
     const html = `
       <script>window.__REDUX_STATE__={"context":{"page":{"updatedAt":"2026-01-15T00:00:00.000Z"}}}</script>
@@ -122,11 +122,40 @@ describe('resolveSourcePageInfo', () => {
     assert.equal(result.comparisonSourceDate, '2025-09-19');
     assert.equal(result.sourceDateKind, 'metadata-updatedAt');
     assert.equal(result.comparisonSourceKind, 'display-relative-date');
+    assert.equal(result.metadataDisplayDivergence, true);
+    assert.equal(result.documentDisplayDivergence, false);
     assert.equal(result.sourceDateDivergence, true);
     assert.equal(result.exceptionApplied, true);
   });
 
-  it('prefers document.updated_at over diverging metadata and display dates', () => {
+  it('keeps metadata divergence diagnostic-only when document.updated_at matches the displayed JST date', () => {
+    const now = new Date('2026-03-19T00:00:00Z');
+    const html = `
+      <script id="ssr-props" type="application/json">{"document":{"updated_at":"2025-09-18T21:08:46.000Z"}}</script>
+      <script>window.__REDUX_STATE__={"context":{"page":{"updatedAt":"2026-01-15T00:00:00.000Z"}}}</script>
+      <main>
+        <h1>Example</h1>
+        <p>Updated 6 months ago</p>
+      </main>
+    `;
+    const result = resolveSourcePageInfo({
+      html,
+      url: 'https://help.testim.io/docs/example',
+      now,
+    });
+    assert.equal(result.documentUpdatedAt, '2025-09-19');
+    assert.equal(result.metadataUpdatedAt, '2026-01-15');
+    assert.equal(result.displayRelativeDate, '2025-09-19');
+    assert.equal(result.resolvedSourceDate, '2025-09-19');
+    assert.equal(result.comparisonSourceDate, '2025-09-19');
+    assert.equal(result.sourceDateKind, 'document-updated-at');
+    assert.equal(result.comparisonSourceKind, 'document-updated-at');
+    assert.equal(result.metadataDisplayDivergence, true);
+    assert.equal(result.documentDisplayDivergence, false);
+    assert.equal(result.sourceDateDivergence, false);
+  });
+
+  it('prefers document.updated_at when it truly diverges from the visible date', () => {
     const now = new Date('2026-03-19T00:00:00Z');
     const html = `
       <script id="ssr-props" type="application/json">{"document":{"updated_at":"2025-09-18T03:00:00.000Z"}}</script>
@@ -153,6 +182,8 @@ describe('resolveSourcePageInfo', () => {
     assert.equal(result.comparisonSourceDate, '2025-09-18');
     assert.equal(result.sourceDateKind, 'document-updated-at');
     assert.equal(result.comparisonSourceKind, 'document-updated-at');
+    assert.equal(result.metadataDisplayDivergence, true);
+    assert.equal(result.documentDisplayDivergence, true);
     assert.equal(result.sourceDateDivergence, true);
     assert.equal(result.exceptionApplied, false);
   });
@@ -187,6 +218,8 @@ describe('fetchSourcePageInfo', () => {
     });
     assert.equal(result.fetchError, 'HTTP 503');
     assert.equal(result.documentUpdatedAt, null);
+    assert.equal(result.metadataDisplayDivergence, false);
+    assert.equal(result.documentDisplayDivergence, false);
     assert.equal(result.resolvedSourceDate, null);
     assert.equal(result.comparisonSourceDate, null);
   });

--- a/scripts/check_outdated_docs.mjs
+++ b/scripts/check_outdated_docs.mjs
@@ -136,12 +136,15 @@ export async function checkOutdatedDocs({
         );
       } else if (classified.status === 'source-date-divergence') {
         const verb = classified.needsUpdate ? '更新候補' : '差分レビュー';
+        const divergenceKind = source.documentDisplayDivergence
+          ? 'document/display'
+          : 'metadata/display fallback';
         console.log(
           `  ⚠️  原文日付が乖離しています: document ${
             source.documentUpdatedAt ?? 'なし'
           } / metadata ${source.metadataUpdatedAt ?? 'なし'} / display ${
             source.displayRelativeDate ?? 'なし'
-          } / 判定 ${source.comparisonSourceDate ?? '不明'} (${verb})\n`
+          } / 判定 ${source.comparisonSourceDate ?? '不明'} (${divergenceKind}, ${verb})\n`
         );
       } else if (classified.status === 'outdated') {
         console.log(
@@ -176,6 +179,8 @@ export async function checkOutdatedDocs({
       documentUpdatedAt: source.documentUpdatedAt,
       metadataUpdatedAt: source.metadataUpdatedAt,
       displayRelativeDate: source.displayRelativeDate,
+      metadataDisplayDivergence: source.metadataDisplayDivergence,
+      documentDisplayDivergence: source.documentDisplayDivergence,
       exceptionApplied: source.exceptionApplied,
       contentRootExtractable: source.contentRootExtractable,
     });

--- a/scripts/fetch_all_updated_dates.mjs
+++ b/scripts/fetch_all_updated_dates.mjs
@@ -75,6 +75,8 @@ export async function fetchAllUpdatedDates({
         documentUpdatedAt: source.documentUpdatedAt,
         metadataUpdatedAt: source.metadataUpdatedAt,
         displayRelativeDate: source.displayRelativeDate,
+        metadataDisplayDivergence: source.metadataDisplayDivergence,
+        documentDisplayDivergence: source.documentDisplayDivergence,
         exceptionApplied: source.exceptionApplied,
       });
       continue;
@@ -108,6 +110,8 @@ export async function fetchAllUpdatedDates({
       documentUpdatedAt: source.documentUpdatedAt,
       metadataUpdatedAt: source.metadataUpdatedAt,
       displayRelativeDate: source.displayRelativeDate,
+      metadataDisplayDivergence: source.metadataDisplayDivergence,
+      documentDisplayDivergence: source.documentDisplayDivergence,
       exceptionApplied: source.exceptionApplied,
     });
 

--- a/scripts/lib/source_pages.mjs
+++ b/scripts/lib/source_pages.mjs
@@ -243,9 +243,15 @@ export function resolveSourcePageInfo({ html, url, now = new Date(), exception =
       : comparisonSourceDate === displayRelativeDate && displayRelativeDate
         ? 'display-relative-date'
         : sourceDateKind;
-  const sourceDateDivergence = Boolean(
+  const metadataDisplayDivergence = Boolean(
     metadataUpdatedAt && displayRelativeDate && metadataUpdatedAt !== displayRelativeDate
   );
+  const documentDisplayDivergence = Boolean(
+    documentUpdatedAt && displayRelativeDate && documentUpdatedAt !== displayRelativeDate
+  );
+  const sourceDateDivergence = documentUpdatedAt
+    ? documentDisplayDivergence
+    : metadataDisplayDivergence;
   const exceptionApplied = Boolean(
     exception?.ignoredSourceDate &&
       comparisonSourceDate &&
@@ -261,6 +267,8 @@ export function resolveSourcePageInfo({ html, url, now = new Date(), exception =
     comparisonSourceDate,
     sourceDateKind,
     comparisonSourceKind,
+    metadataDisplayDivergence,
+    documentDisplayDivergence,
     sourceDateDivergence,
     contentRootExtractable,
     extractionStrategy,
@@ -291,6 +299,8 @@ export async function fetchSourcePageInfo(
         comparisonSourceDate: null,
         sourceDateKind: 'unresolved',
         comparisonSourceKind: 'unresolved',
+        metadataDisplayDivergence: false,
+        documentDisplayDivergence: false,
         sourceDateDivergence: false,
         contentRootExtractable: false,
         extractionStrategy: 'fetch-error',
@@ -318,6 +328,8 @@ export async function fetchSourcePageInfo(
       comparisonSourceDate: null,
       sourceDateKind: 'unresolved',
       comparisonSourceKind: 'unresolved',
+      metadataDisplayDivergence: false,
+      documentDisplayDivergence: false,
       sourceDateDivergence: false,
       contentRootExtractable: false,
       extractionStrategy: 'fetch-error',

--- a/scripts/update_dates_from_english.mjs
+++ b/scripts/update_dates_from_english.mjs
@@ -2,12 +2,7 @@
 
 import fs from 'node:fs';
 
-import {
-  DOCS_DIR,
-  findMdFiles,
-  matchesSectionFilter,
-  readDocFile,
-} from './lib/project.mjs';
+import { DOCS_DIR, findMdFiles, matchesSectionFilter, readDocFile } from './lib/project.mjs';
 import { fetchSourcePageInfo, toIsoDate } from './lib/source_pages.mjs';
 import { getDateException, loadDateExceptions } from './lib/date_exceptions.mjs';
 import { isDirectRun as isDirectCliRun } from './lib/cli.mjs';
@@ -103,10 +98,13 @@ export async function updateDatesFromEnglish({
 
     console.log(`  🔄 更新: ${localDate || 'なし'} → ${sourceDate}`);
     if (source.sourceDateDivergence) {
+      const divergenceKind = source.documentDisplayDivergence
+        ? 'document/display'
+        : 'metadata/display fallback';
       console.log(
         `  ⚠️  document=${source.documentUpdatedAt ?? 'なし'} / metadata=${
           source.metadataUpdatedAt ?? 'なし'
-        } / display=${source.displayRelativeDate ?? 'なし'} / 判定=${sourceDate}`
+        } / display=${source.displayRelativeDate ?? 'なし'} / 判定=${sourceDate} (${divergenceKind})`
       );
     }
 


### PR DESCRIPTION
## Summary
- resolve source dates from `script#ssr-props` `document.updated_at` before falling back to metadata and visible relative dates
- keep metadata/display divergence as a diagnostic signal, and surface `documentUpdatedAt` in update-check outputs
- cover the new precedence and JST normalization in tests, and update the date-tracking docs

## Verification
- `npm test`
- `npm run build`
- `npm run check:updates -- --section=testops-management`

Closes #113