### PR TITLE
docs: CLAUDE.md を最新のコマンド体系に更新

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Japanese localization of Testim Help Documentation (help.testim.io). Built with Astro 5, Tailwind CSS v4, TypeScript, and React (for search UI only). Deployed on Vercel. All responses and content should be in Japanese.
+Japanese localization of Testim Help Documentation (help.testim.io). Built with Astro 6, Tailwind CSS v4, TypeScript, and React (for search UI only). Deployed on Vercel. All responses and content should be in Japanese.
 
 ## Common Commands
 
@@ -13,15 +13,24 @@ Japanese localization of Testim Help Documentation (help.testim.io). Built with 
 | `npm run dev` | Dev server at http://localhost:4321 |
 | `npm run build` | Production build (runs `astro check` + build) |
 | `npm run check` | TypeScript/Astro type checking only |
-| `npm run lint` | Markdown lint (markdownlint) |
+| `npm run lint` | Full lint (`lint:md` + `lint:docs`) |
+| `npm run lint:md` | Markdownlint (`lint:md:content` + `lint:md:repo`) |
+| `npm run lint:docs` | WRITING_GUIDE compliance (frontmatter, links, callouts, feature names, image existence) |
 | `npm run lint:fix` | Auto-fix markdown lint issues |
 | `npm run format` | Format with Prettier (Astro, TS, MD) |
 | `npm run format:check` | Check formatting compliance |
 | `npm run test` | Run tests in `scripts/__tests__/` |
-| `npm run check:updates` | Check which Japanese docs need updating vs English originals |
-| `npm run check:parity` | Source parity check (untranslated text, legacy callouts, orphans) |
-| `npm run check:parity:remote` | Source parity + remote English comparison (headings, images) |
+| `npm run check:parity` | Source parity check (structure, tables, allowlist, EN normalization) |
+| `npm run check:snapshots` | EN snapshot fetch + diff |
 | `npm run docs:pipeline` | Run full doc sync pipeline (fetch, translate, etc.) |
+
+### Single-page commands
+
+| Command | Purpose |
+|---------|---------|
+| `npm run check:parity -- --slug=testim-overview` | Single page parity check |
+| `npm run check:snapshots:diff -- --slug=testim-overview` | Single page snapshot diff |
+| `npm run lint:docs -- --path=src/content/docs/overview/testim-overview.md` | Single file lint |
 
 ## Architecture
 
@@ -36,15 +45,15 @@ Japanese localization of Testim Help Documentation (help.testim.io). Built with 
 ## Authority Sources
 
 - **`docs/SIDEBAR_URLS.md`** — Master list of all documentation URLs, categories, and page ordering. Single source of truth for what pages exist and their structure.
-- **`docs/WRITING_GUIDE.md`** — Authoritative rules for content formatting, frontmatter, links, callouts, and Testim terminology English retention.
+- **`docs/WRITING_GUIDE.md`** — Authoritative rules for content formatting, frontmatter, links, callouts, source-first structure contract, and Testim terminology English retention.
 - **`docs/TRANSLATION_GUIDE.md`** — Translation workflow, natural Japanese guidelines, NG/OK patterns, terminology table.
-- **`docs/OPS_DESIGN.md`** — Operational design: sync/diff/translate/QA flow, review policy, CI schedule, feedback loop.
+- **`docs/OPS_DESIGN.md`** — Operational design: sync/diff/translate/QA flow, parity check details, EN normalization, review policy, feedback loop.
 
 ## Content Rules
 
 Content rules are defined in the authority sources. Do not duplicate rules here — refer to:
 
-- **`docs/WRITING_GUIDE.md`** for frontmatter, internal links (`/docs/{slug}`), callouts (`:::`), source fidelity, Testim terminology English retention
+- **`docs/WRITING_GUIDE.md`** for frontmatter, internal links (`/docs/{slug}`), callouts (`:::`), source-first structure (heading mapping, `:fa-arrow-right:` → bold, `<details>` preservation, JA-only section removal), Testim terminology English retention
 - **`docs/TRANSLATION_GUIDE.md`** for natural Japanese, NG/OK patterns, terminology table, media handling
 
 ## Review & Feedback


### PR DESCRIPTION
## Summary

CLAUDE.md が古いコマンド体系のまま残っていたため更新。

### 主な変更
- Astro 5 → 6
- lint コマンド: 分割後の構成を反映
- check:parity: 構造比較・テーブル・allowlist・EN 正規化
- 存在しないコマンド削除 (check:updates, check:parity:remote)
- --slug 単一ページコマンドのセクション追加
- source-first 構造契約の参照を追記

Generated with Claude Code