### PR TITLE
feat: ツールチェーンのパスベースリンク対応 (#194)

### DIFF
--- a/docs/WRITING_GUIDE.md
+++ b/docs/WRITING_GUIDE.md
@@ -67,13 +67,13 @@ updated: '2025-11-02'
 
 ## 🔗 内部リンク規則
 
-内部リンクは必ず `/docs/{slug}` 形式を使用してください。
+内部リンクは `/docs/{slug}` 形式（推奨）または `/docs/{folder}/{slug}` 形式の両方を使用できます。
 
 ```markdown
-✅ 正しい
+✅ 推奨（フラットスラグ）
 [Testim 概要](/docs/testim-overview)
 
-❌ 禁止（カテゴリフォルダ付き）
+✅ 許容（パス付き — lint 警告あり）
 [Testim 概要](/docs/overview/testim-overview)
 
 ❌ 禁止（`doc:` 形式はソース原稿のみ。公開ページには使わない）
@@ -82,10 +82,10 @@ updated: '2025-11-02'
 
 補足:
 
-- アンカー付きリンクも `/docs/{slug}#section-name` を使用する
-- `/docs/{folder}/{slug}` 形式は lint でエラーになる
+- アンカー付きリンクも `/docs/{slug}#section-name` または `/docs/{folder}/{slug}#section-name` を使用する
+- `/docs/{folder}/{slug}` 形式は lint で **警告** になる（エラーではない）
 - 本文中の `https://docs.tricentis.com/testim/content/.../{slug}.htm` は、対応する JA ファイルが存在する場合 `/docs/{slug}` に変換する（HTML `<a href>` 含む）
-- `/docs/{slug}` のスラグが実在するファイルを指しているか必ず検証する。英語原文側でスラグがリネームされている場合があるため、ファイル名との突き合わせが必要
+- スラグが実在するファイルを指しているか必ず検証する。英語原文側でスラグがリネームされている場合があるため、ファイル名との突き合わせが必要
 
 ---
 

--- a/scripts/__tests__/lib_project.test.mjs
+++ b/scripts/__tests__/lib_project.test.mjs
@@ -1,7 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import path from 'node:path';
 
-import { buildSlugIndex, matchesSectionFilter, splitFrontmatter, toKebab } from '../lib/project.mjs';
+import { buildSlugIndex, buildDocsIndex, extractSourceContentPath, matchesSectionFilter, splitFrontmatter, toKebab } from '../lib/project.mjs';
 
 describe('buildSlugIndex', () => {
   it('returns an object with slug keys mapping to categoryFolder and filePath', () => {
@@ -130,5 +131,92 @@ describe('toKebab', () => {
 
   it('returns empty string for empty input', () => {
     assert.equal(toKebab(''), '');
+  });
+});
+
+describe('extractSourceContentPath', () => {
+  it('extracts one-level path from direct .htm URL', () => {
+    const url = 'https://docs.tricentis.com/testim/content/getting-started/setting-up-your-account.htm';
+    assert.equal(extractSourceContentPath(url), 'getting-started/setting-up-your-account');
+  });
+
+  it('strips /index suffix from directory-style URL', () => {
+    const url = 'https://docs.tricentis.com/testim/content/overview/testim-overview/index.htm';
+    assert.equal(extractSourceContentPath(url), 'overview/testim-overview');
+  });
+
+  it('handles two-level nested path', () => {
+    const url = 'https://docs.tricentis.com/testim/content/integrations/visual-validation/override-applitools-app-name.htm';
+    assert.equal(extractSourceContentPath(url), 'integrations/visual-validation/override-applitools-app-name');
+  });
+
+  it('handles three-level deeply nested path', () => {
+    const url = 'https://docs.tricentis.com/testim/content/overview/testim-overview/use-ai-in-with-testim/index.htm';
+    assert.equal(extractSourceContentPath(url), 'overview/testim-overview/use-ai-in-with-testim');
+  });
+
+  it('returns null for non-tricentis URL', () => {
+    assert.equal(extractSourceContentPath('https://example.com/docs/foo'), null);
+  });
+
+  it('returns null for undefined input', () => {
+    assert.equal(extractSourceContentPath(undefined), null);
+  });
+
+  it('returns null for null input', () => {
+    assert.equal(extractSourceContentPath(null), null);
+  });
+
+  it('returns null for empty string', () => {
+    assert.equal(extractSourceContentPath(''), null);
+  });
+});
+
+describe('buildDocsIndex', () => {
+  it('returns richer index with filePath, localFolder, sourceContentPath', () => {
+    const index = buildDocsIndex();
+    const slugs = Object.keys(index);
+    assert.ok(slugs.length > 0, 'should find at least one doc');
+    const first = index[slugs[0]];
+    assert.ok(typeof first.filePath === 'string');
+    assert.ok(typeof first.localFolder === 'string');
+    assert.ok(first.sourceContentPath === null || typeof first.sourceContentPath === 'string');
+  });
+
+  it('populates sourceContentPath from sourceUrl frontmatter', () => {
+    const index = buildDocsIndex();
+    // testim-overview has a known sourceUrl
+    const entry = index['testim-overview'];
+    assert.ok(entry, 'testim-overview should exist in docs');
+    assert.ok(typeof entry.sourceContentPath === 'string', 'should have a sourceContentPath');
+    assert.ok(entry.sourceContentPath.includes('testim-overview'), 'path should contain the slug');
+  });
+
+  it('returns sourceContentPath null when sourceUrl is missing', async () => {
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-index-nosrc-'));
+    fs.mkdirSync(path.join(dir, 'section'));
+    fs.writeFileSync(
+      path.join(dir, 'section', 'no-source.md'),
+      '---\ntitle: T\ncategory: C\nupdated: 2026-01-01\n---\nBody\n',
+    );
+    const index = buildDocsIndex(dir);
+    assert.equal(index['no-source'].sourceContentPath, null);
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  it('throws on slug collision (two files with same basename in different folders)', async () => {
+    const fs = await import('node:fs');
+    const os = await import('node:os');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-index-test-'));
+    fs.mkdirSync(path.join(dir, 'folder-a'));
+    fs.mkdirSync(path.join(dir, 'folder-b'));
+    const fm = '---\ntitle: T\ncategory: C\nupdated: 2026-01-01\nsourceUrl: https://docs.tricentis.com/testim/content/a/page.htm\n---\n';
+    fs.writeFileSync(path.join(dir, 'folder-a', 'page.md'), fm);
+    fs.writeFileSync(path.join(dir, 'folder-b', 'page.md'), fm);
+    assert.throws(() => buildDocsIndex(dir), /Duplicate slug basename/);
+    // Cleanup
+    fs.rmSync(dir, { recursive: true });
   });
 });

--- a/scripts/__tests__/lint_docs.test.mjs
+++ b/scripts/__tests__/lint_docs.test.mjs
@@ -135,17 +135,17 @@ describe('frontmatter: required fields', () => {
 // B. Internal link format
 // ---------------------------------------------------------------------------
 describe('internal link format', () => {
-  it('returns error for /docs/{folder}/{slug} link', () => {
+  it('returns warning (not error) for /docs/{folder}/{slug} link', () => {
     const content = makeDoc({
       body: 'See [overview](/docs/overview/testim-overview).\n',
     });
     const errors = lintContent(content, 'src/content/docs/test.md');
     const e = errors.find((e) => e.rule === 'internal-link-format');
-    assert.ok(e, 'expected internal-link-format error');
-    assert.equal(e.level, 'error');
+    assert.ok(e, 'expected internal-link-format warning');
+    assert.equal(e.level, 'warning');
   });
 
-  it('no error for /docs/{slug} link', () => {
+  it('no warning for /docs/{slug} link', () => {
     const content = makeDoc({
       body: 'See [overview](/docs/testim-overview).\n',
     });
@@ -153,12 +153,30 @@ describe('internal link format', () => {
     assert.equal(errorsOf(['internal-link-format'], errors).length, 0);
   });
 
-  it('no error for external links', () => {
+  it('no warning for external links', () => {
     const content = makeDoc({
       body: 'See [Testim](https://docs.tricentis.com/testim/content/overview/testim-overview/index.htm).\n',
     });
     const errors = lintContent(content, 'src/content/docs/test.md');
     assert.equal(errorsOf(['internal-link-format'], errors).length, 0);
+  });
+
+  it('no warning for /docs/{folder}/{slug} link inside a code block', () => {
+    const content = makeDoc({
+      body: '```\nSee [overview](/docs/overview/testim-overview).\n```\n',
+    });
+    const errors = lintContent(content, 'src/content/docs/test.md');
+    assert.equal(errorsOf(['internal-link-format'], errors).length, 0);
+  });
+
+  it('returns warning for HTML <a href="/docs/{folder}/{slug}"> link', () => {
+    const content = makeDoc({
+      body: 'See <a href="/docs/overview/testim-overview">overview</a>.\n',
+    });
+    const errors = lintContent(content, 'src/content/docs/test.md');
+    const e = errors.find((e) => e.rule === 'internal-link-format');
+    assert.ok(e, 'expected internal-link-format warning for HTML link');
+    assert.equal(e.level, 'warning');
   });
 });
 
@@ -348,6 +366,42 @@ describe('internal link target existence', () => {
   it('skips links inside inline code', () => {
     const content = makeDoc({
       body: 'Use `[page](/docs/nonexistent-page)` syntax.\n',
+    });
+    const errors = lintContent(content, 'test.md', { allSlugs: slugs, headingsBySlug: headings });
+    assert.equal(errorsOf(['link-target-missing'], errors).length, 0);
+  });
+
+  it('no error for path-based link when basename slug exists', () => {
+    const content = makeDoc({
+      body: 'See [overview](/docs/overview/testim-overview) for details.\n',
+    });
+    const errors = lintContent(content, 'test.md', { allSlugs: slugs, headingsBySlug: headings });
+    assert.equal(errorsOf(['link-target-missing'], errors).length, 0);
+  });
+
+  it('returns error for path-based link when basename slug does not exist', () => {
+    const content = makeDoc({
+      body: 'See [page](/docs/overview/nonexistent-page) for details.\n',
+    });
+    const errors = lintContent(content, 'test.md', { allSlugs: slugs, headingsBySlug: headings });
+    const e = errors.find((e) => e.rule === 'link-target-missing');
+    assert.ok(e, 'expected link-target-missing for unknown slug in path-based link');
+    assert.equal(e.level, 'error');
+  });
+
+  it('returns fragment warning for path-based link with bad fragment', () => {
+    const content = makeDoc({
+      body: 'See [section](/docs/overview/testim-overview#nonexistent-section) here.\n',
+    });
+    const errors = lintContent(content, 'test.md', { allSlugs: slugs, headingsBySlug: headings });
+    const e = errors.find((e) => e.rule === 'link-fragment-missing');
+    assert.ok(e, 'expected link-fragment-missing warning');
+    assert.equal(e.level, 'warning');
+  });
+
+  it('no error for path-based HTML link when basename slug exists', () => {
+    const content = makeDoc({
+      body: 'See <a href="/docs/overview/testim-overview">overview</a>.\n',
     });
     const errors = lintContent(content, 'test.md', { allSlugs: slugs, headingsBySlug: headings });
     assert.equal(errorsOf(['link-target-missing'], errors).length, 0);

--- a/scripts/lib/project.mjs
+++ b/scripts/lib/project.mjs
@@ -102,6 +102,59 @@ export function buildSlugIndex(docsDir = DOCS_DIR) {
   return index;
 }
 
+const SOURCE_URL_RE = /^https:\/\/docs\.tricentis\.com\/testim\/content\/([a-z0-9_-]+(?:\/[a-z0-9_-]+)*)\.htm$/;
+
+/**
+ * Extract the EN content path from a sourceUrl.
+ *
+ * Examples:
+ *   ".../content/running-tests/play-from-here.htm"          → "running-tests/play-from-here"
+ *   ".../content/running-tests/play-from-here/index.htm"    → "running-tests/play-from-here"
+ *   ".../content/overview/testim-overview/use-ai/index.htm"  → "overview/testim-overview/use-ai"
+ *
+ * Returns null for non-matching URLs or non-string input.
+ * @param {string | undefined | null} sourceUrl
+ * @returns {string | null}
+ */
+export function extractSourceContentPath(sourceUrl) {
+  if (typeof sourceUrl !== 'string') return null;
+  const m = SOURCE_URL_RE.exec(sourceUrl);
+  if (!m) return null;
+  const raw = m[1];
+  return raw.endsWith('/index') ? raw.slice(0, -'/index'.length) : raw;
+}
+
+/**
+ * Richer doc index that includes the EN source content path from frontmatter.
+ * Throws Error on basename (slug) collision across different folders.
+ * @param {string} [docsDir]
+ * @returns {Record<string, {filePath:string, localFolder:string, sourceContentPath:string|null}>}
+ */
+export function buildDocsIndex(docsDir = DOCS_DIR) {
+  /** @type {Record<string, {filePath:string, localFolder:string, sourceContentPath:string|null}>} */
+  const index = {};
+  const walk = (dir) => {
+    for (const ent of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, ent.name);
+      if (ent.isDirectory()) { walk(full); continue; }
+      if (!ent.isFile() || !ent.name.endsWith('.md')) continue;
+      const slug = ent.name.replace(/\.md$/, '');
+      if (index[slug]) {
+        throw new Error(
+          `Duplicate slug basename '${slug}': found in "${index[slug].filePath}" and "${full}"`
+        );
+      }
+      const localFolder = path.basename(path.dirname(full));
+      const raw = fs.readFileSync(full, 'utf8');
+      const { data } = matter(raw);
+      const sourceContentPath = extractSourceContentPath(data.sourceUrl);
+      index[slug] = { filePath: full, localFolder, sourceContentPath };
+    }
+  };
+  walk(docsDir);
+  return index;
+}
+
 export function splitFrontmatter(md) {
   if (!md.startsWith('---\n')) return { fm: '', body: md };
   const end = md.indexOf('\n---', 4);

--- a/scripts/lint-docs.mjs
+++ b/scripts/lint-docs.mjs
@@ -101,13 +101,25 @@ export function lintContent(content, filePath, { allSlugs, headingsBySlug } = {}
   }
 
   const bodyLines = body.split('\n');
-  bodyLines.forEach((line, i) => {
-    const internalLinkRe = /\]\(\/docs\/([a-z0-9_-]+)\/([a-z0-9_-]+)(#[^)]+)?\)/g;
+  const bodyStrippedForFormat = stripCode(body).split('\n');
+  bodyStrippedForFormat.forEach((line, i) => {
+    // Markdown: [text](/docs/{folder}/{slug})
+    const mdFormatRe = /\]\(\/docs\/([a-z0-9_-]+)\/([a-z0-9_-]+)(#[^)]+)?\)/g;
     let m;
-    while ((m = internalLinkRe.exec(line)) !== null) {
-      err(
+    while ((m = mdFormatRe.exec(line)) !== null) {
+      warn(
         'internal-link-format',
-        `Internal link must use /docs/{slug} not /docs/{folder}/{slug} (found: /docs/${m[1]}/${m[2]})`,
+        `Prefer /docs/{slug} over /docs/{folder}/{slug} (found: /docs/${m[1]}/${m[2]})`,
+        toAbsoluteLine(i + 1, bodyStart)
+      );
+    }
+    // HTML: <a href="/docs/{folder}/{slug}">
+    const htmlFormatRe = /<a\b[^>]*href=["']\/docs\/([a-z0-9_-]+)\/([a-z0-9_-]+)(#[^\s"']*)?\s*["'][^>]*>/gi;
+    let hm;
+    while ((hm = htmlFormatRe.exec(line)) !== null) {
+      warn(
+        'internal-link-format',
+        `Prefer /docs/{slug} over /docs/{folder}/{slug} (found: /docs/${hm[1]}/${hm[2]})`,
         toAbsoluteLine(i + 1, bodyStart)
       );
     }
@@ -119,42 +131,18 @@ export function lintContent(content, filePath, { allSlugs, headingsBySlug } = {}
     const strippedLines = bodyStripped.split('\n');
 
     strippedLines.forEach((line, i) => {
-      // Check A: Markdown links — [text](/docs/{slug}) or [text](/docs/{slug}#fragment)
-      const mdLinkRe = /\]\(\/(docs\/([a-z0-9_-]+))(#[^)]+)?\)/g;
+      // Check A: Markdown links — [text](/docs/{slug}) or [text](/docs/{folder}/{slug})
+      const mdLinkRe = /\]\(\/docs\/(?:([a-z0-9_-]+)\/)?([a-z0-9_-]+)(#[^)]+)?\)/g;
       let mdMatch;
       while ((mdMatch = mdLinkRe.exec(line)) !== null) {
+        const folder = mdMatch[1]; // present only for /docs/{folder}/{slug}
         const slug = mdMatch[2];
-        const fragment = mdMatch[3]; // includes leading '#'
+        const fragment = mdMatch[3];
+        const displayPath = folder ? `/docs/${folder}/${slug}` : `/docs/${slug}`;
         if (!allSlugs.has(slug)) {
           err(
             'link-target-missing',
-            `Internal link target does not exist: /docs/${slug}`,
-            toAbsoluteLine(i + 1, bodyStart)
-          );
-        } else if (fragment && headingsBySlug) {
-          // Check C: Fragment existence
-          const fragId = fragment.slice(1); // strip '#'
-          const headings = headingsBySlug.get(slug);
-          if (headings && !headings.has(fragId)) {
-            warn(
-              'link-fragment-missing',
-              `Fragment "${fragment}" not found in /docs/${slug}`,
-              toAbsoluteLine(i + 1, bodyStart)
-            );
-          }
-        }
-      }
-
-      // Check B: HTML <a href="/docs/..."> links
-      const htmlLinkRe = /<a\b[^>]*href=["']\/(docs\/([a-z0-9_-]+))(#[^"']*)?\s*["'][^>]*>/gi;
-      let htmlMatch;
-      while ((htmlMatch = htmlLinkRe.exec(line)) !== null) {
-        const slug = htmlMatch[2];
-        const fragment = htmlMatch[3]; // includes leading '#'
-        if (!allSlugs.has(slug)) {
-          err(
-            'link-target-missing',
-            `Internal link target does not exist: /docs/${slug}`,
+            `Internal link target does not exist: ${displayPath}`,
             toAbsoluteLine(i + 1, bodyStart)
           );
         } else if (fragment && headingsBySlug) {
@@ -163,7 +151,34 @@ export function lintContent(content, filePath, { allSlugs, headingsBySlug } = {}
           if (headings && !headings.has(fragId)) {
             warn(
               'link-fragment-missing',
-              `Fragment "${fragment}" not found in /docs/${slug}`,
+              `Fragment "${fragment}" not found in ${displayPath}`,
+              toAbsoluteLine(i + 1, bodyStart)
+            );
+          }
+        }
+      }
+
+      // Check B: HTML <a href="/docs/..."> links
+      const htmlLinkRe = /<a\b[^>]*href=["']\/docs\/(?:([a-z0-9_-]+)\/)?([a-z0-9_-]+)(#[^\s"']*)?\s*["'][^>]*>/gi;
+      let htmlMatch;
+      while ((htmlMatch = htmlLinkRe.exec(line)) !== null) {
+        const folder = htmlMatch[1];
+        const slug = htmlMatch[2];
+        const fragment = htmlMatch[3];
+        const displayPath = folder ? `/docs/${folder}/${slug}` : `/docs/${slug}`;
+        if (!allSlugs.has(slug)) {
+          err(
+            'link-target-missing',
+            `Internal link target does not exist: ${displayPath}`,
+            toAbsoluteLine(i + 1, bodyStart)
+          );
+        } else if (fragment && headingsBySlug) {
+          const fragId = fragment.slice(1);
+          const headings = headingsBySlug.get(slug);
+          if (headings && !headings.has(fragId)) {
+            warn(
+              'link-fragment-missing',
+              `Fragment "${fragment}" not found in ${displayPath}`,
               toAbsoluteLine(i + 1, bodyStart)
             );
           }

--- a/scripts/normalize_docs.mjs
+++ b/scripts/normalize_docs.mjs
@@ -18,7 +18,6 @@ const REPLACEMENTS = [
   [/Testim ビジュアルエディタ(?:ー)?/g, 'Testim Visual Editor'],
   [/ビジュアルエディタ(?:ー)?/g, 'Visual Editor'],
   [/エージェント型テスト自動化/g, 'Agentic Test Automation'],
-  [/\/docs\/([a-z0-9_-]+)\/([a-z0-9_-]+)(#[^)'" \t\n]+)?/g, '/docs/$2$3'],
 ];
 
 const FRONTMATTER_ORDER = [


### PR DESCRIPTION
## Summary

パスベースルーティング移行 (#192) の Phase 0+1。ツールチェーンが `/docs/{folder}/{slug}` 形式を受け付けるようにする。ルーティング自体は変更しない。

- `normalize_docs.mjs`: `/docs/{folder}/{slug}` → `/docs/{slug}` の巻き戻し regex を削除
- `lint-docs.mjs`: `internal-link-format` を error → warning に変更、markdown/HTML 両方でパスベースリンクの存在チェック対応、コードブロック内の誤検出修正
- `project.mjs`: `extractSourceContentPath()` + `buildDocsIndex()` 追加（EN ソースパス抽出 + 重複 slug のハードエラー検出）
- `WRITING_GUIDE.md`: 内部リンク規則を「両形式許可」に更新

## Changes

| ファイル | 変更内容 |
|---|---|
| `scripts/lib/project.mjs` | `extractSourceContentPath()` + `buildDocsIndex()` 追加 (+53) |
| `scripts/lint-docs.mjs` | warning 化 + 両形式 regex + HTML format check + code-block 除外 (+47/-29) |
| `scripts/normalize_docs.mjs` | folder-stripping regex 削除 (-1) |
| `scripts/__tests__/lib_project.test.mjs` | 12 テスト追加 (+90) |
| `scripts/__tests__/lint_docs.test.mjs` | 6 テスト追加/更新 (+64) |
| `docs/WRITING_GUIDE.md` | 内部リンク規則を「両形式許可」に更新 (+12/-12) |

## Design Decisions (Codex レビュー反映)

- **`internal-link-format` は warning 化（削除ではない）** — ルーティング対応 (#196) 前に path-based を推奨しない
- **`buildDocsIndex()` は `buildSlugIndex()` と共存** — 既存利用者の後方互換性を維持
- **衝突検出はハードエラー** — サイレント上書きを防止
- **TRANSLATION_GUIDE.md は未更新** — #197 で「パスベースのみ」に移行する際に一括更新（[コメント済み](https://github.com/rymetry/testim-docs-ja/issues/197#issuecomment-4167029593))
- **既存コードの silent failure は別途対応** — #192 に[技術的負債メモを追記](https://github.com/rymetry/testim-docs-ja/issues/192#issuecomment-4167030070)

## Verification

- ✅ 515/515 テスト PASS
- ✅ `npm run lint` — 0 errors, 0 warnings (287 files)
- ✅ `npm run build` — 289 pages built

## Test plan

- [ ] `extractSourceContentPath` が 1〜3 階層の EN URL を正しく抽出する
- [ ] `buildDocsIndex` が重複 slug でハードエラーを投げる
- [ ] `buildDocsIndex` が sourceUrl 欠損時に `sourceContentPath: null` を返す
- [ ] `/docs/{folder}/{slug}` リンクが lint で warning（error ではない）
- [ ] HTML `<a href="/docs/{folder}/{slug}">` も同様に warning
- [ ] コードブロック内のパスベースリンクが warning を出さない
- [ ] パスベースリンクの存在チェック（basename で解決）
- [ ] パスベースリンクのフラグメントチェック
- [ ] `normalize_docs` が他の REPLACEMENTS（機能名正規化等）を引き続き適用する

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)