### PR TITLE
feat: HTML anchor リンク変換 + ユーティリティ共通化 + エラーハンドリング改善

### DIFF
--- a/scripts/__tests__/fetch_translate_images.test.mjs
+++ b/scripts/__tests__/fetch_translate_images.test.mjs
@@ -81,6 +81,118 @@ describe('rewriteDocLinks', () => {
     const result = rewriteDocLinks('[link](../../salesforce-testing/salesforce-testing-overview.htm)');
     assert.equal(result, '[link](/docs/salesforce-testing/salesforce-testing-overview)');
   });
+
+  // Stage 2 edge cases: external Markdown .htm links should NOT be rewritten
+  it('does not rewrite Markdown https://*.htm link', () => {
+    const md = '[link](https://example.com/page.htm)';
+    assert.equal(rewriteDocLinks(md), md);
+  });
+
+  it('does not rewrite Markdown protocol-relative //*.htm link', () => {
+    const md = '[link](//example.com/page.htm)';
+    assert.equal(rewriteDocLinks(md), md);
+  });
+
+  // Stage 3: HTML <a href="doc:slug">
+  it('rewrites HTML <a href="doc:slug"> to /docs/ path', () => {
+    const result = rewriteDocLinks('<a href="doc:testim-overview">overview</a>');
+    assert.equal(result, '<a href="/docs/overview/testim-overview">overview</a>');
+  });
+
+  it('rewrites HTML doc: link preserving fragment', () => {
+    const result = rewriteDocLinks('<a href="doc:testim-overview#section">link</a>');
+    assert.equal(result, '<a href="/docs/overview/testim-overview#section">link</a>');
+  });
+
+  it('does not rewrite doc:https:// (malformed legacy link)', () => {
+    const md = '<a href="doc:https://help.testim.io/docs/exports-parameters">link</a>';
+    assert.equal(rewriteDocLinks(md), md);
+  });
+
+  it('rewrites HTML doc: link with pre-href attributes', () => {
+    const result = rewriteDocLinks('<a class="foo" href="doc:testim-overview">link</a>');
+    assert.equal(result, '<a class="foo" href="/docs/overview/testim-overview">link</a>');
+  });
+
+  // Stage 4: HTML <a href="path.htm">
+  it('rewrites HTML <a href="slug.htm"> to /docs/ path', () => {
+    const result = rewriteDocLinks('<a href="testim-automate.htm">link</a>');
+    assert.equal(result, '<a href="/docs/overview/testim-overview/testim-automate">link</a>');
+  });
+
+  it('rewrites HTML <a href="../path/slug.htm"> with relative path', () => {
+    const result = rewriteDocLinks('<a href="../editing-tests/conditions/index.htm">link</a>');
+    assert.equal(result, '<a href="/docs/editing-tests/conditions">link</a>');
+  });
+
+  it('rewrites HTML .htm link preserving fragment', () => {
+    const result = rewriteDocLinks('<a href="why-did-my-test-fail.htm#13-api-step-failed">link</a>');
+    assert.equal(result, '<a href="/docs/results/test-results/why-did-my-test-fail#13-api-step-failed">link</a>');
+  });
+
+  it('does not rewrite external https://*.htm link', () => {
+    const md = '<a href="https://example.com/page.htm">link</a>';
+    assert.equal(rewriteDocLinks(md), md);
+  });
+
+  it('does not rewrite already-converted /docs/ HTML link', () => {
+    const md = '<a href="/docs/overview/testim-overview">link</a>';
+    assert.equal(rewriteDocLinks(md), md);
+  });
+
+  it('rewrites multiple HTML anchors in same line', () => {
+    const md = '<a href="doc:testim-overview">a</a> and <a href="testim-automate.htm">b</a>';
+    const result = rewriteDocLinks(md);
+    assert.equal(result, '<a href="/docs/overview/testim-overview">a</a> and <a href="/docs/overview/testim-overview/testim-automate">b</a>');
+  });
+
+  // Edge cases identified in Codex review
+  it('does not rewrite protocol-relative //example.com/*.htm link', () => {
+    const md = '<a href="//example.com/page.htm">link</a>';
+    assert.equal(rewriteDocLinks(md), md);
+  });
+
+  it('does not rewrite ftp://*.htm link', () => {
+    const md = '<a href="ftp://example.com/file.htm">link</a>';
+    assert.equal(rewriteDocLinks(md), md);
+  });
+
+  it('rewrites HTML .htm link with ./ prefix', () => {
+    const result = rewriteDocLinks('<a href="./testim-automate.htm">link</a>');
+    assert.equal(result, '<a href="/docs/overview/testim-overview/testim-automate">link</a>');
+  });
+
+  it('rewrites Markdown .htm link with ./ prefix', () => {
+    const result = rewriteDocLinks('[link](./testim-automate.htm)');
+    assert.equal(result, '[link](/docs/overview/testim-overview/testim-automate)');
+  });
+
+  // SPA hash route (.htm/#/) — strip /#/ and resolve
+  it('rewrites HTML .htm/#/ SPA link', () => {
+    const result = rewriteDocLinks('<a href="../salesforce-testing/salesforce-testing-overview.htm/#/">link</a>');
+    assert.equal(result, '<a href="/docs/salesforce-testing/salesforce-testing-overview">link</a>');
+  });
+
+  it('rewrites Markdown .htm/#/ SPA link', () => {
+    const result = rewriteDocLinks('[link](../salesforce-testing/salesforce-testing-overview.htm/#/)');
+    assert.equal(result, '[link](/docs/salesforce-testing/salesforce-testing-overview)');
+  });
+
+  // Bare index.htm — cannot resolve without page context, leave unchanged
+  it('leaves bare index.htm unchanged (no page context)', () => {
+    const md = '[link](index.htm#section)';
+    assert.equal(rewriteDocLinks(md), md);
+  });
+
+  it('leaves bare HTML index.htm unchanged', () => {
+    const md = '<a href="index.htm#adding-a-grid">link</a>';
+    assert.equal(rewriteDocLinks(md), md);
+  });
+
+  it('resolves directory-prefixed index.htm normally', () => {
+    const result = rewriteDocLinks('[link](../editing-tests/conditions/index.htm)');
+    assert.equal(result, '[link](/docs/editing-tests/conditions)');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/__tests__/lib_project.test.mjs
+++ b/scripts/__tests__/lib_project.test.mjs
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { buildSlugIndex, buildDocsIndex, extractSourceContentPath, matchesSectionFilter, resolveSlug, splitFrontmatter, toKebab } from '../lib/project.mjs';
+import { buildSlugIndex, buildDocsIndex, buildBasenameToPathMap, extractSourceContentPath, filePathToSlug, matchesSectionFilter, resolveSlug, splitFrontmatter, toKebab } from '../lib/project.mjs';
 
 describe('buildSlugIndex', () => {
   it('returns an object with slug keys mapping to categoryFolder and filePath', () => {
@@ -266,6 +266,67 @@ describe('buildDocsIndex', () => {
     assert.ok(index['folder-a/page'], 'folder-a/page should exist');
     assert.ok(index['folder-b/page'], 'folder-b/page should exist');
     // Cleanup
+    fs.rmSync(dir, { recursive: true });
+  });
+});
+
+describe('filePathToSlug', () => {
+  it('converts absolute .md path to slug', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fps-'));
+    fs.mkdirSync(path.join(dir, 'overview'));
+    fs.writeFileSync(path.join(dir, 'overview', 'page.md'), '');
+    assert.equal(filePathToSlug(path.join(dir, 'overview', 'page.md'), dir), 'overview/page');
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  it('handles nested paths', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fps-'));
+    fs.mkdirSync(path.join(dir, 'a', 'b'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'a', 'b', 'c.md'), '');
+    assert.equal(filePathToSlug(path.join(dir, 'a', 'b', 'c.md'), dir), 'a/b/c');
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  it('strips only .md extension', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fps-'));
+    fs.writeFileSync(path.join(dir, 'page.txt'), '');
+    assert.equal(filePathToSlug(path.join(dir, 'page.txt'), dir), 'page.txt');
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  it('handles top-level file (no subfolder)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fps-'));
+    fs.writeFileSync(path.join(dir, 'index.md'), '');
+    assert.equal(filePathToSlug(path.join(dir, 'index.md'), dir), 'index');
+    fs.rmSync(dir, { recursive: true });
+  });
+});
+
+describe('buildBasenameToPathMap', () => {
+  it('maps unique basenames to full path-slug', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bn-'));
+    fs.mkdirSync(path.join(dir, 'folder-a'));
+    fs.writeFileSync(path.join(dir, 'folder-a', 'page.md'), '');
+    const map = buildBasenameToPathMap(dir);
+    assert.equal(map.get('page'), 'folder-a/page');
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  it('sets ambiguous basenames to null', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bn-'));
+    fs.mkdirSync(path.join(dir, 'folder-a'));
+    fs.mkdirSync(path.join(dir, 'folder-b'));
+    fs.writeFileSync(path.join(dir, 'folder-a', 'page.md'), '');
+    fs.writeFileSync(path.join(dir, 'folder-b', 'page.md'), '');
+    const map = buildBasenameToPathMap(dir);
+    assert.equal(map.get('page'), null);
+    fs.rmSync(dir, { recursive: true });
+  });
+
+  it('returns empty map for empty directory', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bn-'));
+    const map = buildBasenameToPathMap(dir);
+    assert.equal(map.size, 0);
     fs.rmSync(dir, { recursive: true });
   });
 });

--- a/scripts/check_source_parity.mjs
+++ b/scripts/check_source_parity.mjs
@@ -7,6 +7,7 @@ import {
   DOCS_DIR,
   ROOT_DIR,
   SIDEBAR_PATH,
+  filePathToSlug,
   findMdFiles,
   matchesSectionFilter,
   readDocFile,
@@ -133,7 +134,7 @@ export async function checkSourceParity({
     allowlist = loadAllowlist();
   } catch (error) {
     console.error(`❌ ${error.message}`);
-    process.exit(1);
+    return 1;
   }
 
   // Resolve --slug to path-based slug (supports both basename and path-based input)
@@ -156,8 +157,8 @@ export async function checkSourceParity({
   let checkedCount = 0;
 
   for (const filePath of allFiles) {
-    const fileSlugForFilter = path.relative(DOCS_DIR, filePath).replace(/\.md$/, '');
-    if (resolvedSlug && fileSlugForFilter !== resolvedSlug) {
+    const fileSlug = filePathToSlug(filePath);
+    if (resolvedSlug && fileSlug !== resolvedSlug) {
       continue;
     }
     const doc = readDocFile(filePath);
@@ -166,7 +167,6 @@ export async function checkSourceParity({
     }
 
     checkedCount += 1;
-    const fileSlug = path.relative(DOCS_DIR, filePath).replace(/\.md$/, '');
     let issues = [
       ...localCheck({ body: doc.body, sidebarSlugs, slug: fileSlug }),
     ];
@@ -228,7 +228,7 @@ export async function checkSourceParity({
   // Sidebar coverage check: detect pages in SIDEBAR_URLS.md without local files
   // Skip in --slug mode (single-page check should not report unrelated global issues)
   if (!resolvedSlug) {
-    const existingSlugs = new Set(allFiles.map(f => path.relative(DOCS_DIR, f).replace(/\.md$/, '')));
+    const existingSlugs = new Set(allFiles.map(f => filePathToSlug(f)));
     const coverageIssues = checkSidebarCoverage({ sidebarSlugs, existingSlugs });
     if (coverageIssues.length > 0) {
       results.push({ file: 'SIDEBAR_URLS.md', sourceUrl: '', category: '', issues: coverageIssues });

--- a/scripts/fetch_translate_images.mjs
+++ b/scripts/fetch_translate_images.mjs
@@ -5,7 +5,7 @@ import { promisify } from 'util';
 import { createHash } from 'crypto';
 import matter from 'gray-matter';
 import { filterItemsBySection } from './lib/sidebar.mjs';
-import { ROOT_DIR, buildSlugIndex, toKebab, resolveSlug } from './lib/project.mjs';
+import { ROOT_DIR, buildSlugIndex, buildBasenameToPathMap, toKebab, resolveSlug } from './lib/project.mjs';
 import { extractSlug } from './lib/madcap_toc.mjs';
 import { generateDescription } from './lib/markdown-utils.mjs';
 import turndown from './lib/turndown.mjs';
@@ -131,7 +131,8 @@ async function downloadAsset(url, destDir) {
     const buf = Buffer.from(await res.arrayBuffer());
     await fs.promises.writeFile(destPath, buf);
   } catch (e) {
-    await execFileAsync('curl', ['-sL', '--compressed', '-A', 'Mozilla/5.0 (Automation)', '-o', destPath, url]);
+    console.warn(`fetch failed for ${url}: ${e.message} — falling back to curl`);
+    await execFileAsync('curl', ['-sL', '--fail', '--compressed', '-A', 'Mozilla/5.0 (Automation)', '-o', destPath, url]);
   }
   await sleep(20);
   return { name: targetName, path: destPath };
@@ -183,55 +184,55 @@ async function rewriteAndDownloadMedia(markdown, categoryFolder, slug, sourceUrl
 }
 
 /**
- * Lazy-cached basename → path-slug lookup built from the docs index.
- * Values are `null` for ambiguous basenames (those that appear in multiple folders).
- */
-let _basenameToPath = null;
-function getBasenameToPathMap() {
-  if (!_basenameToPath) {
-    const slugIndex = buildSlugIndex();
-    const map = new Map();
-    for (const slug of Object.keys(slugIndex)) {
-      const bn = slug.split('/').pop();
-      if (map.has(bn)) {
-        map.set(bn, null); // ambiguous — skip
-      } else {
-        map.set(bn, slug);
-      }
-    }
-    _basenameToPath = map; // cache only after success
-  }
-  return _basenameToPath;
-}
-
-/**
  * Resolve a basename slug to its path-based form. Already-path-based slugs pass through.
  * Returns the original basename unchanged if it is ambiguous or not found in the index.
  */
 function resolveToPathSlug(slug) {
   if (slug.includes('/')) return slug;
-  const map = getBasenameToPathMap();
-  if (!map.has(slug)) return slug; // not in index — leave as-is
+  const map = buildBasenameToPathMap();
+  if (!map.has(slug)) return slug;
   const resolved = map.get(slug);
-  return resolved ?? slug; // ambiguous (null) — fall back to original
+  return resolved ?? slug;
+}
+
+/**
+ * Normalize a relative .htm path to a path-based slug via extractSlug.
+ * Strips leading `../` and `./` prefixes, prepends `/content/` for extractSlug,
+ * then resolves the basename to a full path-based slug.
+ * Returns null if the path cannot be resolved.
+ */
+function resolveHtmPath(rawPath) {
+  const normalized = rawPath.replace(/^(?:\.\.\/)+|^(?:\.\/)+/, '');
+  // Bare index.htm cannot be resolved without page context — leave unchanged
+  if (normalized === 'index.htm') return null;
+  const contentPath = normalized.startsWith('/content/')
+    ? normalized
+    : '/content/' + normalized;
+  const slug = extractSlug(contentPath);
+  if (!slug) return null;
+  return resolveToPathSlug(slug);
 }
 
 export function rewriteDocLinks(markdown) {
-  // Legacy readme.io doc: links — resolve basename to path-based slug
+  // Stage 1: Markdown doc: links — legacy readme.io format
   let result = markdown.replace(/\]\(doc:([a-z0-9_-]+)(#[^)]+)?\)/g, (_match, slug, frag = '') => {
-    return `](/docs/${resolveToPathSlug(slug)}${frag || ''})`;
+    return `](/docs/${resolveToPathSlug(slug)}${frag})`;
   });
-  // MadCap Flare relative .htm links (e.g. ../path/slug.htm, slug/index.htm)
-  result = result.replace(/\]\(([^)#]*\.htm)(#[^)]*)?\)/g, (_match, rawPath, fragment) => {
-    // extractSlug expects /content/... paths; prepend /content for relative paths
-    const normalized = rawPath.replace(/^(?:\.\.\/)+/, '');
-    const p = normalized.startsWith('/content/')
-      ? normalized
-      : '/content/' + normalized;
-    let slug = extractSlug(p);
-    if (!slug) return _match;
-    // Resolve basename-only results to path-based slugs
-    return `](/docs/${resolveToPathSlug(slug)}${fragment || ''})`;
+  // Stage 2: Markdown .htm links — MadCap Flare relative paths (skip schemes/protocol-relative, handle .htm/#/)
+  result = result.replace(/\]\((?![a-z][a-z0-9+.-]*:|\/\/)([^)#]*\.htm)(?:\/#\/)?(#[^)]*)?\)/g, (_match, rawPath, fragment) => {
+    const resolved = resolveHtmPath(rawPath);
+    if (!resolved) return _match;
+    return `](/docs/${resolved}${fragment || ''})`;
+  });
+  // Stage 3: HTML <a href="doc:slug"> — narrow match excludes doc:https://
+  result = result.replace(/<a(\s[^>]*)href="doc:([a-z0-9_-]+)(#[^"]*)?"([^>]*>)/gi, (_match, pre, slug, frag = '', post) => {
+    return `<a${pre}href="/docs/${resolveToPathSlug(slug)}${frag}"${post}`;
+  });
+  // Stage 4: HTML <a href="[../]path/slug.htm"> — relative only, skip URLs with schemes or protocol-relative (also handles .htm/#/)
+  result = result.replace(/<a(\s[^>]*)href="(?![a-z][a-z0-9+.-]*:|\/\/)([^"#]*\.htm)(?:\/#\/)?(#[^"]*)?"([^>]*>)/gi, (_match, pre, rawPath, fragment = '', post) => {
+    const resolved = resolveHtmPath(rawPath);
+    if (!resolved) return _match;
+    return `<a${pre}href="/docs/${resolved}${fragment}"${post}`;
   });
   return result;
 }

--- a/scripts/lib/project.mjs
+++ b/scripts/lib/project.mjs
@@ -60,8 +60,13 @@ export function matchesSectionFilter(relativePath, data, sectionFilter) {
     _cachedFilter = sectionFilter;
     try {
       _cachedSlugSet = getSectionSlugSet(sectionFilter);
-    } catch {
+    } catch (e) {
       _cachedSlugSet = null;
+      if (e.message?.startsWith('Unknown section')) {
+        console.warn(`matchesSectionFilter: ${e.message} — falling back to heuristic match`);
+      } else {
+        console.warn(`matchesSectionFilter: unexpected error: ${e.message}`);
+      }
     }
   }
 
@@ -88,6 +93,35 @@ export function matchesSectionFilter(relativePath, data, sectionFilter) {
   return candidates.some((candidate) => candidate.includes(target));
 }
 
+/**
+ * Convert an absolute .md file path to its path-based slug.
+ * e.g. "/…/src/content/docs/overview/testim-overview.md" → "overview/testim-overview"
+ */
+export function filePathToSlug(filePath, docsDir = DOCS_DIR) {
+  return path.relative(docsDir, filePath).replace(/\.md$/, '');
+}
+
+/**
+ * Lazy-cached basename → path-slug lookup built from the docs index.
+ * Values are `null` for ambiguous basenames (those appearing in multiple folders).
+ */
+let _basenameCache = { dir: null, map: null };
+export function buildBasenameToPathMap(docsDir = DOCS_DIR) {
+  if (_basenameCache.map && _basenameCache.dir === docsDir) return _basenameCache.map;
+  const slugIndex = buildSlugIndex(docsDir);
+  const map = new Map();
+  for (const slug of Object.keys(slugIndex)) {
+    const bn = slug.split('/').pop();
+    if (map.has(bn)) {
+      map.set(bn, null); // ambiguous — skip
+    } else {
+      map.set(bn, slug);
+    }
+  }
+  _basenameCache = { dir: docsDir, map };
+  return map;
+}
+
 export function buildSlugIndex(docsDir = DOCS_DIR) {
   /** @type {Record<string, {categoryFolder:string, filePath:string}>} */
   const index = {};
@@ -96,7 +130,7 @@ export function buildSlugIndex(docsDir = DOCS_DIR) {
       const full = path.join(dir, ent.name);
       if (ent.isDirectory()) walk(full);
       else if (ent.isFile() && ent.name.endsWith('.md')) {
-        const slug = path.relative(docsDir, full).replace(/\.md$/, '');
+        const slug = filePathToSlug(full, docsDir);
         const categoryFolder = path.basename(path.dirname(full));
         index[slug] = { categoryFolder, filePath: full };
       }
@@ -180,7 +214,7 @@ export function buildDocsIndex(docsDir = DOCS_DIR) {
       const full = path.join(dir, ent.name);
       if (ent.isDirectory()) { walk(full); continue; }
       if (!ent.isFile() || !ent.name.endsWith('.md')) continue;
-      const slug = path.relative(docsDir, full).replace(/\.md$/, '');
+      const slug = filePathToSlug(full, docsDir);
       const localFolder = path.basename(path.dirname(full));
       const raw = fs.readFileSync(full, 'utf8');
       const { data } = matter(raw);

--- a/scripts/lib/redirects.mjs
+++ b/scripts/lib/redirects.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { filePathToSlug } from './project.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_DOCS_DIR = path.resolve(__dirname, '..', '..', 'src', 'content', 'docs');
@@ -31,7 +32,7 @@ export function buildRedirectMap(docsDir = DEFAULT_DOCS_DIR) {
       }
       if (!ent.isFile() || !ent.name.endsWith('.md')) continue;
       const basename = ent.name.replace(/\.md$/, '');
-      const pathSlug = path.relative(docsDir, full).replace(/\.md$/, '');
+      const pathSlug = filePathToSlug(full, docsDir);
       // Skip top-level files (no folder prefix — no redirect needed)
       if (!pathSlug.includes('/')) continue;
       const existing = byBasename.get(basename) ?? [];

--- a/scripts/lint-docs.mjs
+++ b/scripts/lint-docs.mjs
@@ -10,6 +10,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import matter from 'gray-matter';
 import { getSectionSlugSet } from './lib/sidebar.mjs';
+import { filePathToSlug } from './lib/project.mjs';
 
 
 const ROOT = path.resolve(fileURLToPath(import.meta.url), '../..');
@@ -108,57 +109,34 @@ export function lintContent(content, filePath, { allSlugs, headingsBySlug } = {}
     const bodyStripped = stripCode(body);
     const strippedLines = bodyStripped.split('\n');
 
+    const validateLink = (slugPath, fragment, lineIdx) => {
+      const displayPath = `/docs/${slugPath}`;
+      if (!allSlugs.has(slugPath)) {
+        err('link-target-missing', `Internal link target does not exist: ${displayPath}`, lineIdx);
+      } else if (fragment && headingsBySlug) {
+        const fragId = fragment.slice(1);
+        const headings = headingsBySlug.get(slugPath);
+        if (headings && !headings.has(fragId)) {
+          warn('link-fragment-missing', `Fragment "${fragment}" not found in ${displayPath}`, lineIdx);
+        }
+      }
+    };
+
     strippedLines.forEach((line, i) => {
+      const lineIdx = toAbsoluteLine(i + 1, bodyStart);
+
       // Check A: Markdown links
       const mdLinkRe = /\]\(\/docs\/([a-z0-9_-]+(?:\/[a-z0-9_-]+)*)(#[^)]+)?\)/g;
       let mdMatch;
       while ((mdMatch = mdLinkRe.exec(line)) !== null) {
-        const slugPath = mdMatch[1];
-        const fragment = mdMatch[2];
-        const displayPath = `/docs/${slugPath}`;
-        if (!allSlugs.has(slugPath)) {
-          err(
-            'link-target-missing',
-            `Internal link target does not exist: ${displayPath}`,
-            toAbsoluteLine(i + 1, bodyStart)
-          );
-        } else if (fragment && headingsBySlug) {
-          const fragId = fragment.slice(1);
-          const headings = headingsBySlug.get(slugPath);
-          if (headings && !headings.has(fragId)) {
-            warn(
-              'link-fragment-missing',
-              `Fragment "${fragment}" not found in ${displayPath}`,
-              toAbsoluteLine(i + 1, bodyStart)
-            );
-          }
-        }
+        validateLink(mdMatch[1], mdMatch[2], lineIdx);
       }
 
       // Check B: HTML <a href="/docs/..."> links
       const htmlLinkRe = /<a\b[^>]*href=["']\/docs\/([a-z0-9_-]+(?:\/[a-z0-9_-]+)*)(#[^\s"']*)?\s*["'][^>]*>/gi;
       let htmlMatch;
       while ((htmlMatch = htmlLinkRe.exec(line)) !== null) {
-        const slugPath = htmlMatch[1];
-        const fragment = htmlMatch[2];
-        const displayPath = `/docs/${slugPath}`;
-        if (!allSlugs.has(slugPath)) {
-          err(
-            'link-target-missing',
-            `Internal link target does not exist: ${displayPath}`,
-            toAbsoluteLine(i + 1, bodyStart)
-          );
-        } else if (fragment && headingsBySlug) {
-          const fragId = fragment.slice(1);
-          const headings = headingsBySlug.get(slugPath);
-          if (headings && !headings.has(fragId)) {
-            warn(
-              'link-fragment-missing',
-              `Fragment "${fragment}" not found in ${displayPath}`,
-              toAbsoluteLine(i + 1, bodyStart)
-            );
-          }
-        }
+        validateLink(htmlMatch[1], htmlMatch[2], lineIdx);
       }
     });
   }
@@ -258,7 +236,7 @@ async function main() {
   if (section) {
     const slugSet = getSectionSlugSet(section);
     files = files.filter((file) => {
-      const slug = path.relative(DOCS_ROOT, file).replace(/\.md$/, '');
+      const slug = filePathToSlug(file, DOCS_ROOT);
       return slugSet.has(slug);
     });
   }
@@ -273,7 +251,7 @@ async function main() {
   const allSlugs = new Set();
   const headingsBySlug = new Map();
   for (const f of allFiles) {
-    const slug = path.relative(DOCS_ROOT, f).replace(/\.md$/, '');
+    const slug = filePathToSlug(f, DOCS_ROOT);
     allSlugs.add(slug);
     const raw = fs.readFileSync(f, 'utf8');
     const { body: rawBody } = parseFrontmatter(raw);

--- a/scripts/migrate-links.mjs
+++ b/scripts/migrate-links.mjs
@@ -8,28 +8,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { buildSlugIndex } from './lib/project.mjs';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const DOCS_DIR = path.resolve(__dirname, '..', 'src', 'content', 'docs');
-
-// ---------------------------------------------------------------------------
-// Build basename → pathSlug lookup
-// ---------------------------------------------------------------------------
-function buildBasenameToPathMap(docsDir = DOCS_DIR) {
-  const slugIndex = buildSlugIndex(docsDir);
-  /** @type {Map<string, string | null>} */
-  const map = new Map();
-  for (const slug of Object.keys(slugIndex)) {
-    const bn = slug.split('/').pop();
-    if (map.has(bn)) {
-      map.set(bn, null); // ambiguous
-    } else {
-      map.set(bn, slug);
-    }
-  }
-  return map;
-}
+import { buildBasenameToPathMap, DOCS_DIR } from './lib/project.mjs';
 
 // ---------------------------------------------------------------------------
 // Strip code blocks, inline code & HTML comments to avoid replacing links inside them

--- a/scripts/normalize_docs.mjs
+++ b/scripts/normalize_docs.mjs
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import matter from 'gray-matter';
 import { getSectionSlugSet } from './lib/sidebar.mjs';
-import { ROOT_DIR, DOCS_DIR, findMdFiles } from './lib/project.mjs';
+import { ROOT_DIR, DOCS_DIR, findMdFiles, filePathToSlug } from './lib/project.mjs';
 import { generateDescription } from './lib/markdown-utils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -53,7 +53,7 @@ function orderFrontmatter(data) {
 }
 
 function normalizeFile(filePath, urlMappings) {
-  const slug = path.relative(DOCS_ROOT, filePath).replace(/\.md$/, '');
+  const slug = filePathToSlug(filePath, DOCS_ROOT);
   const raw = fs.readFileSync(filePath, 'utf8');
   const parsed = matter(raw);
   const data = { ...(parsed.data ?? {}) };
@@ -85,14 +85,19 @@ async function main() {
   const args = process.argv.slice(2);
   const section = args.find((arg) => arg.startsWith('--section='))?.split('=').slice(1).join('=');
   const slugSet = section ? getSectionSlugSet(section) : null;
-  const files = findMdFiles(DOCS_ROOT).filter((filePath) => !slugSet || slugSet.has(path.relative(DOCS_ROOT, filePath).replace(/\.md$/, '')));
+  const files = findMdFiles(DOCS_ROOT).filter((filePath) => !slugSet || slugSet.has(filePathToSlug(filePath, DOCS_ROOT)));
 
   // Load url_mapping.json once for all files (avoid re-reading per file)
   let urlMappings = {};
   try {
     const mappingPath = path.join(__dirname, 'url_mapping.json');
     ({ mappings: urlMappings } = JSON.parse(fs.readFileSync(mappingPath, 'utf8')));
-  } catch { /* mapping file unavailable — leave empty for lint to catch */ }
+  } catch (e) {
+    if (e.code !== 'ENOENT') {
+      console.error(`normalize_docs: failed to load url_mapping.json: ${e.message}`);
+      console.error('URL-based normalization will be skipped for all files.');
+    }
+  }
 
   let changed = 0;
   for (const filePath of files) {

--- a/scripts/snapshot_diff.mjs
+++ b/scripts/snapshot_diff.mjs
@@ -18,6 +18,7 @@ import path from 'node:path';
 import {
   DOCS_DIR,
   ROOT_DIR,
+  filePathToSlug,
   findMdFiles,
   matchesSectionFilter,
   readDocFile,
@@ -155,7 +156,7 @@ function buildSourceUrlIndex({ section }) {
     const doc = readDocFile(filePath);
     if (!doc.data.sourceUrl) continue;
     if (section && !matchesSectionFilter(doc.relativePath, doc.data, section)) continue;
-    const slug = path.relative(DOCS_DIR, filePath).replace(/\.md$/, '');
+    const slug = filePathToSlug(filePath);
     index[slug] = doc.data.sourceUrl;
   }
   return index;
@@ -182,7 +183,7 @@ function diffSidebar() {
       return { changed: true, addedPages: pages, removedPages: [] };
     } catch (e) {
       console.warn(`diffSidebar: failed to parse new sidebar JSON: ${e.message}`);
-      return { changed: true, addedPages: [], removedPages: [] };
+      return { changed: true, addedPages: [], removedPages: [], parseError: true };
     }
   }
 
@@ -201,7 +202,7 @@ function diffSidebar() {
     return { changed, addedPages, removedPages };
   } catch (e) {
     console.warn(`diffSidebar: failed to parse sidebar JSON for diff: ${e.message}`);
-    return { changed: true, addedPages: [], removedPages: [] };
+    return { changed: true, addedPages: [], removedPages: [], parseError: true };
   }
 }
 
@@ -223,6 +224,15 @@ function findHtmlFiles(dir, baseDir = dir) {
   return files;
 }
 
+function emptyErrorResult() {
+  return {
+    error: true,
+    summary: { totalSnapshots: 0, changed: 0, added: 0, removed: 0, unchanged: 0 },
+    changes: [],
+    sidebar: { changed: false, addedPages: [], removedPages: [] },
+  };
+}
+
 export async function main(argv) {
   const args = parseArgs(argv);
   const sourceUrls = buildSourceUrlIndex(args);
@@ -230,12 +240,12 @@ export async function main(argv) {
   const resolvedSlug = args.slug ? resolveSlug(args.slug) : null;
   if (args.slug && !resolvedSlug) {
     console.error(`❌ Unknown slug: "${args.slug}". No matching document found.`);
-    return { error: true };
+    return emptyErrorResult();
   }
 
   if (!fs.existsSync(CONTENT_DIR)) {
     console.log('No snapshots found. Run check:snapshots:fetch first.');
-    return;
+    return emptyErrorResult();
   }
 
   // Build slug→URL map from SIDEBAR_URLS.md once for O(1) fallback lookups
@@ -334,7 +344,11 @@ export async function main(argv) {
     console.log(`Snapshot diff: ${report.summary.changed} changed, ${report.summary.added} added, ${report.summary.removed} removed, ${report.summary.unchanged} unchanged`);
 
     if (sidebar.changed) {
-      console.log(`Sidebar: ${sidebar.addedPages.length} page(s) added, ${sidebar.removedPages.length} page(s) removed`);
+      if (sidebar.parseError) {
+        console.log('Sidebar: ⚠️ JSON parse error — could not compare sidebar (see warning above)');
+      } else {
+        console.log(`Sidebar: ${sidebar.addedPages.length} page(s) added, ${sidebar.removedPages.length} page(s) removed`);
+      }
     }
 
     if (changes.length > 0) {

--- a/scripts/snapshot_update.mjs
+++ b/scripts/snapshot_update.mjs
@@ -20,6 +20,7 @@ import path from 'node:path';
 import {
   DOCS_DIR,
   ROOT_DIR,
+  filePathToSlug,
   findMdFiles,
   matchesSectionFilter,
   readDocFile,
@@ -71,7 +72,7 @@ function collectTargets({ section, slug }) {
     const { data } = doc;
     if (!data.sourceUrl) continue;
 
-    const fileSlug = path.relative(DOCS_DIR, filePath).replace(/\.md$/, '');
+    const fileSlug = filePathToSlug(filePath);
     if (resolvedSlug && fileSlug !== resolvedSlug) continue;
     if (section && !matchesSectionFilter(doc.relativePath, data, section)) continue;
 
@@ -200,6 +201,7 @@ async function verifySidebar({ dryRun = false } = {}) {
     const totalPages = sections.reduce((sum, s) => sum + s.pages.length, 0);
     return { ok: true, sectionCount: sections.length, pageCount: totalPages };
   } catch (error) {
+    console.error('verifySidebar failed:', error);
     return { ok: false, reason: error.message };
   }
 }

--- a/scripts/sync_frontmatter_from_sidebar.mjs
+++ b/scripts/sync_frontmatter_from_sidebar.mjs
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { DOCS_DIR, SIDEBAR_PATH, findMdFiles } from './lib/project.mjs';
+import { DOCS_DIR, SIDEBAR_PATH, filePathToSlug, findMdFiles } from './lib/project.mjs';
 import { extractJapaneseLabel } from './lib/sidebar.mjs';
 import { extractSlug } from './lib/madcap_toc.mjs';
 
@@ -141,7 +141,7 @@ function main() {
   const changedExamples = [];
 
   for (const filePath of files) {
-    const slug = path.relative(docsRoot, filePath).replace(/\.md$/, '');
+    const slug = filePathToSlug(filePath);
     const entry = bySlug.get(slug);
     if (!entry) {
       unmatched.push(path.relative(docsRoot, filePath));


### PR DESCRIPTION
## Summary

4つの Issue を一括実装。検知ロジック (diff 比較・parity チェック) は変更なし。

- **#205**: `rewriteDocLinks()` に HTML `<a>` タグのリンク変換を追加 (Stage 3: `doc:`, Stage 4: `.htm`)
- **#204**: `filePathToSlug` + `buildBasenameToPathMap` を `project.mjs` に集約し、8ファイルの重複を排除
- **#206**: `lint-docs.mjs` の Check A/B リンク検証ロジックを `validateLink` クロージャに統合
- **#201**: 7件のエラーハンドリング改善 (bare catch 排除、exit code 整合性、curl `--fail` 追加)

## Changes

### #205: rewriteDocLinks HTML anchor 対応
- Stage 3: `<a href="doc:slug">` → `<a href="/docs/resolved">` (narrow regex — `doc:https://` 除外)
- Stage 4: `<a href="../path/slug.htm">` → `<a href="/docs/resolved">` (全 URI scheme + `//` 除外)
- `.htm/#/` SPA ルート対応 (5件)、bare `index.htm` ガード (19件)
- `resolveHtmPath()` 抽出で Stage 2/4 を DRY 化
- 31 テスト (既存 10 + 新規 21)

### #204: スクリプトユーティリティ共通化
- `filePathToSlug(filePath, docsDir?)` — `path.relative().replace()` パターン 11箇所を統合
- `buildBasenameToPathMap(docsDir?)` — 2つの重複実装を lazy cache 付き共通版に統合
- `migrate-links.mjs` / `fetch_translate_images.mjs` のローカル実装を削除
- 7 テスト新規追加

### #206: lint-docs リンク検証共通化
- Check A (Markdown) と Check B (HTML) の 18行重複を `validateLink` クロージャに統合
- 既存 60 テストで動作保証

### #201: エラーハンドリング hardening (A〜G)
| ID | 修正内容 |
|---|---|
| A | `matchesSectionFilter` — Unknown section を warn + heuristic fallback |
| B | `normalize_docs` — ENOENT ガード + 非 ENOENT を `console.error` |
| C | `downloadAsset` — fetch 失敗を warn + curl `--fail` フラグ追加 |
| D | `diffSidebar` — `parseError` フラグ + コンソール出力反映 |
| E | `snapshot_diff` — `undefined` → 構造化エラーオブジェクト (`emptyErrorResult()`) |
| F | `verifySidebar` — `console.error(error)` でスタックトレース保持 |
| G | `check_source_parity` — `process.exit(1)` → `return 1` |

## Test plan

- [x] `npm run test` — 556 pass / 0 fail
- [x] `npm run build` — 290 pages, complete
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] Codex review x4 — final: "No issues found"
- [x] pr-review-toolkit x3 (code/errors/tests/simplify) — final: all clean

Closes #201, closes #204, closes #205, closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)