### PR TITLE
docs: ドキュメント整合性の修正 (#213)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,8 +28,8 @@ Japanese localization of Testim Help Documentation (docs.tricentis.com/testim). 
 **Single-page commands:**
 
 ```bash
-npm run check:parity -- --slug=testim-overview
-npm run check:snapshots:diff -- --slug=testim-overview
+npm run check:parity -- --slug=overview/testim-overview
+npm run check:snapshots:diff -- --slug=overview/testim-overview
 npm run lint:docs -- --path=src/content/docs/overview/testim-overview.md
 ```
 
@@ -41,13 +41,13 @@ Full reference: `scripts/README.md`
 - **Routing**: Single dynamic route `src/pages/docs/[...slug].astro` — slug is the path relative to `src/content/docs/` (e.g., `overview/testim-overview.md` → `/docs/overview/testim-overview`). Legacy basename URLs are redirected via `buildRedirectMap()` in `astro.config.mjs`.
 - **Navigation**: Built from `src/lib/docs.ts` `buildNavigation()` — groups by `category` frontmatter, ordered by `docs/SIDEBAR_URLS.md`.
 - **Search**: Client-side MiniSearch in `src/components/SearchModal.tsx` (React), with data from `/api/search.json`.
-- **Layout**: `src/layouts/DocsLayout.astro` wraps all doc pages with sidebar (`NavSidebar.astro`) and TOC (`TableOfContents.astro`).
+- **Layout**: `src/layouts/DocsLayout.astro` wraps all doc pages with sidebar (`src/components/navigation/NavSidebar.astro`) and TOC (`TableOfContents.astro`).
 - **Auth mode**: `BASIC_AUTH_ENABLED` env var toggles between SSR+auth (review) and static (production). See `src/middleware.ts`.
-- **Doc pipeline**: `scripts/pipeline.mjs` orchestrates fetching English sources, generating placeholders, and preparing LLM translation tasks. Checkpoint-based resume via `scripts/.checkpoint`.
+- **Doc pipeline**: `scripts/pipeline.mjs` orchestrates the full translation workflow: fetch EN sources → generate placeholders (`generate_untranslated_placeholders.mjs`) → prepare LLM tasks (`prepare_llm_tasks.mjs`) → apply LLM translations (`apply_llm_translations.mjs`). Checkpoint-based resume via `scripts/.checkpoint`.
 - **Snapshot pipeline**:
-  - **コンテンツ**: 各ページの HTML から `#mc-main-content` を抽出し `snapshots/en/content/{folder}/{basename}.html` に保存
-  - **サイドバー**: MadCap Flare TOC データ (`scripts/lib/madcap_toc.mjs`) を解析し `snapshots/en/sidebar.json` に保存
-  - **パリティ比較**: HTML スナップショットを `turndown` で Markdown 変換後、JA 翻訳と構造比較
+  - **Content**: Extracts `#mc-main-content` from each EN page HTML, saves to `snapshots/en/content/{folder}/{basename}.html`.
+  - **Sidebar**: Parses MadCap Flare TOC data (`scripts/lib/madcap_toc.mjs`), saves to `snapshots/en/sidebar.json`.
+  - **Parity comparison**: Converts HTML snapshots to Markdown via `turndown`, then compares structure with JA translations.
 
 ## Authority Sources
 

--- a/docs/TRANSLATION_GUIDE.md
+++ b/docs/TRANSLATION_GUIDE.md
@@ -591,7 +591,7 @@ find src/content/docs -name "*.md" | sort
 
 - [ ] ファイル名が元のURL slugと一致している
 - [ ] ファイルが適切なカテゴリフォルダに配置されている
-- [ ] frontmatterに必要な項目（title, description, category, order, updated, sourceUrl, keywords）がすべて記載されている
+- [ ] frontmatter の必須項目（title, description, category, updated, sourceUrl）がすべて記載されている（order, keywords はオプション）
 - [ ] description が日本語の要約になっており、`原文: URL` のようなプレースホルダになっていない
 - [ ] カテゴリ名が日本語化されており、他のページと統一されている
 - [ ] orderが `docs/SIDEBAR_URLS.md` と既存の数値帯に整合している
@@ -902,13 +902,13 @@ touch src/content/docs/[new-category-folder]/[page-slug].md
 
 1. 公式サイトで更新内容を確認
 2. 該当するmdファイルを編集
-3. `updated` フィールドを現在の日付に更新
+3. `updated` フィールドを英語原文の更新日に合わせる（JA 編集日ではない）
 4. 新しいメディアファイルがあれば追加ダウンロード
 5. 削除されたメディアファイルがあれば削除
 
 ```bash
-# 更新日の変更例
-updated: '2025-11-15'  # 更新日を今日の日付に
+# 更新日の変更例（英語原文の更新日に追従）
+updated: '2026-04-01'
 ```
 
 ### 10.3 カテゴリ順序の調整

--- a/docs/WRITING_GUIDE.md
+++ b/docs/WRITING_GUIDE.md
@@ -43,17 +43,26 @@
 ---
 title: 'ページタイトル（日本語）'
 description: 'ページの説明（100文字以内、プレースホルダ禁止）'
+category: '概要'
+order: 1001
+updated: '2026-01-15'
 sourceUrl: 'https://docs.tricentis.com/testim/content/{category}/{slug}.htm'
-updated: '2025-11-02'
+keywords:
+  - キーワード1
+  - キーワード2
 ---
 ```
 
-| フィールド | 必須 | 規則 |
-| --- | --- | --- |
-| `title` | ✅ | 日本語タイトル |
-| `description` | ✅ | 具体的な説明文。「説明文」「TODO」「原文: ...」などのプレースホルダ禁止 |
-| `sourceUrl` | ✅ | 英語原文 URL（`https://docs.tricentis.com/testim/content/.../{slug}.htm`）必須 |
-| `updated` | ✅ | 更新日（`YYYY-MM-DD` 形式） |
+| フィールド | 必須 | デフォルト | 規則 |
+| --- | --- | --- | --- |
+| `title` | ✅ | — | 日本語タイトル |
+| `description` | ✅ | — | 具体的な説明文。「説明文」「TODO」「原文: ...」などのプレースホルダ禁止 |
+| `category` | ✅ | — | `docs/SIDEBAR_URLS.md` のセクション日本語ラベルに一致させる |
+| `updated` | ✅ | — | 更新日（`YYYY-MM-DD` 形式） |
+| `sourceUrl` | ✅ | — | 英語原文 URL（`https://docs.tricentis.com/testim/content/.../{slug}.htm`）必須 |
+| `order` | — | `0` | サイドバー内の表示順序（`docs/SIDEBAR_URLS.md` 基準） |
+| `keywords` | — | `[]` | 検索用キーワード（日本語、最大10件目安） |
+| `hero` | — | — | ヒーローセクション（トップページ用、通常の記事では不要） |
 
 追加ルール:
 
@@ -62,6 +71,7 @@ updated: '2025-11-02'
 - `description` は本文から読める内容を 1-2 文で要約する
 - frontmatter の欠落は build 前に修正する
 - `sourceUrl` は追跡用メタデータではなく、本文整備の正本として扱う
+- スキーマ定義: `src/content.config.ts`（Zod バリデーション）
 
 ---
 
@@ -697,7 +707,7 @@ src/content/docs/
 
 - `remark-gfm`: GitHub Flavored Markdown
 - `remark-directive`: カスタムディレクティブ
-- `remark-callouts`: 情報パネル自動変換（カスタム）
+- `@microflash/remark-callout-directives`: 情報パネル自動変換（`:::note` 等）
 - `remark-code-meta`: コードブロックメタ情報（カスタム）
 
 ### Rehype プラグイン
@@ -931,7 +941,7 @@ MDX が必要なのは：
 
 - 📖 [**執筆機能リファレンス**](./WRITING_FEATURES.md) - 全機能の詳細な実装例
 - 🌐 [**翻訳ガイド**](./TRANSLATION_GUIDE.md) - 公式ドキュメントからの翻訳手順
-- 📘 [**README**](./README.md) - プロジェクト概要とセットアップ
+- 📘 [**README**](../README.md) - プロジェクト概要とセットアップ
 
 ### 外部リソース
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -397,46 +397,22 @@ npm test    # node --test scripts/__tests__/*.mjs
 | `docs:prepare-llm` | prepare_llm_tasks.mjs | LLM タスク準備 |
 | `docs:apply-llm` | apply_llm_translations.mjs | LLM 翻訳適用 |
 | `docs:report-categories` | report_frontmatter_categories.mjs | カテゴリ集計 |
+| `format` | prettier --write | コードフォーマット |
+| `format:check` | prettier --check | フォーマットチェック（CI 用） |
 
 ---
 
 ## 運用フロー
 
-### 日常運用（ページ単位）
+運用フローの詳細は **[`docs/OPS_DESIGN.md`](../docs/OPS_DESIGN.md)** を参照してください。以下はクイックリファレンスです。
 
 ```bash
+# ページ単位チェック
 npm run check:parity -- --slug=overview/testim-overview
-npm run check:snapshots:diff -- --slug=overview/testim-overview
 npm run lint:docs -- --path=src/content/docs/overview/testim-overview.md
-```
 
-### 定期運用（全文）
-
-```bash
-npm run lint:docs          # リンク実在 + frontmatter + 構文
-npm run check:parity       # 構造パリティ全件
-npm run test && npm run build
-```
-
-### 初回セクション整備
-
-```bash
-npm run docs:sync-sidebar
-npm run docs:pipeline:full -- --section="Overview"
-npm run lint:docs -- --section="Overview"
-npm run check:parity
-npm test && npm run build
-```
-
-### 継続メンテナンス（3日ごと）
-
-```bash
-npm run docs:sync-sidebar          # 1. URL 最新化
-npm run check:snapshots            # 2. スナップショット取得→差分検出
-npm run check:parity               # 3. 翻訳品質チェック
-npm run check:summary              # 4. summary / audit manifest
-npm run docs:pipeline              # 5. 変更分の翻訳パイプライン
-npm run lint:docs && npm test && npm run build  # 6. QA
+# 全文チェック
+npm run lint:docs && npm run check:parity && npm test && npm run build
 ```
 
 ### CI 連携


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: `--slug` 例のパスベース形式修正、言語統一、NavSidebar パス明記、LLM パイプライン説明追記
- **WRITING_GUIDE.md**: frontmatter テーブルを `content.config.ts` と完全整合、プラグイン名修正、壊れたリンク修正
- **TRANSLATION_GUIDE.md**: `updated` フィールド説明を WRITING_GUIDE と統一、checklist のオプション項目修正、年号更新
- **scripts/README.md**: `format`/`format:check` 追加、運用フローを OPS_DESIGN.md へ集約

### 変更詳細

| ID | 対象 | 修正内容 |
|----|------|----------|
| M13 | CLAUDE.md | `--slug=testim-overview` → `--slug=overview/testim-overview` (3箇所) |
| M14 | WRITING_GUIDE.md | frontmatter テーブルに category, order, keywords, hero を追加。必須/オプション/デフォルト明記 |
| M15 | scripts/README.md | `format`, `format:check` を npm スクリプト対応表に追加 |
| L2 | WRITING_GUIDE.md | `remark-callouts` → `@microflash/remark-callout-directives` |
| L3 | CLAUDE.md | Snapshot pipeline セクションを英語に統一 |
| L5 | scripts/README.md | 運用フロー重複を削減、OPS_DESIGN.md へリンク |
| L6 | TRANSLATION_GUIDE.md | 例示年号 2025 → 2026 |
| — | WRITING_GUIDE.md | 壊れたリンク `./README.md` → `../README.md` |
| — | TRANSLATION_GUIDE.md | `updated` 説明を「英語原文の更新日に追従」に修正 |
| — | TRANSLATION_GUIDE.md | checklist: order/keywords を必須→オプションに修正 |
| — | CLAUDE.md | NavSidebar の正確なパス、LLM パイプライン説明追記 |

## Test plan

- [x] `npm run lint:docs` — 0 errors, 0 warnings
- [x] `npm test` — 545 テスト合格
- [x] `npm run build` — 290 ページビルド成功
- [x] Codex CLI レビュー 2 ラウンド: Round 1 で 3 件指摘→修正→Round 2 で No issues found

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)