### PR TITLE
docs: EN原文変更への追従（4ページ）+ パリティ不一致解消

### DIFF
--- a/snapshots/en/content/advanced-editing/validations/pixel-validation-and-pixel-wait-for.html
+++ b/snapshots/en/content/advanced-editing/validations/pixel-validation-and-pixel-wait-for.html
@@ -1,20 +1,10 @@
 
                                         <h1>Visual Validation (element, viewport, full-page)</h1>
-                                        <p>The visual validation and wait-for steps allow you to compare visual differences between your baseline and your current test run with precision. This functionality is provided by <a href="../../integrations/visual-validation/index.htm">Applitools</a> and <a href="../../integrations/visual-validation/lambdatest_integration.htm">LambdaTest</a>. </p>
-                                        <p>Before you begin, you first need to integrate either the <a href="../../integrations/visual-validation/index.htm">Applitools Eyes</a> or <a href="../../integrations/visual-validation/lambdatest_integration.htm">LambdaTest Smart UI</a> app with Testim. For more information, see our <a href="../../integrations/visual-validation/visual_validation_index.htm">visual validation integrations guide</a>.<br />For more information, see the following resources:</p>
+                                        <p>The visual validation and wait-for steps allow you to compare visual differences between your baseline and your current test run with precision. This functionality is provided by <a href="../../integrations/visual-validation/index.htm">Applitools</a> and <a href="../../integrations/visual-validation/lambdatest_integration.htm">LambdaTest</a> apps. </p>
+                                        <p>Before you begin, you need to integrate either the <a href="../../integrations/visual-validation/index.htm">Applitools Eyes</a> or <a href="../../integrations/visual-validation/lambdatest_integration.htm">LambdaTest Smart UI</a> app with Testim. For more information, see our <a href="../../integrations/visual-validation/visual_validation_index.htm">visual validation integrations guide</a>.<br />For more information, see the following resources:</p>
                                         <ul>
-                                            <li>
-                                                <p><a href="https://applitools.com/docs/topics/test-manager/viewers/tm-baseline-viewer.html">https://applitools.com/docs/topics/test-manager/viewers/tm-baseline-viewer.html</a>
-                                                </p>
-                                            </li>
-                                            <li>
-                                                <p><a href="https://applitools.com/docs/topics/test-manager/viewers/tm-compare-baselines-viewer.html">https://applitools.com/docs/topics/test-manager/viewers/tm-compare-baselines-viewer.html</a>
-                                                </p>
-                                            </li>
-                                            <li>
-                                                <p><a href="https://applitools.com/docs/topics/test-manager/viewers/tm-compare-baselines-editor.html">https://applitools.com/docs/topics/test-manager/viewers/tm-compare-baselines-editor.html</a>
-                                                </p>
-                                            </li>
+                                            <li><a href="https://applitools.com/docs/" target="_blank">Applitools documentation (opens in new tab)</a>.</li>
+                                            <li><a href="https://www.testmuai.com/support/docs/" target="_blank">LambdaTest documentation (opens in new tab)</a>.</li>
                                         </ul>
                                         <div class="note">
                                             <p>The RCA and Ultrafast Test Cloud (i.e. adding extra environments) features will be rejected by Applitools without appropriate licensing. Contact your Applitools representative for more information.</p>

--- a/snapshots/en/content/integrations/visual-validation/lambdatest_integration.html
+++ b/snapshots/en/content/integrations/visual-validation/lambdatest_integration.html
@@ -1,17 +1,17 @@
 
                                         <h1>LambdaTest SmartUI integration</h1>
-                                        <p>LambdaTest SmartUI is a <a href="../../advanced-editing/validations/pixel-validation-and-pixel-wait-for.htm">visual validation</a> tool that tests your web app’s UI across devices and highlights visual differences or layout issues. Integrate LambdaTest with <span class="mc-variable General.ProductName variable">Testim</span> to automate catching visual regressions.</p>
+                                        <p>LambdaTest SmartUI is a <a href="../../advanced-editing/validations/pixel-validation-and-pixel-wait-for.htm">visual validation</a> tool that tests your web app’s UI across devices and highlights visual differences or layout issues, such as overlapping text, broken images, or incorrect spacing. Integrate LambdaTest with <span class="mc-variable General.ProductName variable">Testim</span> to automate catching visual regressions.</p>
                                         <h2>Before you start </h2>
                                         <p>Before integrating LambdaTest with <span class="mc-variable General.ProductName variable">Testim</span>, make sure you have the following: </p>
                                         <ul>
                                             <li>
-                                                <p>You have admin rights both in LambdaTest and <span class="mc-variable General.ProductName variable">Testim</span>. </p>
+                                                <p>Admin rights both in LambdaTest and <span class="mc-variable General.ProductName variable">Testim</span>. </p>
                                             </li>
                                             <li>
-                                                <p>Your project is on our <a href="https://www.testim.io/pricing/">professional plan</a>. </p>
+                                                <p>A project on our <a href="https://www.testim.io/pricing/">professional plan</a>. </p>
                                             </li>
                                         </ul>
-                                        <p>To integrate LambdaTest with <span class="mc-variable General.ProductName variable">Testim</span>, you'll need the following details from LambdaTest:</p>
+                                        <p>You'll also need  need the following details from LambdaTest:</p>
                                         <ul>
                                             <li>
                                                 <p>Username.</p>
@@ -25,13 +25,14 @@
                                         </ul>
                                         <p>To learn how to get these details, check out <a href="https://www.testmuai.com/support/docs/hyperexecute-how-to-get-my-username-and-access-key/" target="_blank">LambdaTest's guide (opens in new tab)</a>.</p>
                                         <h2>Integrate LambdaTest SmartUI</h2>
-                                        <p>You can start with LambdaTest as your first visual testing provider or switch to LambdaTest from another provider. In both cases, follow these steps:</p>
+                                        <p>You can start with LambdaTest as your first visual testing provider or switch to LambdaTest from another provider. </p>
+                                        <p>In either case, follow these steps:</p>
                                         <ol>
                                             <li value="1">
                                                 <p>Go to <strong>Settings &gt; Integration &gt; Visual testing</strong>. </p>
                                             </li>
                                             <li value="2">
-                                                <p>Select <strong>login</strong> in the LambdaTest pane.</p>
+                                                <p>Select <strong>login</strong> in the <strong>LambdaTest</strong> pane.</p>
                                             </li>
                                             <li value="3">
                                                 <p>Enter your <strong>Username</strong>, <strong>Access key</strong> and <strong>Project Token</strong> from LambdaTest.</p>
@@ -40,6 +41,13 @@
                                                 <p>Select <strong>Connect</strong>.</p>
                                             </li>
                                         </ol>
-                                        <p>Now you're using LambdaTest Smart UI as a <a href="../../advanced-editing/validations/pixel-validation-and-pixel-wait-for.htm">visual testing provider</a>. </p>
-                                        <p>If you integrated your first visual testing provider, design and run your first test to create baselines for detecting regressions. If you switched providers, <span class="mc-variable General.ProductName variable">Testim</span> will automatically run tests to record new baselines. If you switch providers again, <span class="mc-variable General.ProductName variable">Testim</span> reuses your existing baselines.</p>
+                                        <p>Now you're using LambdaTest Smart UI as a <a href="../../advanced-editing/validations/pixel-validation-and-pixel-wait-for.htm">visual testing provider</a>, and you're ready to create or reuse baselines:</p>
+                                        <ul>
+                                            <li>
+                                                <p><strong>If this is the first visual testing provider you integrated</strong>: Design and run your first test to create baselines for detecting regressions. </p>
+                                            </li>
+                                            <li>
+                                                <p><strong>If you switched providers</strong>: The first time you switch providers, <span class="mc-variable General.ProductName variable">Testim</span> will automatically run tests to record new baselines. If you switch providers again, <span class="mc-variable General.ProductName variable">Testim</span> will reuse your existing baselines.</p>
+                                            </li>
+                                        </ul>
                                     

--- a/snapshots/en/content/integrations/visual-validation/visual_validation_index.html
+++ b/snapshots/en/content/integrations/visual-validation/visual_validation_index.html
@@ -1,6 +1,6 @@
 
                                         <h1>Visual validation</h1>
-                                        <p>Visual validation tools compare your baseline with the current test run to detect UI changes or layout issues.</p>
+                                        <p><a href="../../advanced-editing/validations/pixel-validation-and-pixel-wait-for.htm">Visual validation</a> apps compare the baselines of your app's user interface with the current test run to detect changes or layout issues.</p>
                                         <p><span class="mc-variable General.ProductName variable">Testim</span> offers the following visual validation integrations:</p>
                                         <ul>
                                             <li>

--- a/snapshots/en/content/running-tests/the-command-line-cli.html
+++ b/snapshots/en/content/running-tests/the-command-line-cli.html
@@ -5,7 +5,7 @@
                                         <h2><a name="cli-installation"></a>CLI Installation</h2>
                                         <p>Install Testim package.</p>
                                         <div class="codeSnippet"><a class="codeSnippetCopyButton" role="button" href="javascript:void(0);">Copy</a>
-                                            <div class="codeSnippetBody"><pre><code>npm install -g @testim/testim-cli</code></pre>
+                                            <div class="codeSnippetBody" data-mc-continue="False" data-mc-line-number-start="1" data-mc-use-line-numbers="False"><pre><code>npm install -g @testim/testim-cli &amp;&amp; testim connect</code></pre>
                                             </div>
                                         </div>
                                         <p>That’s it!</p>

--- a/snapshots/en/sidebar.json
+++ b/snapshots/en/sidebar.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-04-02T15:37:41.723Z",
+  "fetchedAt": "2026-04-04T07:21:16.853Z",
   "baseUrl": "https://docs.tricentis.com/testim",
   "sections": [
     {

--- a/src/content/docs/advanced-editing/validations/pixel-validation-and-pixel-wait-for.md
+++ b/src/content/docs/advanced-editing/validations/pixel-validation-and-pixel-wait-for.md
@@ -20,14 +20,13 @@ keywords:
 
 ピクセルレベルでビジュアル差分を検証する
 
-ビジュアル検証／待機ステップでは、ベースラインと現在の実行結果の視覚的差分を精度高く比較できます。本機能は [Applitools](https://applitools.com/) と [LambdaTest](https://www.lambdatest.com/) によって提供されています。
+ビジュアル検証／待機ステップでは、ベースラインと現在の実行結果の視覚的差分を精度高く比較できます。本機能は [Applitools](https://applitools.com/) と [LambdaTest](https://www.lambdatest.com/) のアプリによって提供されています。
 
 開始前に、[Applitools Eyes](https://applitools.com/) または [LambdaTest SmartUI](https://www.lambdatest.com/) と Testim を連携してください。詳しくは[ビジュアル検証統合ガイド](/docs/integrations/visual-validation/visual_validation_index)を参照。\
 関連情報：
 
-- [https://applitools.com/docs/test-manager/viewers/tm-baseline-viewer.html](https://applitools.com/docs/test-manager/viewers/tm-baseline-viewer.html)
-- [https://applitools.com/docs/test-manager/viewers/tm-compare-baselines-viewer.html](https://applitools.com/docs/test-manager/viewers/tm-compare-baselines-viewer.html)
-- [https://applitools.com/docs/test-manager/viewers/tm-compare-baselines-editor.html](https://applitools.com/docs/test-manager/viewers/tm-compare-baselines-editor.html)
+- [Applitools ドキュメント](https://applitools.com/docs/)
+- [LambdaTest ドキュメント](https://www.lambdatest.com/support/docs/)
 
 :::note
 RCA や Ultrafast Test Cloud（追加環境）は適切なライセンスがないと Applitools 側で拒否されます。詳細は Applitools 担当者にお問い合わせください。

--- a/src/content/docs/integrations/visual-validation/lambdatest_integration.md
+++ b/src/content/docs/integrations/visual-validation/lambdatest_integration.md
@@ -14,16 +14,16 @@ keywords:
   - 統合設定
 ---
 
-LambdaTest SmartUI は、Web アプリの UI をデバイス横断でテストし、視覚的な差分やレイアウトの問題を検出する[ビジュアル検証](/docs/advanced-editing/validations/pixel-validation-and-pixel-wait-for)ツールです。LambdaTest を Testim と統合することで、ビジュアルリグレッションの検出を自動化できます。
+LambdaTest SmartUI は、Web アプリの UI をデバイス横断でテストし、テキストの重なり、画像の破損、不正な間隔などの視覚的な差分やレイアウトの問題を検出する[ビジュアル検証](/docs/advanced-editing/validations/pixel-validation-and-pixel-wait-for)ツールです。LambdaTest を Testim と統合することで、ビジュアルリグレッションの検出を自動化できます。
 
 ## 開始前の準備
 
 LambdaTest と Testim を統合する前に、以下を確認してください:
 
-- LambdaTest と Testim の両方で管理者権限が必要です
-- Testim プロジェクトが [Professional plan](https://www.testim.io/pricing/) である必要があります
+- LambdaTest と Testim の両方で管理者権限があること
+- Testim プロジェクトが [Professional plan](https://www.testim.io/pricing/) であること
 
-LambdaTest と Testim を統合するには、LambdaTest から以下の認証情報が必要です:
+また、LambdaTest から以下の認証情報が必要です:
 
 - Username
 - Access key
@@ -33,13 +33,16 @@ LambdaTest と Testim を統合するには、LambdaTest から以下の認証�
 
 ## LambdaTest SmartUI の統合
 
-LambdaTest を最初のビジュアルテストプロバイダーとして使用開始するか、別のプロバイダーから LambdaTest に切り替えることができます。どちらの場合も、以下の手順に従ってください:
+LambdaTest を最初のビジュアルテストプロバイダーとして使用開始するか、別のプロバイダーから LambdaTest に切り替えることができます。
+
+どちらの場合も、以下の手順に従ってください:
 
 1. **Settings > Integration > Visual testing** に移動します。
-2. LambdaTest ペインで **login** を選択します。
+2. **LambdaTest** ペインで **login** を選択します。
 3. LambdaTest から取得した **Username**、**Access key**、**Project Token** を入力します。
 4. **Connect** を選択します。
 
-LambdaTest SmartUI が[ビジュアルテストプロバイダー](/docs/advanced-editing/validations/pixel-validation-and-pixel-wait-for)として使用されるようになりました。
+LambdaTest SmartUI が[ビジュアルテストプロバイダー](/docs/advanced-editing/validations/pixel-validation-and-pixel-wait-for)として使用されるようになりました。ベースラインの作成または再利用の準備が完了しています:
 
-初めてビジュアルテストプロバイダーを統合した場合は、テストを設計して実行し、リグレッション検出用のベースラインを確立してください。プロバイダーを切り替えた場合、Testim は新しいベースラインを記録するためにテストを自動的に再実行します。再度プロバイダーを切り替える場合は、既存のベースラインが再利用されます。
+- **初めてビジュアルテストプロバイダーを統合した場合**: テストを設計して実行し、リグレッション検出用のベースラインを確立してください。
+- **プロバイダーを切り替えた場合**: 初回の切り替え時に、Testim は新しいベースラインを記録するためにテストを自動的に再実行します。再度プロバイダーを切り替える場合は、既存のベースラインが再利用されます。

--- a/src/content/docs/integrations/visual-validation/visual_validation_index.md
+++ b/src/content/docs/integrations/visual-validation/visual_validation_index.md
@@ -13,7 +13,7 @@ keywords:
   - LambdaTest
 ---
 
-ビジュアル検証ツールは、ベースラインと現在のテスト実行を比較して、UI の変更やレイアウトの問題を検出します。
+[ビジュアル検証](/docs/advanced-editing/validations/pixel-validation-and-pixel-wait-for)アプリは、アプリのユーザーインターフェースのベースラインと現在のテスト実行を比較して、変更やレイアウトの問題を検出します。
 
 Testim は以下のビジュアル検証統合を提供しています:
 

--- a/src/content/docs/running-tests/the-command-line-cli.md
+++ b/src/content/docs/running-tests/the-command-line-cli.md
@@ -31,7 +31,7 @@ CLI 経由での実行には Node.js がインストールされている必要�
 Testim パッケージをインストールします。
 
 ```shell
-npm install -g @testim/testim-cli
+npm install -g @testim/testim-cli && testim connect
 ```
 
 以上です！


### PR DESCRIPTION
## Summary
- **lambdatest_integration**: 説明文に具体例追加、前提条件の文体統一、統合後の案内をリスト形式に変更
- **pixel-validation-and-pixel-wait-for**: 関連リンクを個別Applitools URLから一��ドキュメントURLに更新
- **visual_validation_index**: 説明文をEN原文に合わせ更新、ビジュアル検証ページへのリンク追加
- **the-command-line-cli**: CLIインストールコマンドに `testim connect` を追加
- **ENスナップショット**: 4ページ分の最新スナップショットを更新

## Checklist
- [x] Compared against sourceUrl original (snapshot diff で差分確認済み)
- [x] Callouts use ::: directive syntax
- [x] Internal links use /docs/{slug} format
- [x] Testim terminology kept in English
- [x] lint / test / build all pass
- [x] Parity signal resolved (lambdatest_integration bullet-count-mismatch 解消)

Closes #221
Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)