### PR TITLE
parity: Issue #247 PR4 — summary / reporting / CLI cutover (advisory visibility)

### DIFF
--- a/scripts/__tests__/check_source_parity.test.mjs
+++ b/scripts/__tests__/check_source_parity.test.mjs
@@ -307,6 +307,135 @@ describe('CLI coverage helpers', () => {
       });
     });
   });
+
+  // Issue #247 PR4 — source-unusable 単独 advisory 専用 CLI suffix
+  // structure mismatch を含まない source-unusable 単独 advisory ファイルに
+  // 対し、CLI で「翻訳者責任外の snapshot debt」であることを明示する
+  // `(source unusable)` suffix を出す。advisory に structure mismatch が
+  // 1 件でも混ざるなら既存の `(advisory only)` に落ちる。`isAdvisoryOnly
+  // ParityIssue` の scope (= structure + source-unusable 両方) は変更
+  // しない。
+  describe('Issue #247 PR4 — source-unusable 専用 CLI suffix', () => {
+    it('source-unusable 単独 (advisory) → icon ⏸️, suffix " (source unusable)"', () => {
+      const state = getConsoleCoverageState([
+        { type: 'source-unusable', severity: 'actionable' },
+      ]);
+      assert.deepEqual(state, {
+        allAcked: false,
+        allCovered: false,
+        icon: '⏸️',
+        suffix: ' (source unusable)',
+      });
+    });
+
+    it('snapshot-incomplete 単独 (advisory) → icon ⏸️, suffix " (source unusable)"', () => {
+      const state = getConsoleCoverageState([
+        { type: 'snapshot-incomplete', severity: 'actionable' },
+      ]);
+      assert.deepEqual(state, {
+        allAcked: false,
+        allCovered: false,
+        icon: '⏸️',
+        suffix: ' (source unusable)',
+      });
+    });
+
+    it('snapshot-incomplete + source-unusable (両方 source-unusable 系) → " (source unusable)"', () => {
+      const state = getConsoleCoverageState([
+        { type: 'snapshot-incomplete', severity: 'actionable' },
+        { type: 'source-unusable', severity: 'actionable' },
+      ]);
+      assert.deepEqual(state, {
+        allAcked: false,
+        allCovered: false,
+        icon: '⏸️',
+        suffix: ' (source unusable)',
+      });
+    });
+
+    it('source-unusable + section-structure-mismatch (advisory mix) → " (advisory only)"', () => {
+      // advisory に structure mismatch が含まれているので、CLI 上は
+      // structure drift 側を優先する既存の "(advisory only)" に落ちる。
+      const state = getConsoleCoverageState([
+        { type: 'source-unusable', severity: 'actionable' },
+        { type: 'section-structure-mismatch', severity: 'actionable' },
+      ]);
+      assert.deepEqual(state, {
+        allAcked: false,
+        allCovered: false,
+        icon: '⏸️',
+        suffix: ' (advisory only)',
+      });
+    });
+
+    it('source-unusable + frozen baseline (segment-missing, baselined) → " (advisory + baseline/ack)"', () => {
+      const state = getConsoleCoverageState([
+        { type: 'source-unusable', severity: 'actionable' },
+        { type: 'segment-missing', severity: 'actionable', baselined: true },
+      ]);
+      assert.deepEqual(state, {
+        allAcked: false,
+        allCovered: false,
+        icon: '⏸️',
+        suffix: ' (advisory + baseline/ack)',
+      });
+    });
+
+    it('source-unusable + valid ack (segment-missing, acked) → " (advisory + baseline/ack)"', () => {
+      const state = getConsoleCoverageState([
+        { type: 'source-unusable', severity: 'actionable' },
+        {
+          type: 'segment-missing',
+          severity: 'actionable',
+          acknowledged: true,
+          ackExpired: false,
+        },
+      ]);
+      assert.deepEqual(state, {
+        allAcked: false,
+        allCovered: false,
+        icon: '⏸️',
+        suffix: ' (advisory + baseline/ack)',
+      });
+    });
+
+    it('acked source-unusable 単独 → " (all acknowledged)"', () => {
+      // ack 経路は advisory より優先 (PR2 契約と同じ)。
+      const state = getConsoleCoverageState([
+        {
+          type: 'source-unusable',
+          severity: 'actionable',
+          acknowledged: true,
+          ackExpired: false,
+        },
+      ]);
+      assert.deepEqual(state, {
+        allAcked: true,
+        allCovered: true,
+        icon: '⏸️',
+        suffix: ' (all acknowledged)',
+      });
+    });
+
+    it('baselined snapshot-incomplete 単独 → " (covered by baseline/ack)"', () => {
+      // baseline 経路も advisory より優先 (PR1 時点では新 type に
+      // baseline は付かないが forward compatibility のため pin)。
+      const state = getConsoleCoverageState([
+        {
+          type: 'snapshot-incomplete',
+          severity: 'actionable',
+          baselined: true,
+          baselineExpired: false,
+        },
+      ]);
+      assert.deepEqual(state, {
+        allAcked: false,
+        allCovered: true,
+        icon: '⏸️',
+        suffix: ' (covered by baseline/ack)',
+      });
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -1365,6 +1365,165 @@ describe('Issue #247 PR4 — parityFollowup sourceUnusable subsection exposure',
 });
 
 // ---------------------------------------------------------------------------
+// Issue #247 PR4 — renderSummaryMarkdown が `## Structure Mismatch (advisory)` /
+// `## Source Unusable (advisory)` セクションを追加する。`## Parity` の
+// `Active issue files` は引き続き `reportableActiveFiles` を読むので、
+// PR4 時点では structure mismatch を含まない値のまま (PR5 cutover で
+// 意味が広がる)。
+// ---------------------------------------------------------------------------
+
+describe('Issue #247 PR4 — renderSummaryMarkdown structure / source unusable sections', () => {
+  function makeBaseInputs() {
+    const snapshot = {};
+    const parity = {
+      summary: {
+        actionableFiles: 0,
+        signalFiles: 0,
+        errorFiles: 0,
+        activeActionableFiles: 0,
+        activeErrorFiles: 0,
+        activeFiles: 0,
+        reportableActiveFiles: 0,
+        reportableActiveActionableFiles: 0,
+        acknowledgedIssues: 0,
+        structureMismatchIssues: 5,
+        structureMismatchFiles: 3,
+        structureMismatchByType: {
+          'section-structure-mismatch': 4,
+          'segment-order-mismatch': 1,
+        },
+        snapshotUnusableIssues: 2,
+        snapshotUnusableFiles: 2,
+        snapshotUnusableByType: {
+          'snapshot-incomplete': 1,
+          'source-unusable': 1,
+        },
+      },
+    };
+    const actionableReport = {
+      generatedAt: '2026-04-08T00:00:00Z',
+      snapshotDiff: {
+        summary: { changed: 0, added: 0, removed: 0, unchanged: 100, totalSnapshots: 100 },
+      },
+      parityRegression: {
+        summary: {
+          issueCount: 0,
+          structureMismatchIssues: 5,
+          structureMismatchFiles: 3,
+          structureMismatchByType: {
+            'section-structure-mismatch': 4,
+            'segment-order-mismatch': 1,
+          },
+        },
+      },
+      parityFollowup: {
+        summary: {
+          baselineDebt: {
+            baselinedIssues: 0,
+            baselinedFiles: 0,
+            expiredBaselineEntries: 0,
+            baselineInvalidatedSlugs: [],
+          },
+          advisoryQueue: { issues: 0, files: 0, blockingItems: 0, advisoryQueueScope: null },
+          sourceUnusable: {
+            snapshotUnusableIssues: 2,
+            snapshotUnusableFiles: 2,
+            snapshotUnusableByType: {
+              'snapshot-incomplete': 1,
+              'source-unusable': 1,
+            },
+          },
+        },
+      },
+      auditManifest: { total: 0, bucketCounts: {} },
+    };
+    return { snapshot, parity, actionableReport };
+  }
+
+  it('includes "## Structure Mismatch (advisory)" section when structureMismatchIssues > 0', () => {
+    const { snapshot, parity, actionableReport } = makeBaseInputs();
+    const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
+    assert.match(md, /## Structure Mismatch \(advisory\)/);
+    assert.match(md, /Total: 5 issues across 3 files/);
+    // PR5 で gate に載る予定であることを heading 自体ではなく本文で明示
+    assert.match(md, /PR5 cutover|advisory|gate に載りません/);
+    // type 別内訳 (alpha sort)
+    assert.match(md, /section-structure-mismatch: 4/);
+    assert.match(md, /segment-order-mismatch: 1/);
+  });
+
+  it('includes "## Source Unusable (advisory)" section when snapshotUnusableIssues > 0', () => {
+    const { snapshot, parity, actionableReport } = makeBaseInputs();
+    const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
+    assert.match(md, /## Source Unusable \(advisory\)/);
+    assert.match(md, /Total: 2 issues across 2 files/);
+    // 翻訳者責任外であることの注意文
+    assert.match(md, /translation failure|snapshot.*source sync|翻訳/);
+    // type 別内訳 (alpha sort)
+    assert.match(md, /snapshot-incomplete: 1/);
+    assert.match(md, /source-unusable: 1/);
+  });
+
+  it('OMITS both new sections when both counters are 0', () => {
+    const snapshot = {};
+    const parity = {
+      summary: {
+        activeActionableFiles: 0,
+        activeErrorFiles: 0,
+        activeFiles: 0,
+        reportableActiveFiles: 0,
+        acknowledgedIssues: 0,
+        structureMismatchIssues: 0,
+        structureMismatchFiles: 0,
+        structureMismatchByType: {},
+        snapshotUnusableIssues: 0,
+        snapshotUnusableFiles: 0,
+        snapshotUnusableByType: {},
+      },
+    };
+    const actionableReport = {
+      generatedAt: '2026-04-08T00:00:00Z',
+      snapshotDiff: {
+        summary: { changed: 0, added: 0, removed: 0, unchanged: 100, totalSnapshots: 100 },
+      },
+      parityRegression: {
+        summary: {
+          issueCount: 0,
+          structureMismatchIssues: 0,
+          structureMismatchFiles: 0,
+          structureMismatchByType: {},
+        },
+      },
+      parityFollowup: {
+        summary: {
+          baselineDebt: { baselinedIssues: 0, baselinedFiles: 0, expiredBaselineEntries: 0, baselineInvalidatedSlugs: [] },
+          advisoryQueue: { issues: 0, files: 0, blockingItems: 0, advisoryQueueScope: null },
+          sourceUnusable: {
+            snapshotUnusableIssues: 0,
+            snapshotUnusableFiles: 0,
+            snapshotUnusableByType: {},
+          },
+        },
+      },
+      auditManifest: { total: 0, bucketCounts: {} },
+    };
+    const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
+    assert.doesNotMatch(md, /## Structure Mismatch/);
+    assert.doesNotMatch(md, /## Source Unusable/);
+  });
+
+  it('## Parity section の "Active issue files" は structure mismatch を含まない値 (reportableActiveFiles を読む)', () => {
+    // PR4 時点では `reportableActiveFiles` に structure mismatch は流れ込まない。
+    // structure mismatch が 5 件あっても "Active issue files" は 0 のまま。
+    const { snapshot, parity, actionableReport } = makeBaseInputs();
+    const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
+    assert.match(md, /Active issue files: 0/);
+    // 念のため "Active actionable files" もまだ 0
+    assert.match(md, /Active actionable files: 0/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Phase 7: parityRegression excludes non-expired baselined issues
 // ---------------------------------------------------------------------------
 

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -1080,6 +1080,135 @@ describe('parityFollowup in buildActionableReport', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Issue #247 PR4 — parityRegression が structure mismatch の補助 counter を
+// summary に露出する。`isReportableParityIssue` の flip は伴わないので
+// `topEntries` には structure mismatch は含まれず、`shouldOpenIssue` も
+// structure mismatch 単独では立たない。summary の補助カウンタからのみ
+// 観測可能になる。
+// ---------------------------------------------------------------------------
+
+describe('Issue #247 PR4 — parityRegression structure mismatch summary exposure', () => {
+  const emptySnapshot = {
+    checkedAt: '2026-04-08T00:00:00Z',
+    summary: { totalSnapshots: 100, changed: 0, added: 0, removed: 0, unchanged: 100 },
+    changes: [],
+    sidebar: { changed: false, addedPages: [], removedPages: [] },
+  };
+
+  function makeParityWithStructureMismatch() {
+    return {
+      summary: {
+        checkedAt: '2026-04-08T00:00:00Z',
+        actionableFiles: 0,
+        signalFiles: 0,
+        errorFiles: 0,
+        activeActionableFiles: 0,
+        activeFiles: 0,
+        activeErrorFiles: 0,
+        reportableActiveFiles: 0,
+        reportableActiveActionableFiles: 0,
+        structureMismatchIssues: 5,
+        structureMismatchFiles: 3,
+        structureMismatchByType: {
+          'section-structure-mismatch': 4,
+          'segment-order-mismatch': 1,
+        },
+      },
+      files: [
+        {
+          file: 'src/content/docs/running-tests/the-command-line-cli.md',
+          issues: [
+            {
+              type: 'section-structure-mismatch',
+              severity: 'actionable',
+              detail: 'section[2]/block[3] kind diff',
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  it('exposes structureMismatchIssues / structureMismatchFiles / structureMismatchByType in parityRegression.summary', () => {
+    const parity = makeParityWithStructureMismatch();
+    const report = buildActionableReport(emptySnapshot, parity, []);
+    assert.equal(report.parityRegression.summary.structureMismatchIssues, 5);
+    assert.equal(report.parityRegression.summary.structureMismatchFiles, 3);
+    assert.deepEqual(report.parityRegression.summary.structureMismatchByType, {
+      'section-structure-mismatch': 4,
+      'segment-order-mismatch': 1,
+    });
+  });
+
+  it('defaults structure mismatch counters to 0 / {} when summary fields are absent', () => {
+    const parity = {
+      summary: { checkedAt: '2026-04-08T00:00:00Z' },
+      files: [],
+    };
+    const report = buildActionableReport(emptySnapshot, parity, []);
+    assert.equal(report.parityRegression.summary.structureMismatchIssues, 0);
+    assert.equal(report.parityRegression.summary.structureMismatchFiles, 0);
+    assert.deepEqual(report.parityRegression.summary.structureMismatchByType, {});
+  });
+
+  it('does NOT include structure mismatch files in parityRegression.topEntries (PR4 — gate flip is PR5)', () => {
+    const parity = makeParityWithStructureMismatch();
+    const report = buildActionableReport(emptySnapshot, parity, []);
+    // `isReportableParityIssue` は PR4 では flip しないので、structure
+    // mismatch 単独のファイルは topEntries に流れ込まない。
+    assert.equal(report.parityRegression.topEntries.length, 0);
+    // shouldOpenIssue も立たない (= GitHub 上に新規 issue は open されない)
+    assert.equal(report.parityRegression.shouldOpenIssue, false);
+    assert.equal(report.parityRegression.summary.issueCount, 0);
+  });
+
+  it('parityRegression.body contains "## Structure Mismatch (advisory)" section when structureMismatchIssues > 0', () => {
+    const parity = makeParityWithStructureMismatch();
+    const report = buildActionableReport(emptySnapshot, parity, []);
+    assert.match(report.parityRegression.body, /## Structure Mismatch \(advisory\)/);
+    // 件数 / ファイル数の wiring 確認
+    assert.match(
+      report.parityRegression.body,
+      /Total: 5 issues across 3 files/,
+    );
+    // type 別内訳 (sort 順は alpha 昇順)
+    assert.match(
+      report.parityRegression.body,
+      /section-structure-mismatch: 4/,
+    );
+    assert.match(
+      report.parityRegression.body,
+      /segment-order-mismatch: 1/,
+    );
+    // 「PR5 で gate に載る予定」の引用行
+    assert.match(
+      report.parityRegression.body,
+      /PR5 の baseline migration と同時に gate に載る予定です/,
+    );
+  });
+
+  it('parityRegression.body OMITS the "## Structure Mismatch" section when structureMismatchIssues = 0', () => {
+    const parity = {
+      summary: {
+        checkedAt: '2026-04-08T00:00:00Z',
+        actionableFiles: 0,
+        signalFiles: 0,
+        errorFiles: 0,
+        activeActionableFiles: 0,
+        activeFiles: 0,
+        activeErrorFiles: 0,
+        structureMismatchIssues: 0,
+        structureMismatchFiles: 0,
+        structureMismatchByType: {},
+      },
+      files: [],
+    };
+    const report = buildActionableReport(emptySnapshot, parity, []);
+    assert.doesNotMatch(report.parityRegression.body, /## Structure Mismatch/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Phase 7: parityRegression excludes non-expired baselined issues
 // ---------------------------------------------------------------------------
 

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -1209,6 +1209,162 @@ describe('Issue #247 PR4 — parityRegression structure mismatch summary exposur
 });
 
 // ---------------------------------------------------------------------------
+// Issue #247 PR4 — parityFollowup の sourceUnusable サブセクション露出。
+// 翻訳者責任外 (snapshot / source sync 側 debt) のため、shouldOpenIssue の
+// 条件には加えない。`summary.sourceUnusable` 経由で counter のみ可視化する。
+// ---------------------------------------------------------------------------
+
+describe('Issue #247 PR4 — parityFollowup sourceUnusable subsection exposure', () => {
+  const emptySnapshot = {
+    checkedAt: '2026-04-08T00:00:00Z',
+    summary: { totalSnapshots: 100, changed: 0, added: 0, removed: 0, unchanged: 100 },
+    changes: [],
+    sidebar: { changed: false, addedPages: [], removedPages: [] },
+  };
+
+  const cleanParity = {
+    summary: {
+      checkedAt: '2026-04-08T00:00:00Z',
+      actionableFiles: 0,
+      signalFiles: 0,
+      errorFiles: 0,
+      baselinedIssues: 0,
+      baselinedFiles: 0,
+      expiredBaselineEntries: 0,
+      baselineInvalidatedSlugs: [],
+      advisoryQueueIssues: 0,
+      advisoryQueueFiles: 0,
+    },
+    files: [],
+    advisoryQueueScope: { type: 'full', isComplete: true, filters: {}, checkedFiles: 100, totalFiles: 100 },
+    advisoryQueue: [],
+  };
+
+  it('exposes sourceUnusable counters in parityFollowup.summary', () => {
+    const parity = {
+      ...cleanParity,
+      summary: {
+        ...cleanParity.summary,
+        snapshotUnusableIssues: 3,
+        snapshotUnusableFiles: 2,
+        snapshotUnusableByType: {
+          'snapshot-incomplete': 2,
+          'source-unusable': 1,
+        },
+      },
+    };
+    const report = buildActionableReport(emptySnapshot, parity, []);
+    assert.ok(report.parityFollowup.summary.sourceUnusable, 'sourceUnusable subsection must exist');
+    assert.equal(report.parityFollowup.summary.sourceUnusable.snapshotUnusableIssues, 3);
+    assert.equal(report.parityFollowup.summary.sourceUnusable.snapshotUnusableFiles, 2);
+    assert.deepEqual(report.parityFollowup.summary.sourceUnusable.snapshotUnusableByType, {
+      'snapshot-incomplete': 2,
+      'source-unusable': 1,
+    });
+  });
+
+  it('defaults sourceUnusable counters to 0 / {} when summary fields are absent', () => {
+    const report = buildActionableReport(emptySnapshot, cleanParity, []);
+    assert.ok(report.parityFollowup.summary.sourceUnusable);
+    assert.equal(report.parityFollowup.summary.sourceUnusable.snapshotUnusableIssues, 0);
+    assert.equal(report.parityFollowup.summary.sourceUnusable.snapshotUnusableFiles, 0);
+    assert.deepEqual(report.parityFollowup.summary.sourceUnusable.snapshotUnusableByType, {});
+  });
+
+  it('shouldOpenIssue stays FALSE when source-unusable is the only signal (PR4 — translation 責任外)', () => {
+    // PR4 では parityFollowup の `shouldOpenIssue` 判定には source-unusable を
+    // 加えない。snapshot / source sync 側の debt なので、翻訳 PR で修正でき
+    // ない issue を新規 open すると「baseline 必要」と誤読される。
+    const parity = {
+      ...cleanParity,
+      summary: {
+        ...cleanParity.summary,
+        snapshotUnusableIssues: 5,
+        snapshotUnusableFiles: 3,
+        snapshotUnusableByType: { 'snapshot-incomplete': 4, 'source-unusable': 1 },
+      },
+    };
+    const report = buildActionableReport(emptySnapshot, parity, []);
+    assert.equal(report.parityFollowup.shouldOpenIssue, false);
+    // body もゼロケースのまま空文字列
+    assert.equal(report.parityFollowup.body, '');
+  });
+
+  it('parityFollowup.body contains "## Source Unusable (advisory)" section when sourceUnusable counts > 0 AND another signal opens the issue', () => {
+    // body は `shouldOpenIssue=true` のときだけ生成される。source-unusable
+    // 単独では shouldOpenIssue が立たないので、別の signal (expired
+    // baseline) と同居させて body を生成させる。
+    const parity = {
+      ...cleanParity,
+      summary: {
+        ...cleanParity.summary,
+        expiredBaselineEntries: 1,
+        snapshotUnusableIssues: 4,
+        snapshotUnusableFiles: 2,
+        snapshotUnusableByType: { 'snapshot-incomplete': 3, 'source-unusable': 1 },
+      },
+      files: [
+        {
+          file: 'src/content/docs/overview/page-a.md',
+          issues: [
+            {
+              type: 'segment-missing',
+              severity: 'actionable',
+              baselined: true,
+              baselineExpired: true,
+              baselineReviewAfter: '2026-03-01',
+              detail: 'expired',
+            },
+          ],
+        },
+      ],
+    };
+    const report = buildActionableReport(emptySnapshot, parity, []);
+    assert.equal(report.parityFollowup.shouldOpenIssue, true);
+    assert.match(report.parityFollowup.body, /## Source Unusable \(advisory\)/);
+    assert.match(report.parityFollowup.body, /Total: 4 issues across 2 files/);
+    // sort 順固定: snapshot-incomplete → source-unusable
+    assert.match(report.parityFollowup.body, /snapshot-incomplete: 3/);
+    assert.match(report.parityFollowup.body, /source-unusable: 1/);
+    // 翻訳者責任外であることの注意文
+    assert.match(
+      report.parityFollowup.body,
+      /翻訳者責任外|snapshot.*source sync|翻訳 PR では修正できません/,
+    );
+  });
+
+  it('parityFollowup.body OMITS the "## Source Unusable" section when snapshotUnusableIssues = 0', () => {
+    const parity = {
+      ...cleanParity,
+      summary: {
+        ...cleanParity.summary,
+        expiredBaselineEntries: 1,
+        snapshotUnusableIssues: 0,
+        snapshotUnusableFiles: 0,
+        snapshotUnusableByType: {},
+      },
+      files: [
+        {
+          file: 'src/content/docs/overview/page-a.md',
+          issues: [
+            {
+              type: 'segment-missing',
+              severity: 'actionable',
+              baselined: true,
+              baselineExpired: true,
+              detail: 'expired',
+            },
+          ],
+        },
+      ],
+    };
+    const report = buildActionableReport(emptySnapshot, parity, []);
+    assert.equal(report.parityFollowup.shouldOpenIssue, true);
+    assert.doesNotMatch(report.parityFollowup.body, /## Source Unusable/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Phase 7: parityRegression excludes non-expired baselined issues
 // ---------------------------------------------------------------------------
 

--- a/scripts/__tests__/source_parity_issue_state.test.mjs
+++ b/scripts/__tests__/source_parity_issue_state.test.mjs
@@ -567,10 +567,11 @@ describe('Issue #247 PR1 — isSourceUnusableIssue', () => {
   });
 });
 
-describe('Issue #247 PR2 — isReportableParityIssue excludes new taxonomy until PR4 cutover', () => {
+describe('Issue #247 PR2 — isReportableParityIssue excludes new taxonomy until PR5 cutover', () => {
   // PR2 で structure-mismatch / source-unusable の emission を入れたが、
   // gate cutover (= `reportableActive*` への組み込み) は Issue #247 の
-  // PR 分割案で PR4 の責務になっている。
+  // PR 分割案で PR5 の責務になっている (PR4 は summary / reporting / CLI
+  // の可視化のみで gate flip を伴わない)。
   //
   // PR2 時点で gate に載せると、PR1 で `BASELINE_ELIGIBLE_TYPES` に新 type
   // を入れていない (PR5 で wiring 予定) ため、既存の segment-* drift で
@@ -578,10 +579,12 @@ describe('Issue #247 PR2 — isReportableParityIssue excludes new taxonomy until
   // 瞬間に gate exit 1 でブロックされる。これを避けるため `isReportable
   // ParityIssue` で新 type を gate 経路から明示的に exclude する。
   //
-  // PR4 の cutover では `source_parity_issue_state.mjs::isReportable
+  // PR5 の cutover では `source_parity_issue_state.mjs::isReportable
   // ParityIssue` の `if (isStructureMismatchIssue(...) || isSourceUnusable
-  // Issue(...)) return false;` を削除するだけで、structure mismatch が
-  // `reportableActive*` に流れ込む。それまでは独立 counter
+  // Issue(...)) return false;` 行を `isSourceUnusableIssue(...)` のみに
+  // 縮小することで、structure mismatch が `reportableActive*` に流れ込む。
+  // source-unusable は PR5 cutover 後も翻訳者責任外として gate に乗らず
+  // advisory のまま。それまでは独立 counter
   // (`structureMismatchIssues` / `snapshotUnusableIssues`) からだけ参照
   // される構造化 advisory として動く。
   //
@@ -595,14 +598,14 @@ describe('Issue #247 PR2 — isReportableParityIssue excludes new taxonomy until
     'snapshot-incomplete',
     'source-unusable',
   ]) {
-    it(`${type} is NOT reportable in PR2 even when active (gate cutover deferred to PR4)`, () => {
+    it(`${type} is NOT reportable in PR2 even when active (gate cutover deferred to PR5)`, () => {
       assert.equal(
         isReportableParityIssue({
           type,
           severity: 'actionable',
         }),
         false,
-        `${type} must not be reportable until PR4 cutover`,
+        `${type} must not be reportable until PR5 cutover`,
       );
     });
   }
@@ -633,10 +636,10 @@ describe('Issue #247 PR2 — isReportableParityIssue excludes new taxonomy until
     );
   });
 
-  it('expired baseline on a structure mismatch is STILL non-reportable in PR2 (gate cutover is PR4)', () => {
-    // PR4 では「baseline 期限切れ → 再点火」だが、PR2 時点では gate
+  it('expired baseline on a structure mismatch is STILL non-reportable in PR2 (gate cutover is PR5)', () => {
+    // PR5 では「baseline 期限切れ → 再点火」だが、PR2 時点では gate
     // cutover 自体が未実施なので、期限切れも reportable にならない。
-    // PR4 でこのテストを「true 期待」に flip する。
+    // PR5 でこのテストを「true 期待」に flip する。
     assert.equal(
       isReportableParityIssue({
         type: 'section-structure-mismatch',
@@ -650,7 +653,7 @@ describe('Issue #247 PR2 — isReportableParityIssue excludes new taxonomy until
 
   it('new taxonomy is NOT coarse (isCoarseAuditSignal returns false)', () => {
     // coarse signal とは別経路で gate exclusion されている点を pin。
-    // PR4 でこの分類は変えず、isReportableParityIssue 側だけ flip する。
+    // PR5 でこの分類は変えず、isReportableParityIssue 側だけ flip する。
     for (const type of [
       'section-structure-mismatch',
       'segment-order-mismatch',

--- a/scripts/__tests__/source_parity_summary_format.test.mjs
+++ b/scripts/__tests__/source_parity_summary_format.test.mjs
@@ -1,0 +1,243 @@
+import { before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Issue #247 PR4 — `scripts/lib/source_parity_summary_format.mjs` の純粋
+// formatter ヘルパー (`formatStructureMismatchSection` /
+// `formatSourceUnusableSection`) の挙動を pin する。
+//
+// PR4 の主要 deliverable である CLI 末尾セクション (`[structure mismatch]` /
+// `[source unusable]`) を inline `console.log` で書くと regression を
+// テストできないため、純粋 formatter として切り出してここで:
+//   - 0 件 / 欠損時の omit-zero 挙動
+//   - 非ゼロ時のヘッダー文言と注意文
+//   - type 別内訳の sort 順とソースフィールド名の wiring
+// を固定する。`check_source_parity.mjs` 側はこの helper を呼んで結果を
+// `console.log` するだけなので、stdout を直接テストする基盤を新設する
+// 必要がない。
+
+let formatStructureMismatchSection;
+let formatSourceUnusableSection;
+
+before(async () => {
+  ({
+    formatStructureMismatchSection,
+    formatSourceUnusableSection,
+  } = await import('../lib/source_parity_summary_format.mjs'));
+});
+
+describe('formatStructureMismatchSection', () => {
+  it('returns null when structureMismatchIssues is 0 (omit-zero contract)', () => {
+    const result = formatStructureMismatchSection({
+      structureMismatchIssues: 0,
+      structureMismatchFiles: 0,
+      structureMismatchByType: {},
+    });
+    assert.equal(result, null);
+  });
+
+  it('returns null when structureMismatchIssues is undefined (defensive nullish)', () => {
+    const result = formatStructureMismatchSection({});
+    assert.equal(result, null);
+  });
+
+  it('returns null when summary is null (defensive)', () => {
+    assert.equal(formatStructureMismatchSection(null), null);
+  });
+
+  it('returns null when summary is undefined (defensive)', () => {
+    assert.equal(formatStructureMismatchSection(undefined), null);
+  });
+
+  it('non-zero summary returns header + advisory note + sorted type breakdown', () => {
+    const result = formatStructureMismatchSection({
+      structureMismatchIssues: 5,
+      structureMismatchFiles: 3,
+      structureMismatchByType: {
+        'segment-order-mismatch': 2,
+        'section-structure-mismatch': 3,
+      },
+    });
+    assert.notEqual(result, null);
+    const lines = result.split('\n');
+    // ヘッダーの文言固定 (件数 / ファイル数の wiring 含む)
+    assert.equal(
+      lines[0],
+      '[structure mismatch] 全文構造保持違反 (advisory / PR5 で gate に移行予定): 5 件 / 3 ファイル',
+    );
+    // 注意文の固定
+    assert.equal(
+      lines[1],
+      '  現時点では gate には載りません。reviewer が drift を把握するための独立 counter として出力しています。',
+    );
+    // type 別内訳ヘッダー
+    assert.equal(lines[2], '  type 別内訳:');
+    // ソート順 (アルファ昇順) 固定: section-structure-mismatch → segment-order-mismatch
+    assert.equal(lines[3], '    section-structure-mismatch: 3 件');
+    assert.equal(lines[4], '    segment-order-mismatch: 2 件');
+  });
+
+  it('omits the type breakdown section when structureMismatchByType is empty', () => {
+    const result = formatStructureMismatchSection({
+      structureMismatchIssues: 2,
+      structureMismatchFiles: 1,
+      structureMismatchByType: {},
+    });
+    assert.notEqual(result, null);
+    const lines = result.split('\n');
+    // ヘッダー + 注意文の 2 行のみ
+    assert.equal(lines.length, 2);
+    assert.ok(lines[0].includes('[structure mismatch]'));
+    assert.ok(lines[1].startsWith('  現時点では gate には載りません'));
+  });
+
+  it('omits the type breakdown section when structureMismatchByType is missing', () => {
+    const result = formatStructureMismatchSection({
+      structureMismatchIssues: 2,
+      structureMismatchFiles: 1,
+    });
+    assert.notEqual(result, null);
+    const lines = result.split('\n');
+    assert.equal(lines.length, 2);
+  });
+
+  it('uses the structureMismatch* fields, not the snapshotUnusable* fields (regression guard)', () => {
+    // counter フィールド名の typo / 取り違えを防ぐ regression guard。
+    // snapshotUnusable* を渡しても 0 とみなして null を返す。
+    const result = formatStructureMismatchSection({
+      snapshotUnusableIssues: 9,
+      snapshotUnusableFiles: 9,
+      snapshotUnusableByType: { 'snapshot-incomplete': 9 },
+    });
+    assert.equal(result, null);
+  });
+});
+
+describe('formatSourceUnusableSection', () => {
+  it('returns null when snapshotUnusableIssues is 0 (omit-zero contract)', () => {
+    const result = formatSourceUnusableSection({
+      snapshotUnusableIssues: 0,
+      snapshotUnusableFiles: 0,
+      snapshotUnusableByType: {},
+    });
+    assert.equal(result, null);
+  });
+
+  it('returns null when snapshotUnusableIssues is undefined (defensive nullish)', () => {
+    const result = formatSourceUnusableSection({});
+    assert.equal(result, null);
+  });
+
+  it('returns null when summary is null (defensive)', () => {
+    assert.equal(formatSourceUnusableSection(null), null);
+  });
+
+  it('returns null when summary is undefined (defensive)', () => {
+    assert.equal(formatSourceUnusableSection(undefined), null);
+  });
+
+  it('non-zero summary returns header + advisory note + sorted type breakdown', () => {
+    const result = formatSourceUnusableSection({
+      snapshotUnusableIssues: 3,
+      snapshotUnusableFiles: 2,
+      snapshotUnusableByType: {
+        'source-unusable': 2,
+        'snapshot-incomplete': 1,
+      },
+    });
+    assert.notEqual(result, null);
+    const lines = result.split('\n');
+    assert.equal(
+      lines[0],
+      '[source unusable] snapshot 比較不能 (advisory / 翻訳者責任外): 3 件 / 2 ファイル',
+    );
+    assert.equal(
+      lines[1],
+      '  snapshot 側 / source sync 側の debt です。翻訳 PR では修正できません。',
+    );
+    assert.equal(lines[2], '  type 別内訳:');
+    // ソート順固定: snapshot-incomplete → source-unusable
+    assert.equal(lines[3], '    snapshot-incomplete: 1 件');
+    assert.equal(lines[4], '    source-unusable: 2 件');
+  });
+
+  it('omits the type breakdown section when snapshotUnusableByType is empty', () => {
+    const result = formatSourceUnusableSection({
+      snapshotUnusableIssues: 1,
+      snapshotUnusableFiles: 1,
+      snapshotUnusableByType: {},
+    });
+    assert.notEqual(result, null);
+    const lines = result.split('\n');
+    assert.equal(lines.length, 2);
+    assert.ok(lines[0].includes('[source unusable]'));
+    assert.ok(lines[1].startsWith('  snapshot 側 / source sync 側の debt'));
+  });
+
+  it('omits the type breakdown section when snapshotUnusableByType is missing', () => {
+    const result = formatSourceUnusableSection({
+      snapshotUnusableIssues: 1,
+      snapshotUnusableFiles: 1,
+    });
+    assert.notEqual(result, null);
+    const lines = result.split('\n');
+    assert.equal(lines.length, 2);
+  });
+
+  it('uses the snapshotUnusable* fields, not the structureMismatch* fields (regression guard)', () => {
+    const result = formatSourceUnusableSection({
+      structureMismatchIssues: 9,
+      structureMismatchFiles: 9,
+      structureMismatchByType: { 'section-structure-mismatch': 9 },
+    });
+    assert.equal(result, null);
+  });
+});
+
+describe('両 formatter の独立性 (regression guard)', () => {
+  it('only structure mismatch is non-zero → only structure section is returned', () => {
+    const summary = {
+      structureMismatchIssues: 5,
+      structureMismatchFiles: 3,
+      structureMismatchByType: { 'section-structure-mismatch': 5 },
+      snapshotUnusableIssues: 0,
+      snapshotUnusableFiles: 0,
+      snapshotUnusableByType: {},
+    };
+    assert.notEqual(formatStructureMismatchSection(summary), null);
+    assert.equal(formatSourceUnusableSection(summary), null);
+  });
+
+  it('only source unusable is non-zero → only source unusable section is returned', () => {
+    const summary = {
+      structureMismatchIssues: 0,
+      structureMismatchFiles: 0,
+      structureMismatchByType: {},
+      snapshotUnusableIssues: 2,
+      snapshotUnusableFiles: 2,
+      snapshotUnusableByType: { 'snapshot-incomplete': 2 },
+    };
+    assert.equal(formatStructureMismatchSection(summary), null);
+    assert.notEqual(formatSourceUnusableSection(summary), null);
+  });
+
+  it('both non-zero → both sections are returned independently', () => {
+    const summary = {
+      structureMismatchIssues: 5,
+      structureMismatchFiles: 3,
+      structureMismatchByType: { 'section-structure-mismatch': 5 },
+      snapshotUnusableIssues: 2,
+      snapshotUnusableFiles: 2,
+      snapshotUnusableByType: {
+        'snapshot-incomplete': 1,
+        'source-unusable': 1,
+      },
+    };
+    const structureSection = formatStructureMismatchSection(summary);
+    const sourceSection = formatSourceUnusableSection(summary);
+    assert.notEqual(structureSection, null);
+    assert.notEqual(sourceSection, null);
+    // 文言の最初の行が衝突していないこと
+    assert.ok(structureSection.startsWith('[structure mismatch]'));
+    assert.ok(sourceSection.startsWith('[source unusable]'));
+  });
+});

--- a/scripts/check_source_parity.mjs
+++ b/scripts/check_source_parity.mjs
@@ -21,6 +21,8 @@ import {
   detectSourceUsability,
   extractSegmentsFromHtml,
   extractSegmentsFromMarkdown,
+  formatSourceUnusableSection,
+  formatStructureMismatchSection,
   isNonBlockingParityIssue,
   loadSidebarSlugs,
   localCheck,
@@ -809,6 +811,20 @@ export async function checkSourceParity({
           }
         }
       }
+    }
+    // Issue #247 PR4 — structure mismatch / source unusable の独立 advisory
+    // セクションを CLI 末尾に追加する。両 formatter とも 0 件のときは null
+    // を返すので、その場合はセクション自体を省略する。pure helper の文言は
+    // `source_parity_summary_format.test.mjs` で固定済み。
+    const structureMismatchSection = formatStructureMismatchSection(summary);
+    if (structureMismatchSection) {
+      console.log('');
+      console.log(structureMismatchSection);
+    }
+    const sourceUnusableSection = formatSourceUnusableSection(summary);
+    if (sourceUnusableSection) {
+      console.log('');
+      console.log(sourceUnusableSection);
     }
     if (includeAdvisory) {
       const scopeLabel = advisoryQueueScope.isComplete

--- a/scripts/check_source_parity.mjs
+++ b/scripts/check_source_parity.mjs
@@ -29,6 +29,7 @@ import {
 } from './lib/source_parity.mjs';
 import {
   isAdvisoryOnlyParityIssue,
+  isSourceUnusableIssue,
   isValidAcknowledgedIssue,
 } from './lib/source_parity_issue_state.mjs';
 export { isValidAcknowledgedIssue };
@@ -182,7 +183,7 @@ export function getConsoleCoverageState(issues) {
   //   ack         — `isValidAcknowledgedIssue` が true
   //   baseline    — `isFrozenByBaseline` が true (= isNonBlockingIssue が
   //                 true で ack でないもの)
-  //   advisory    — Issue #247 PR2 で emit したが PR4 まで gate cutover
+  //   advisory    — Issue #247 PR2 で emit したが PR5 まで gate cutover
   //                 されない type で、ack/baseline でも覆われていない
   //   reportable  — それ以外 (= active な gate-blocking issue)
   const allAcked = issues.every((issue) => isValidAcknowledgedIssue(issue));
@@ -192,6 +193,17 @@ export function getConsoleCoverageState(issues) {
   );
   const hasAdvisory = issues.some((issue) => isAdvisoryOnlyIssue(issue));
   const hasBaselineOrAck = issues.some((issue) => isNonBlockingIssue(issue));
+  // Issue #247 PR4 — source-unusable 単独 advisory 判定。advisory な issue
+  // すべてが source-unusable 系のとき、CLI では「翻訳者責任外の snapshot
+  // debt」であることを明示する専用 suffix `(source unusable)` を出す。
+  // `isAdvisoryOnlyParityIssue` の scope 自体は変えず (structure mismatch +
+  // source-unusable の両方を advisory として扱う PR2 契約を維持) 、CLI 表示
+  // のみを差別化する。advisory に structure mismatch が 1 件でも混じれば
+  // 既存 `(advisory only)` に落ちる。
+  const advisoryIssues = issues.filter((issue) => isAdvisoryOnlyIssue(issue));
+  const allAdvisoryAreSourceUnusable =
+    advisoryIssues.length > 0 &&
+    advisoryIssues.every((issue) => isSourceUnusableIssue(issue));
 
   // active reportable issue が 1 つでも残っていればファイルはブロッキング扱い。
   if (!allCoveredOrAdvisory) {
@@ -211,9 +223,20 @@ export function getConsoleCoverageState(issues) {
   } else if (allBaselineOrAck) {
     // 既存の動作を保持: 全件が ack / baseline で覆われている。
     suffix = ' (covered by baseline/ack)';
+  } else if (
+    hasAdvisory &&
+    !hasBaselineOrAck &&
+    allAdvisoryAreSourceUnusable
+  ) {
+    // Issue #247 PR4 — source-unusable 単独 advisory。翻訳者に修正を求める
+    // drift ではないことを CLI で明示する。structure mismatch を含む advisory
+    // mix は次の分岐 (`(advisory only)`) に落ちる。
+    suffix = ' (source unusable)';
   } else if (hasAdvisory && !hasBaselineOrAck) {
-    // Issue #247 PR2 — 全件が advisory only。PR4 cutover で gate に
-    // 載るまでは構造化 advisory として可視化するだけで gate は止めない。
+    // Issue #247 PR2 — 全件が advisory only。structure mismatch 単独、または
+    // structure mismatch + source-unusable の advisory。PR5 cutover で
+    // structure mismatch が gate に載るまでは、構造化 advisory として
+    // 可視化するだけで gate は止めない。
     suffix = ' (advisory only)';
   } else {
     // 混在: PR2 由来の advisory と既存の ack/baseline が同居。

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -706,6 +706,34 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
   const acknowledgedIssues = parity.summary?.acknowledgedIssues || 0;
   const expiredAcknowledgements = parity.summary?.expiredAcknowledgements || 0;
 
+  // Issue #247 PR4 — structure mismatch の補助 counter (PR2 で emit され、
+  // PR5 で gate に載る予定)。`isReportableParityIssue` を flip しないため
+  // `parityTopEntries` には含めず、summary と body の独立セクションのみで
+  // 露出する。
+  const structureMismatchIssues = parity.summary?.structureMismatchIssues ?? 0;
+  const structureMismatchFiles = parity.summary?.structureMismatchFiles ?? 0;
+  const structureMismatchByType = parity.summary?.structureMismatchByType ?? {};
+
+  const structureMismatchBodyLines =
+    structureMismatchIssues > 0
+      ? [
+          '## Structure Mismatch (advisory)',
+          '',
+          `- Total: ${structureMismatchIssues} issues across ${structureMismatchFiles} files`,
+          ...(Object.keys(structureMismatchByType).length > 0
+            ? [
+                '- By type:',
+                ...Object.keys(structureMismatchByType)
+                  .sort()
+                  .map((type) => `  - ${type}: ${structureMismatchByType[type]}`),
+              ]
+            : []),
+          '',
+          '> これらは現在 advisory です。PR5 の baseline migration と同時に gate に載る予定です。',
+          '',
+        ]
+      : [];
+
   const parityIssueBody = [
     '## Summary',
     '',
@@ -732,6 +760,7 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
       }),
     ),
     '',
+    ...structureMismatchBodyLines,
     '## Artifacts',
     '',
     '- `parity-check-status.json`',
@@ -826,6 +855,16 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
         expiredAcknowledgements: parity.summary?.expiredAcknowledgements || 0,
         issuesByType: parityIssueSummary.issuesByType,
         issuesBySeverity: parityIssueSummary.issuesBySeverity,
+        // Issue #247 PR4 — structure mismatch の独立 counter を補助フィールド
+        // として露出する。`isReportableParityIssue` は PR4 では flip しない
+        // ため `topEntries` / `issueCount` には流れ込まないが、JSON consumer
+        // (sync-detection-issues / ダッシュボード / 人手レビュー) はこの
+        // フィールドから drift の存在を観測できる。PR5 cutover で structure
+        // mismatch が `topEntries` 側にも流れ込むが、その時点でもこの 3
+        // フィールドは並走させる。
+        structureMismatchIssues,
+        structureMismatchFiles,
+        structureMismatchByType,
       },
     },
     parityFollowup: buildParityFollowup(parity, options),

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -943,6 +943,54 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
           .map(([type, count]) => `  - ${type}: ${count}`)
       : ['  - (none)'];
 
+  // Issue #247 PR4 — structure mismatch / source unusable の独立 advisory
+  // セクション。`## Parity` の `Active issue files` は引き続き
+  // `reportableActiveFiles` を読むので PR4 時点では structure mismatch を
+  // 含まない。新セクションは 0 件のときは省略する。
+  const structureMismatchIssues = parity.summary?.structureMismatchIssues ?? 0;
+  const structureMismatchFiles = parity.summary?.structureMismatchFiles ?? 0;
+  const structureMismatchByType = parity.summary?.structureMismatchByType ?? {};
+  const structureMismatchSection =
+    structureMismatchIssues > 0
+      ? [
+          '## Structure Mismatch (advisory)',
+          '',
+          `- Total: ${structureMismatchIssues} issues across ${structureMismatchFiles} files`,
+          '- Advisory — PR5 cutover までは gate に載りません',
+          ...(Object.keys(structureMismatchByType).length > 0
+            ? [
+                '- By type:',
+                ...Object.keys(structureMismatchByType)
+                  .sort()
+                  .map((type) => `  - ${type}: ${structureMismatchByType[type]}`),
+              ]
+            : []),
+          '',
+        ]
+      : [];
+
+  const snapshotUnusableIssues = parity.summary?.snapshotUnusableIssues ?? 0;
+  const snapshotUnusableFiles = parity.summary?.snapshotUnusableFiles ?? 0;
+  const snapshotUnusableByType = parity.summary?.snapshotUnusableByType ?? {};
+  const sourceUnusableSection =
+    snapshotUnusableIssues > 0
+      ? [
+          '## Source Unusable (advisory)',
+          '',
+          `- Total: ${snapshotUnusableIssues} issues across ${snapshotUnusableFiles} files`,
+          '- Not a translation failure — snapshot / source sync 側 debt です。翻訳 PR では修正できません。',
+          ...(Object.keys(snapshotUnusableByType).length > 0
+            ? [
+                '- By type:',
+                ...Object.keys(snapshotUnusableByType)
+                  .sort()
+                  .map((type) => `  - ${type}: ${snapshotUnusableByType[type]}`),
+              ]
+            : []),
+          '',
+        ]
+      : [];
+
   return [
     '# Docs Detection Summary',
     '',
@@ -973,6 +1021,8 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
       ? [`- ⚠ Expired acknowledgements: ${parity.summary.expiredAcknowledgements}`]
       : []),
     '',
+    ...structureMismatchSection,
+    ...sourceUnusableSection,
     '## Audit Signals',
     '',
     '- audit-only: coarse counting / shape / table-cell heuristics',

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -459,6 +459,7 @@ function buildParityFollowupBody({
   advisoryQueueFiles,
   advisoryQueueScope,
   includeAdvisoryInBody,
+  sourceUnusable,
 }) {
   const lines = [
     '## Summary',
@@ -478,6 +479,28 @@ function buildParityFollowupBody({
       `  - Blocking: ${blockingAdvisoryItems.length}`,
       '',
     );
+  }
+
+  // Issue #247 PR4 — source-unusable サブセクション。`shouldOpenIssue` の
+  // 条件には加えていない (翻訳者責任外なので新規 issue は open しない) が、
+  // 既に別の signal で issue body が生成されているなら、source-unusable の
+  // 件数も併記して reviewer に状況を見せる。0 件のときはセクション自体を
+  // 省略する。
+  if (sourceUnusable && sourceUnusable.snapshotUnusableIssues > 0) {
+    lines.push(
+      '## Source Unusable (advisory)',
+      '',
+      `- Total: ${sourceUnusable.snapshotUnusableIssues} issues across ${sourceUnusable.snapshotUnusableFiles} files`,
+      '- Not a translation failure — snapshot / source sync 側 debt です。翻訳 PR では修正できません。',
+    );
+    const sortedTypes = Object.keys(sourceUnusable.snapshotUnusableByType ?? {}).sort();
+    if (sortedTypes.length > 0) {
+      lines.push('- By type:');
+      for (const type of sortedTypes) {
+        lines.push(`  - ${type}: ${sourceUnusable.snapshotUnusableByType[type]}`);
+      }
+    }
+    lines.push('');
   }
 
   if (expiredBaselineFiles.length > 0) {
@@ -551,6 +574,15 @@ function buildParityFollowup(parity, options = {}) {
   const advisoryQueueFiles = summary.advisoryQueueFiles ?? 0;
   const isComplete = advisoryQueueScope?.isComplete ?? null;
 
+  // Issue #247 PR4 — source-unusable サブセクション。`shouldOpenIssue` の
+  // 判定には加えない (翻訳者責任外、新規 issue を open しない契約)。summary
+  // への露出と body サブセクションのみを担う。
+  const sourceUnusable = {
+    snapshotUnusableIssues: summary.snapshotUnusableIssues ?? 0,
+    snapshotUnusableFiles: summary.snapshotUnusableFiles ?? 0,
+    snapshotUnusableByType: summary.snapshotUnusableByType ?? {},
+  };
+
   const blockingAdvisoryItems = advisoryQueue.filter((e) => e.blocking);
   const hasBlockingAdvisory = isComplete === true && blockingAdvisoryItems.length > 0;
 
@@ -612,6 +644,7 @@ function buildParityFollowup(parity, options = {}) {
           advisoryQueueFiles,
           advisoryQueueScope,
           includeAdvisoryInBody: isComplete === true,
+          sourceUnusable,
         }),
         FAMILY_KEYS.PARITY_FOLLOWUP,
       )
@@ -642,6 +675,10 @@ function buildParityFollowup(parity, options = {}) {
         includedInIssueBody: isComplete === true,
       },
       reviewHints,
+      // Issue #247 PR4 — source-unusable counter のサブセクション。
+      // shouldOpenIssue には影響しないが、JSON consumer (人手レビュー /
+      // ダッシュボード) が翻訳者責任外の snapshot debt を観測できる。
+      sourceUnusable,
     },
   };
 }

--- a/scripts/lib/source_parity.mjs
+++ b/scripts/lib/source_parity.mjs
@@ -4,6 +4,10 @@ export * from './source_parity_extract.mjs';
 export * from './source_parity_checks.mjs';
 export * from './source_parity_issue_state.mjs';
 export * from './source_parity_summary.mjs';
+export {
+  formatStructureMismatchSection,
+  formatSourceUnusableSection,
+} from './source_parity_summary_format.mjs';
 export * from './source_parity_advisory_queue.mjs';
 export * from './source_parity_page_coverage.mjs';
 export * from './source_parity_acknowledgements.mjs';

--- a/scripts/lib/source_parity_issue_state.mjs
+++ b/scripts/lib/source_parity_issue_state.mjs
@@ -68,7 +68,7 @@ export function isReportableParityIssue(issue) {
   if (isCoarseAuditSignal(issue)) return false;
 
   // Issue #247 PR2 — structure-mismatch / source-unusable は PR2 で
-  // emission を入れた段階で、PR4 の gate cutover まで `reportableActive*`
+  // emission を入れた段階で、PR5 の gate cutover まで `reportableActive*`
   // (gate counter) には乗せない。専用の `structureMismatchIssues` /
   // `snapshotUnusableIssues` counter にだけ集計する。
   //
@@ -79,10 +79,14 @@ export function isReportableParityIssue(issue) {
   //      した瞬間に gate exit 1 でブロックされる (新 type は baseline で
   //      freeze できないため)。
   //   2. 段階的 cutover の意図 — PR2 は emitter / contract を pin する
-  //      フェーズで、gate flip は PR4 の責務 (Issue #247 の PR 分割案
-  //      参照)。
-  //   3. PR4 でこの 2 行を削除するだけで cutover が完了する設計。
-  //      それまでは structure-mismatch は構造化 advisory として
+  //      フェーズで、PR4 は summary / reporting / CLI の可視化のみ、gate
+  //      flip は PR5 の責務 (Issue #247 の PR 分割案参照)。
+  //   3. PR5 では `isStructureMismatchIssue(issue)` の分岐のみ削除する
+  //      ことで structure mismatch を gate に載せる (= reportable 化)。
+  //      `isSourceUnusableIssue(issue)` の分岐は PR5 でも残す — snapshot /
+  //      source sync 側 debt は翻訳 PR で修正できないため、PR5 cutover
+  //      後も advisory のまま。
+  //   4. それまでは structure-mismatch は構造化 advisory として
   //      `structureMismatch*` counter から見えるが、gate は再点火しない。
   if (isStructureMismatchIssue(issue) || isSourceUnusableIssue(issue)) return false;
 
@@ -96,7 +100,7 @@ export function isReportableParityIssue(issue) {
  * ack / baseline で覆われていないものを「advisory only」として識別する
  * 純粋述語。
  *
- * PR2 で emission を入れたが gate cutover は PR4 の責務、という方針
+ * PR2 で emission を入れたが gate cutover は PR5 の責務、という方針
  * (`isReportableParityIssue` の docstring 参照) を CLI 表示と整合させる
  * ために独立した述語にしている。advisory only な issue は:
  *   - gate には乗らない (`isReportableParityIssue` が false を返す)
@@ -109,7 +113,9 @@ export function isReportableParityIssue(issue) {
  * なる (ack / baseline 経路が優先で、advisory より具体的なカバレッジ
  * 情報を持っているため)。
  *
- * PR4 cutover ではこの述語と CLI 側の advisory 表示分岐を削除する。
+ * PR5 cutover では structure mismatch 側がここから外れ (reportable に
+ * 昇格するため)、この述語は source-unusable のみを指すよう scope が
+ * 縮小される予定。PR4 では scope を変更しない。
  */
 export function isAdvisoryOnlyParityIssue(issue) {
   if (!issue || typeof issue !== 'object') return false;
@@ -124,7 +130,7 @@ export function isAdvisoryOnlyParityIssue(issue) {
 export function isNonBlockingParityIssue(issue) {
   // 「非ブロッキング」の元の意味 — ack または baseline で **明示的に** 覆わ
   // れている issue だけ。Issue #247 PR2 で emission を入れた structure-
-  // mismatch / source-unusable は、PR4 cutover まで gate には乗らないが、
+  // mismatch / source-unusable は、PR5 cutover まで gate には乗らないが、
   // それは ack / baseline で覆われているからではなく advisory として
   // 扱っているからなので、ここには含めない。CLI の "(covered by
   // baseline/ack)" / "(advisory only)" を区別するために

--- a/scripts/lib/source_parity_structure.mjs
+++ b/scripts/lib/source_parity_structure.mjs
@@ -303,7 +303,11 @@ function describeKindSequence(kinds) {
   return kinds.join(' → ');
 }
 
-function buildKindMultisetDiff(enSection, jaSection, enKinds, jaKinds) {
+// 以下 3 つの builder は detail 文字列に EN 側の `sectionPath` だけを使い、
+// JA section オブジェクトは参照しない (`buildBaseDiff` も `section: enSection`
+// 経由でしか section 情報を読まない)。シグネチャから `jaSection` を外して
+// astro check の未使用引数 hint (ts(6133)) を消す。
+function buildKindMultisetDiff(enSection, enKinds, jaKinds) {
   const detail =
     `Section "${enSection.sectionPath || '(preface)'}" block structure differs: ` +
     `EN=[${describeKindSequence(enKinds)}] vs JA=[${describeKindSequence(jaKinds)}]`;
@@ -317,7 +321,7 @@ function buildKindMultisetDiff(enSection, jaSection, enKinds, jaKinds) {
   });
 }
 
-function buildKindSequenceDiff(enSection, jaSection, enKinds, jaKinds) {
+function buildKindSequenceDiff(enSection, enKinds, jaKinds) {
   const detail =
     `Section "${enSection.sectionPath || '(preface)'}" block kinds reordered: ` +
     `EN=[${describeKindSequence(enKinds)}] vs JA=[${describeKindSequence(jaKinds)}]`;
@@ -331,7 +335,7 @@ function buildKindSequenceDiff(enSection, jaSection, enKinds, jaKinds) {
   });
 }
 
-function buildContentOrderDiff(enSection, jaSection, enKinds, jaKinds, permutation) {
+function buildContentOrderDiff(enSection, enKinds, jaKinds, permutation) {
   const permDesc = permutation
     .slice()
     .sort((a, b) => a.enIndex - b.enIndex)
@@ -432,7 +436,7 @@ export function compareSectionStructure(enSection, jaSection) {
   const enMultiset = buildMultiset(enKinds);
   const jaMultiset = buildMultiset(jaKinds);
   if (!multisetsEqual(enMultiset, jaMultiset)) {
-    return [buildKindMultisetDiff(enSection, jaSection, enKinds, jaKinds)];
+    return [buildKindMultisetDiff(enSection, enKinds, jaKinds)];
   }
 
   // Stage B — kind sequence (multiset 一致 / 並び順のみ不一致)。
@@ -440,7 +444,7 @@ export function compareSectionStructure(enSection, jaSection) {
   // ここに来た時点で multiset は一致しているので、kind 列が違えば必ず
   // 「mixed-kind reorder」(例: [p, ul] vs [ul, p]) のケース。
   if (!sequencesEqual(enKinds, jaKinds)) {
-    return [buildKindSequenceDiff(enSection, jaSection, enKinds, jaKinds)];
+    return [buildKindSequenceDiff(enSection, enKinds, jaKinds)];
   }
 
   // Stage C — content-order bijection。ここに来た時点で multiset と
@@ -448,7 +452,7 @@ export function compareSectionStructure(enSection, jaSection) {
   // swap / rotation を、invariant token の content bijection で検出する。
   const permutation = detectContentOrderPermutation(enBlocks, jaBlocks);
   if (permutation) {
-    return [buildContentOrderDiff(enSection, jaSection, enKinds, jaKinds, permutation)];
+    return [buildContentOrderDiff(enSection, enKinds, jaKinds, permutation)];
   }
 
   return [];

--- a/scripts/lib/source_parity_summary.mjs
+++ b/scripts/lib/source_parity_summary.mjs
@@ -33,8 +33,13 @@ import {
  *     mismatch (section-structure-mismatch / segment-order-mismatch) の
  *     独立 counter。ack (valid) と frozen baseline は除外し、gate に載せる
  *     予定の active な structure violation のみカウントする。PR2 で emitter
- *     を追加するまでは常にゼロ。PR4 で `reportableActive*` と揃えて gate
- *     cutover する。
+ *     を追加した。PR4 では summary / reporting / CLI の表層 (検出レポート、
+ *     `renderSummaryMarkdown`、CLI 末尾セクション) に first-class で露出
+ *     させる cutover を行うが、`reportableActive*` への流入は伴わない (gate
+ *     flip は PR5 の責務)。PR4 時点では `reportableActiveFiles` には含まれ
+ *     ず、独立 counter として並走する状態。PR5 で `BASELINE_ELIGIBLE_TYPES`
+ *     拡張 + `isReportableParityIssue` flip が同時に行われ、structure
+ *     mismatch が gate に載る。
  *
  *     PR1 時点の注意: 新 type は `BASELINE_ELIGIBLE_TYPES` にまだ含まれない
  *     ため、現実運用で baseline が付くことは無い (loader が reject する)。
@@ -45,8 +50,13 @@ import {
  *     Issue #247 PR1 — snapshot / source 起因で comparator が成立しない
  *     ページ用の独立 counter。`snapshot-incomplete` / `source-unusable` を
  *     translation drift と混ぜないために別枠で集計する。PR3 で emitter を
- *     追加するまでは常にゼロ。baseline eligibility は structureMismatch と
- *     同じで、PR1 時点では未対応 (PR5 で wiring)。
+ *     追加。PR4 では summary / reporting / CLI に first-class で露出させる
+ *     (parityFollowup の `summary.sourceUnusable` サブセクションと CLI 末尾
+ *     セクション)。**翻訳者責任外 (snapshot / source sync 側 debt) のため、
+ *     PR4/PR5 いずれでも `reportableActive*` には含めない**。常に独立
+ *     advisory counter として可視化する。baseline eligibility は
+ *     structureMismatch と同じで、PR5 で wiring 予定 (人手管理のため
+ *     baseline で freeze はできるが gate には載らない)。
  *
  *   baselinedIssues / baselinedFiles / baselinedByType /
  *   baselinedByInconclusiveCategory / expiredBaselineEntries

--- a/scripts/lib/source_parity_summary_format.mjs
+++ b/scripts/lib/source_parity_summary_format.mjs
@@ -1,0 +1,78 @@
+/**
+ * Issue #247 PR4 — summary counter を CLI 表示用の複数行テキストに変換する
+ * 純粋 formatter。副作用なし。0 件のときは null を返し、呼び出し側
+ * (`check_source_parity.mjs`) はそれを見てセクション自体を省略する契約。
+ *
+ * pure function に切り出している理由:
+ *   - PR4 の主要 deliverable なので、stdout に直接 write する inline
+ *     `console.log` では regression をキャッチできない
+ *   - summary の field 名 (`structureMismatchIssues` / `structureMismatchByType`
+ *     / `snapshotUnusableIssues` 等) との wiring を静的にテストできる
+ *   - 0 件時の omit 挙動と type 別内訳の sort 順を逐一 fixture で pin できる
+ *
+ * いずれの formatter も、対応する `*Issues` counter が 0 / 欠損 / null /
+ * undefined のいずれであっても null を返す (omit-zero contract)。
+ */
+
+/**
+ * `[structure mismatch]` セクションを生成する。
+ *
+ * @param {object|null|undefined} summary  `summarizeParityResults()` の戻り値
+ *   と同 shape のオブジェクト。`structureMismatchIssues` /
+ *   `structureMismatchFiles` / `structureMismatchByType` を読む。
+ * @returns {string|null}  非ゼロ時は複数行テキスト、0 / 欠損時は null。
+ */
+export function formatStructureMismatchSection(summary) {
+  if (!summary || typeof summary !== 'object') return null;
+  const issues = summary.structureMismatchIssues || 0;
+  const files = summary.structureMismatchFiles || 0;
+  if (issues === 0) return null;
+  const byType =
+    summary.structureMismatchByType && typeof summary.structureMismatchByType === 'object'
+      ? summary.structureMismatchByType
+      : {};
+  const lines = [
+    `[structure mismatch] 全文構造保持違反 (advisory / PR5 で gate に移行予定): ${issues} 件 / ${files} ファイル`,
+    '  現時点では gate には載りません。reviewer が drift を把握するための独立 counter として出力しています。',
+  ];
+  const sortedTypes = Object.keys(byType).sort();
+  if (sortedTypes.length > 0) {
+    lines.push('  type 別内訳:');
+    for (const type of sortedTypes) {
+      lines.push(`    ${type}: ${byType[type]} 件`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * `[source unusable]` セクションを生成する。snapshot / source sync 側 debt
+ * のため翻訳 PR では修正できない旨を CLI で明示する。
+ *
+ * @param {object|null|undefined} summary  `summarizeParityResults()` の戻り値
+ *   と同 shape のオブジェクト。`snapshotUnusableIssues` /
+ *   `snapshotUnusableFiles` / `snapshotUnusableByType` を読む。
+ * @returns {string|null}  非ゼロ時は複数行テキスト、0 / 欠損時は null。
+ */
+export function formatSourceUnusableSection(summary) {
+  if (!summary || typeof summary !== 'object') return null;
+  const issues = summary.snapshotUnusableIssues || 0;
+  const files = summary.snapshotUnusableFiles || 0;
+  if (issues === 0) return null;
+  const byType =
+    summary.snapshotUnusableByType && typeof summary.snapshotUnusableByType === 'object'
+      ? summary.snapshotUnusableByType
+      : {};
+  const lines = [
+    `[source unusable] snapshot 比較不能 (advisory / 翻訳者責任外): ${issues} 件 / ${files} ファイル`,
+    '  snapshot 側 / source sync 側の debt です。翻訳 PR では修正できません。',
+  ];
+  const sortedTypes = Object.keys(byType).sort();
+  if (sortedTypes.length > 0) {
+    lines.push('  type 別内訳:');
+    for (const type of sortedTypes) {
+      lines.push(`    ${type}: ${byType[type]} 件`);
+    }
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

Issue #247 の最小着手セット PR1→PR5 の **4 本目**。PR2/PR3 で emission 済みだがまだ advisory でしか見えない `section-structure-mismatch` / `segment-order-mismatch` / `snapshot-incomplete` / `source-unusable` を **summary / reporting / CLI の表層で first-class に可視化** する。**gate flip は伴わない** (本 PR の前後で `npm run check:parity` の exit code は変化しない契約)。

具体的に追加するもの:
1. `getConsoleCoverageState` に **source-unusable 専用 suffix** `(source unusable)` を追加し、structure mismatch advisory と snapshot debt advisory を CLI で見分けられるようにする
2. `check_source_parity.mjs` の CLI summary 末尾に `[structure mismatch]` / `[source unusable]` の独立セクションを追加 (非ゼロ時のみ)。文言は新規 pure helper `scripts/lib/source_parity_summary_format.mjs` に切り出して unit test で固定
3. `detection_reports.mjs::buildActionableReport` の `parityRegression.summary` に `structureMismatchIssues` / `structureMismatchFiles` / `structureMismatchByType` を露出 (`isReportableParityIssue` は flip しないので `topEntries` には流れ込まない)
4. `parityFollowup.summary.sourceUnusable` を新設し、`parityFollowup.body` に `## Source Unusable (advisory)` セクションを追加 (`shouldOpenIssue` の条件には加えない — 翻訳者責任外)
5. `renderSummaryMarkdown` に `## Structure Mismatch (advisory)` / `## Source Unusable (advisory)` セクションを追加

## Non-goals (PR5/PR6 への申し送り)

- `isReportableParityIssue` の flip → **PR5**
- `BASELINE_ELIGIBLE_TYPES` 拡張 + baseline migration → **PR5**
- 代表ページの fixture 追加 → **PR6**
- `paragraph-count-mismatch` 等 coarse heuristic の扱い変更 → 引き続き audit-only

## Why PR4 is split from PR5

`pr3-no-spec` ブランチ上では `running-tests/the-command-line-cli` などの代表ページが既に active な `section-structure-mismatch` を emit しているため、`BASELINE_ELIGIBLE_TYPES` migration を伴わずに `isReportableParityIssue` を flip すると `npm run check:parity` の full run が即 exit code 1 を返し PR4 単体で CI が通らない / `main` マージ時に赤化する。これを避けるため、gate cutover (= `isReportableParityIssue` flip + baseline migration + 代表ページの baseline entry 追加) は **PR5 に統合** することにした。PR4 は「翻訳者 / reviewer が drift を summary / report / CLI で確認できる」状態までを整える独立した可視化レイヤ。

## Test plan

- [x] `npm test` — 1454 件 PASS (PR3 baseline 1413 + 新規 41)
- [x] `npm run lint` — 0 error / 0 warning
- [x] `npm run build` — astro check + build green
- [x] `npm run check:parity` full run の exit code が PR3 baseline と同じ (= 0)
- [x] `parity-check-status.json` の `summary.{reportableActiveFiles, structureMismatchIssues, structureMismatchByType, snapshotUnusableIssues, snapshotUnusableByType}` が PR3 baseline と完全一致 (PR4 は counter を変えない契約)
- [x] structure mismatch 代表ページ JSON 検査 (suffix は使わない — coarse signal の併発で ❌ になるため)
  - [x] `running-tests/the-command-line-cli` → `section-structure-mismatch: 10`
  - [x] `results/test-results/network-logs` → `section-structure-mismatch: 2`
  - [x] `advanced-editing/validations/email-validation` → `section-structure-mismatch: 2`
- [x] source unusable 代表ページの stdout suffix が `(advisory only)` → `(source unusable)` に flip
  - [x] `salesforce-testing/faq`
  - [x] `salesforce-testing/salesforce-testing-overview`
- [x] CLI summary 末尾に `[structure mismatch]` / `[source unusable]` セクションが出力される
- [x] artifact 吸収ページ (`advanced-editing/custom-action-step-mobile`) は壊れていない

## TDD 進捗

7 commits、各 commit は Step 単位で分割:

1. `c2f02d2` docs: docstring updates (PR4/PR5 role split)
2. `c3413f8` feat: getConsoleCoverageState (source unusable) suffix
3. `72aa48d` feat: source_parity_summary_format pure helpers
4. `cbbb7b2` feat: CLI summary sections wired to pure helpers
5. `17a5063` feat: parityRegression structure mismatch summary exposure
6. `21f3a2c` feat: parityFollowup sourceUnusable subsection
7. `8f46c21` feat: renderSummaryMarkdown structure / source unusable sections

設計書の全文は本 PR のコメント (続けて投稿) を参照してください。

Issue: #247