### PR TITLE
Issue #247 PR6 — fixture pin + docs (structure comparator / source unusable)

### DIFF
--- a/docs/OPS_DESIGN.md
+++ b/docs/OPS_DESIGN.md
@@ -82,6 +82,42 @@ queue 全体を消費する。
 - `EN uses <details> blocks` — EN が `<details>` を使用
 - `EN body largely wrapped in code fence` — EN 本文の 50% 以上がコードフェンス内
 
+### Structure comparator (canonical block sequence)
+
+`alignSegments` が weighted LCS を走らせる前に、heading path が一致する section ごとに `compareSectionStructure()` を呼び、**原文 block 列の並びと多重集合** を比較する。この比較器は Issue #247 で導入され、`paragraph-count-mismatch` などの count heuristic を降格した後の **構造保持の主判定** を担う。
+
+**比較対象の block 語彙 (凍結)**: `paragraph` / `ordered-list` / `unordered-list` / `callout-body` / `table` / `details-summary`。segment 単位の `ordered-list-item` / `unordered-list-item` / `table-cell` は比較前に list / table block に畳み込まれる (block 内部の件数差は別 comparator の責務)。
+
+**3 段階の fall-through**:
+
+| Stage | 条件 | emit type | structureCategory |
+| --- | --- | --- | --- |
+| A | EN/JA で block kind の **多重集合** が違う (cross-kind merge/split/collapse) | `section-structure-mismatch` | `kind-multiset` |
+| B | multiset は一致するが **並び順** が違う (mixed-kind reorder) | `segment-order-mismatch` | `kind-sequence` |
+| C | kind 列は完全一致しているが **content bijection が monotonic でない** (same-kind の swap / rotation) | `segment-order-mismatch` | `content-order` |
+
+どの stage も発火しなければ比較器は空配列を返し、alignSegments は従来通り weighted LCS にフォールスルーする。section あたり最大 1 件までしか emit しない — 先に発火した stage が勝ち、後続 stage は short-circuit でスキップされる (gate 契約を予測可能にするため)。
+
+**gate 分類**: `section-structure-mismatch` と `segment-order-mismatch` は PR5 cutover 以降 **reportable** (gate 対象)。`parity-baseline.json` に entry が無ければ `--fail-on=any` と `--fail-on=actionable` の両方で exit code 1。
+
+**baseline identity**: structure 系 entry の machine identity は **`sectionIndex` + `structureCategory` + `structureFingerprint`** の 3 つ組で構成する (`buildBaselineKey` / `buildBaselineKeyFromEntry`)。`structureFingerprint` は `structureCategory` + `enKinds` + `jaKinds` (+ content-order の場合は `contentPermutation` の `enIndex→jaIndex` pair) を sha256 に畳み込んだもの。`sectionPath` は **reviewer 可読性のために entry に保存するが identity key には含めない** — 同一ページ内で同じ heading text が複数現れる場合に sectionPath だけだと一意にならないため (PR5 Finding 2)。
+
+### Source unusable 判定
+
+比較前に `detectSourceUsability()` が EN snapshot の **比較可能性** を判定する。比較不能と判定されたページはその 1 件だけを emit し、後続の alignSegments / structure comparator は呼ばれない (translation drift と snapshot/source debt を混ぜないため)。
+
+**3 つの reason (凍結)**:
+
+| reason | 発火条件 | emit type |
+| --- | --- | --- |
+| `shallow-snapshot` | raw EN ≤ 800 bytes かつ EN body ≤ 2 かつ JA body ≥ 5 かつ ratio ≥ 4 | `snapshot-incomplete` |
+| `extractor-empty` | clean HTML なのに EN body が 0 で JA body ≥ 3 | `snapshot-incomplete` |
+| `escaped-details-residue` | (通常経路) `&lt;/details&gt;` 残存 **または** open/close 不均衡 (= broken details tree) **かつ** `enHeadingSegmentCount === 0` で JA heading ≥ 2 (= section anchor failure) を **両方** 満たす。(extractError 経路) open/close 不均衡 (`open !== close`) のみで判定 | `source-unusable` |
+
+`escaped-details-residue` の判定が **狭く** なっているのは、`advanced-editing/coding-assistant` のように `<details>` の使用例を本文に含むため preprocessEnHtml 後も balanced な escaped marker が残るが extractor / comparator は正常に動く合法ケースを誤発火させないため (PR3 P1 fix)。「escaped marker が残るだけ」では unusable と判定しない。
+
+**gate 分類**: `snapshot-incomplete` と `source-unusable` は **advisory のみ** — `summary.snapshotUnusableIssues` / `summary.snapshotUnusableFiles` に集計されるが `summary.reportableActiveFiles` には入らない。そのため active な source unusable が何件あっても exit code は 0。これは「翻訳者責任外の snapshot / source sync 側の debt」を翻訳者 gate で失敗させないためで、PR5 cutover 後も同じ契約。`parity-baseline.json` には `usabilityReason` を key として entry を置けるので、人手管理の枠としては活用できる。
+
 ## チェックの保証範囲
 
 | 保証する | 保証しない |
@@ -91,6 +127,7 @@ queue 全体を消費する。
 | 画像ファイル実在 | 文体品質 |
 | frontmatter 整合 | 厳密な Astro レンダリング |
 | 原文構造差分 | セマンティックな翻訳精度 |
+| block 列レベルの構造保持 (paragraph / list / callout / table / details の並びと多重集合) | |
 
 ### 日常運用（ページ単位）
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -92,8 +92,32 @@ npm run check:parity -- --fail-on=any                     # acknowledgement を�
 | `table-cell-empty-mismatch`   | テーブルセルの空/非空不一致                        | audit-only   |
 | `table-cell-token-mismatch`   | テーブルセルの invariant token 不一致              | audit-only   |
 | `missing-snapshot`            | EN snapshot が存在しないページ                     | gate signal  |
+| `section-structure-mismatch`  | EN/JA の section body で block kind 多重集合が違う | reportable   |
+| `segment-order-mismatch`      | section 内 block 種別の並びまたは content 順が違う | reportable   |
+| `snapshot-incomplete`         | EN snapshot が shallow/extractor-empty で比較不能  | advisory     |
+| `source-unusable`             | EN snapshot が malformed details で復元不能        | advisory     |
 
 **audit-only signals**: 上記の `audit-only` 印が付いた 9 種は coarse counting / shape / table-cell heuristics で、`segment-*` exact diff engine と重複した noise になりがちなため `parity-regression` issue body と gate exit code から除外される。`parity-check-status.json` には引き続き出力され、`deep-audit` workflow と `npm run check:parity -- --include-audit-signals` でのみ詳細を確認できる。`gate signal` 印は新規 / 欠落ページ検知のために gate にとどめる。allowlist は `scripts/lib/source_parity_types.mjs` の `COARSE_SIGNAL_TYPES` に集約されており、新 issue type を追加するときは review で「audit-only か gate-eligible か」を必ず判断する。
+
+**structure comparator (Issue #247)**: `alignSegments` が weighted LCS を走らせる前に、heading path が一致する section ごとに canonical block sequence を比較する。block 単位の語彙は `paragraph` / `ordered-list` / `unordered-list` / `callout-body` / `table` / `details-summary` の 6 種に凍結されており、segment 単位の list item / table cell は比較前に対応する list / table block に畳まれる。
+
+3 段階の fall-through で section あたり最大 1 件の diff を emit する:
+
+1. **kind-multiset** (`section-structure-mismatch`) — block 種別の多重集合が違う
+2. **kind-sequence** (`segment-order-mismatch`) — 多重集合は一致するが並び順が違う
+3. **content-order** (`segment-order-mismatch`) — kind 列は同じだが content bijection が monotonic でない
+
+いずれかが発火すると後続 stage は short-circuit され、alignSegments の weighted LCS も呼ばれない (section body に対して structure issue と segment diff が二重発火しないため)。
+
+**baseline identity**: structure 系 entry の machine identity は **`sectionIndex` + `structureCategory` + `structureFingerprint`** の 3 つ組 (`buildBaselineKey` / `buildBaselineKeyFromEntry`)。`structureFingerprint` は `structureCategory` + `enKinds` + `jaKinds` (content-order では `contentPermutation`) を sha256 に畳み込む。`sectionPath` は entry に保存するが identity key には含めない (同一ページ内で同じ heading text が複数現れる場合に sectionPath が一意にならないため、PR5 Finding 2)。
+
+**source unusability gate**: `detectSourceUsability()` は alignSegments 呼び出し前に EN snapshot の比較可能性を判定する。判定条件は以下:
+
+- `shallow-snapshot` (`snapshot-incomplete`) — raw EN HTML が 800 bytes 以下かつ EN body ≤ 2 かつ JA body ≥ 5 かつ JA/EN ratio ≥ 4
+- `extractor-empty` (`snapshot-incomplete`) — clean HTML なのに EN body が 0 で JA body ≥ 3
+- `escaped-details-residue` (`source-unusable`) — (通常経路) `&lt;/details&gt;` 残存 **または** open/close 不均衡 **かつ** `enHeadingSegmentCount === 0 && jaHeadingSegmentCount >= 2` を **両方** 満たす / (extractError 経路) `open !== close` の不均衡のみで判定
+
+`escaped-details-residue` は **狭く** narrowing されており、`<details>` 例を本文に含む合法ページ (`advanced-editing/coding-assistant` 等) は false positive にならない。発火したページでは alignSegments が呼ばれない (translation drift と snapshot debt を混ぜないため)。両者とも **advisory のみ** で gate exit code には寄与しないが、`summary.snapshotUnusable*` の独立 counter に集計される。
 
 **acknowledgements**: `parity-acknowledgements.json` で issue に acknowledgement を付与可能。slug + issueType + (detailIncludes or detailRegex) で一致。**issue を結果から削除せず**、`acknowledged: true` タグを付けて非 blocking 化する。`sourceFingerprint` と `reviewAfter` による自動失効あり。
 

--- a/scripts/__tests__/source_parity_clean_page_fixtures.test.mjs
+++ b/scripts/__tests__/source_parity_clean_page_fixtures.test.mjs
@@ -1,0 +1,121 @@
+/**
+ * Issue #247 PR6 — Confirmed zero-drift ページの false-positive sentinel。
+ *
+ * 対象ページ (plan 作成時に実測で確定):
+ *   - settings/cli-prerequisites
+ *     (enSegments=10, jaSegments=10, structureIssues=0, totalIssues=0)
+ *   - salesforce-testing/salesforce-testing-getting-started
+ *     (enSegments=79, jaSegments=79, structureIssues=0, totalIssues=0)
+ *
+ * 両ページとも EN/JA が完全整合している clean page で、PR5 base で
+ * parity-baseline.json / parity-acknowledgements.json のどちらにも
+ * エントリが無い。comparator が正しく動いている限り、structure issue は
+ * 0 件かつ segment-* diff も 0 件のはず。
+ *
+ * pin する契約:
+ *   1. section-structure-mismatch / segment-order-mismatch が 0 件
+ *      (false positive の主たるガード)
+ *   2. 総 issue 数も 0 件 (clean page なので drift が無い — より強い不変条件)
+ *   3. alignment が inconclusive にならない (健全ページで解析不能になる
+ *      のは regress のサイン)
+ *
+ * 当初検討された `advanced-editing/custom-action-step-mobile` と
+ * `results/test-runs` は両方とも実測で structure issue が 0 件ではない
+ * ため本 fixture からは除外。前者は Task 3 (representative summary) で
+ * 「baseline 吸収済み structure mismatch ページ」として扱う。
+ */
+import { before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+let alignSegments;
+let parityDiffsToIssues;
+let extractSegmentsFromHtml;
+let extractSegmentsFromMarkdown;
+
+before(async () => {
+  ({
+    alignSegments,
+    parityDiffsToIssues,
+    extractSegmentsFromHtml,
+    extractSegmentsFromMarkdown,
+  } = await import('../lib/source_parity.mjs'));
+});
+
+const ROOT = join(import.meta.dirname, '../../');
+const SNAPSHOTS_DIR = join(ROOT, 'snapshots/en/content');
+const JA_CONTENT_DIR = join(ROOT, 'src/content/docs');
+
+// ---------------------------------------------------------------------------
+// ヘルパ: JA md の frontmatter を除去し本文だけを返す。
+// source_parity_source_usability_fixtures.test.mjs (PR3) と同じ実装を
+// 複製する。lib への切り出しは production code change を伴うため PR6 では
+// 行わない。
+// ---------------------------------------------------------------------------
+function extractJaBody(mdContent) {
+  const withoutFm = mdContent.replace(/^---[\s\S]*?---\n/m, '');
+  return withoutFm.trim();
+}
+
+// ---------------------------------------------------------------------------
+// ヘルパ: Task 1 と同じ shape を返す。alignment を含めていないと
+// `const { alignment } = runStructureComparator(slug)` で TypeError になる。
+// ---------------------------------------------------------------------------
+function runStructureComparator(slug) {
+  const rawEnHtml = readFileSync(join(SNAPSHOTS_DIR, `${slug}.html`), 'utf8');
+  const jaMd = readFileSync(join(JA_CONTENT_DIR, `${slug}.md`), 'utf8');
+  const jaBody = extractJaBody(jaMd);
+  const enSegments = extractSegmentsFromHtml(rawEnHtml);
+  const jaSegments = extractSegmentsFromMarkdown(jaBody);
+  const alignment = alignSegments(enSegments, jaSegments);
+  const issues = parityDiffsToIssues(alignment.diffs);
+  const structureIssues = issues.filter(
+    (i) => i.type === 'section-structure-mismatch' || i.type === 'segment-order-mismatch',
+  );
+  return { alignment, issues, structureIssues };
+}
+
+// ---------------------------------------------------------------------------
+// plan 作成時に実測で zero-drift を確定した 2 ページ。配列の順序と要素は
+// PR6 実装時の回帰確認で前提が成立していることを確認済み。
+// ---------------------------------------------------------------------------
+const CLEAN_PAGE_SLUGS = Object.freeze([
+  'settings/cli-prerequisites',
+  'salesforce-testing/salesforce-testing-getting-started',
+]);
+
+for (const slug of CLEAN_PAGE_SLUGS) {
+  describe(`source_parity_clean_page_fixtures: ${slug}`, () => {
+    it('alignment が inconclusive にならない (健全 page の最低保証)', () => {
+      const { alignment } = runStructureComparator(slug);
+      assert.equal(
+        alignment.inconclusive ?? false,
+        false,
+        `${slug}: alignment.inconclusive === true になった — PR5 base では解析成功していたはず`,
+      );
+    });
+
+    it('section-structure-mismatch / segment-order-mismatch が 0 件 (false positive sentinel)', () => {
+      const { structureIssues } = runStructureComparator(slug);
+      assert.equal(
+        structureIssues.length,
+        0,
+        `${slug}: structure issue が ${structureIssues.length} 件検出された — ` +
+          `plan 前提 (zero-drift clean page) が崩れている。` +
+          `最初の issue: ${JSON.stringify(structureIssues[0] ?? null)}`,
+      );
+    });
+
+    it('総 issue 数も 0 件 (clean page の強い不変条件)', () => {
+      const { issues } = runStructureComparator(slug);
+      assert.equal(
+        issues.length,
+        0,
+        `${slug}: 総 issue 数が ${issues.length} 件 — ` +
+          `plan 前提では EN/JA が完全整合しており 0 件のはず。` +
+          `最初の issue: ${JSON.stringify(issues[0] ?? null)}`,
+      );
+    });
+  });
+}

--- a/scripts/__tests__/source_parity_representative_summary.test.mjs
+++ b/scripts/__tests__/source_parity_representative_summary.test.mjs
@@ -1,0 +1,166 @@
+/**
+ * Issue #247 PR6 — representative full-run summary contract test.
+ *
+ * 代表 6 ページに対して checkSourceParity({ slug }) を in-process で順次呼び、
+ * 生成された parity-check-status.json を読み取って各 page の summary
+ * counter を pin する。
+ *
+ * 対象 slug と期待分類:
+ *
+ *   | slug                                               | expected counters             |
+ *   | -------------------------------------------------- | ----------------------------- |
+ *   | running-tests/the-command-line-cli                 | structure baselined           |
+ *   | results/test-results/network-logs                  | structure baselined           |
+ *   | advanced-editing/validations/email-validation      | structure baselined           |
+ *   | salesforce-testing/faq                             | source-unusable baselined     |
+ *   | salesforce-testing/salesforce-testing-overview     | snapshot-incomplete baselined |
+ *   | advanced-editing/custom-action-step-mobile         | structure baselined (3 件) + segment-* baselined |
+ *
+ * pin する契約:
+ *   1. 全 slug で reportableActiveFiles === 0 (PR5 gate cutover が live
+ *      かつ baseline が有効)
+ *   2. structure 系 4 slug (the-command-line-cli / network-logs /
+ *      email-validation / custom-action-step-mobile) で structureMismatchIssues
+ *      === 0 (全件 baselined。active counter なので baseline 化されたものは
+ *      含まれず 0)
+ *   3. source-unusable 系 2 slug で snapshotUnusableIssues === 0 (全件
+ *      baselined) かつ reportableActiveFiles === 0
+ *   4. 全 slug で baselinedByType に「期待される type」が 1 件以上含まれている
+ *      ことを確認 (structure 系 4 slug は section-structure-mismatch、
+ *      source-unusable 系 2 slug は source-unusable / snapshot-incomplete)
+ *
+ * 手法:
+ *   既存 source_parity_align_runtime.test.mjs のバックアップパターンを使って
+ *   parity-check-status.json を退避し、slug ごとに checkSourceParity() を
+ *   呼んで read → assert → 次の slug に進む。
+ */
+import { before, after, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, copyFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+
+let checkSourceParity;
+
+before(async () => {
+  ({ checkSourceParity } = await import('../check_source_parity.mjs'));
+});
+
+const ROOT = join(import.meta.dirname, '../../');
+const STATUS_PATH = join(ROOT, 'parity-check-status.json');
+const STATUS_BACKUP_PATH = join(ROOT, 'parity-check-status.pr6-test-backup.json');
+
+before(() => {
+  if (existsSync(STATUS_PATH)) {
+    copyFileSync(STATUS_PATH, STATUS_BACKUP_PATH);
+  }
+});
+
+after(() => {
+  if (existsSync(STATUS_BACKUP_PATH)) {
+    copyFileSync(STATUS_BACKUP_PATH, STATUS_PATH);
+    unlinkSync(STATUS_BACKUP_PATH);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// ヘルパ: slug 絞りで checkSourceParity を呼び、status JSON を読み取って返す。
+// ---------------------------------------------------------------------------
+async function runForSlug(slug) {
+  const exitCode = await checkSourceParity({ slug, json: true });
+  if (!existsSync(STATUS_PATH)) {
+    throw new Error(
+      `checkSourceParity({ slug: ${JSON.stringify(slug)} }) が status file を書かなかった`,
+    );
+  }
+  const status = JSON.parse(readFileSync(STATUS_PATH, 'utf8'));
+  return { exitCode, status };
+}
+
+// ---------------------------------------------------------------------------
+// 代表 slug の共通契約 (全 slug で 0 になる counter)
+// ---------------------------------------------------------------------------
+const COMMON_ZERO_COUNTERS = Object.freeze({
+  reportableActiveFiles: 0,
+  structureMismatchIssues: 0,
+  snapshotUnusableIssues: 0,
+  reportableActiveActionableFiles: 0,
+});
+
+// ---------------------------------------------------------------------------
+// slug ごとの baselinedByType 下限。
+// 「少なくともこの type が baseline に含まれていること」を pin する。
+// 個別件数の drift は Task 1 (structure fixture) が捕まえるため、
+// ここでは type の存在だけを確認する。
+// ---------------------------------------------------------------------------
+const PINNED_PAGES = Object.freeze([
+  {
+    slug: 'running-tests/the-command-line-cli',
+    // section-structure-mismatch × 10 が baselined
+    requiredBaselinedTypes: ['section-structure-mismatch'],
+  },
+  {
+    slug: 'results/test-results/network-logs',
+    // section-structure-mismatch × 2 が baselined
+    requiredBaselinedTypes: ['section-structure-mismatch'],
+  },
+  {
+    slug: 'advanced-editing/validations/email-validation',
+    // section-structure-mismatch × 2 が baselined
+    requiredBaselinedTypes: ['section-structure-mismatch'],
+  },
+  {
+    slug: 'salesforce-testing/faq',
+    // source-unusable × 1 が baselined
+    requiredBaselinedTypes: ['source-unusable'],
+  },
+  {
+    slug: 'salesforce-testing/salesforce-testing-overview',
+    // snapshot-incomplete × 1 が baselined
+    requiredBaselinedTypes: ['snapshot-incomplete'],
+  },
+  {
+    slug: 'advanced-editing/custom-action-step-mobile',
+    // PR5 base で section-structure-mismatch × 3 + segment-* × 7 が全件 baseline 化。
+    // representative summary 上は active counter が全て 0。
+    // 「baseline で structure mismatch を吸収しているページ」として
+    // section-structure-mismatch を必須型に含める。
+    requiredBaselinedTypes: ['section-structure-mismatch'],
+  },
+]);
+
+// ---------------------------------------------------------------------------
+// slug ごとに describe を分け、before() で 1 度だけ checkSourceParity を呼ぶ。
+// 同一 describe 内の 2 it() で結果を使い回す (in-process 呼び出しの回数を半減)。
+// ---------------------------------------------------------------------------
+for (const pin of PINNED_PAGES) {
+  describe(`source_parity_representative_summary: ${pin.slug}`, () => {
+    let cached = null;
+    before(async () => {
+      cached = await runForSlug(pin.slug);
+    });
+
+    it('gate exit code が 0 かつ reportable*/structure/unusable counter が 0', () => {
+      const { exitCode, status } = cached;
+      const s = status.summary;
+      assert.equal(exitCode, 0, `${pin.slug}: exitCode drift (pin=0, actual=${exitCode})`);
+      for (const [key, expected] of Object.entries(COMMON_ZERO_COUNTERS)) {
+        assert.equal(
+          s[key] || 0,
+          expected,
+          `${pin.slug}: summary.${key} drift (pin=${expected}, actual=${s[key] || 0})`,
+        );
+      }
+    });
+
+    it('baseline に必要な issue type が含まれている (advisory ではなく baselined で吸収)', () => {
+      const byType = cached.status.summary.baselinedByType || {};
+      for (const requiredType of pin.requiredBaselinedTypes) {
+        assert.ok(
+          (byType[requiredType] || 0) >= 1,
+          `${pin.slug}: baselinedByType[${requiredType}] が 0 — PR5 baseline で吸収されるべき ` +
+            `(actual: ${JSON.stringify(byType)})`,
+        );
+      }
+    });
+  });
+}

--- a/scripts/__tests__/source_parity_structure_fixtures.test.mjs
+++ b/scripts/__tests__/source_parity_structure_fixtures.test.mjs
@@ -1,0 +1,255 @@
+/**
+ * Issue #247 PR6 — 代表ページに対する canonical block sequence comparator
+ * の実 snapshot + 実 JA md 回帰 fixture テスト。
+ *
+ * 対象 3 ページ (Issue #247 本文で structure mismatch として明示されたもの):
+ *   - running-tests/the-command-line-cli
+ *   - results/test-results/network-logs
+ *   - advanced-editing/validations/email-validation
+ *
+ * pin する契約:
+ *   1. alignSegments → parityDiffsToIssues 経由で section-structure-mismatch /
+ *      segment-order-mismatch が **少なくとも 1 件** emit される (false red
+ *      回帰の防止)
+ *   2. 各 page で emit される structure issue の件数が PR5 baseline と一致する
+ *      (drift 発生時のシグナル)
+ *   3. 先頭 issue の structureCategory / sectionPath / enKinds / jaKinds が
+ *      固定の期待値と一致する (comparator の出力契約の固定)
+ *
+ * このテストは gate 側の挙動 (baseline tagging / acknowledgement tagging /
+ * exit code) には触れない — それは §Task 3 の representative summary test が
+ * 担当する。ここは **comparator の raw 出力** だけを pin する。
+ */
+import { before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+let alignSegments;
+let parityDiffsToIssues;
+let extractSegmentsFromHtml;
+let extractSegmentsFromMarkdown;
+
+before(async () => {
+  ({
+    alignSegments,
+    parityDiffsToIssues,
+    extractSegmentsFromHtml,
+    extractSegmentsFromMarkdown,
+  } = await import('../lib/source_parity.mjs'));
+});
+
+const ROOT = join(import.meta.dirname, '../../');
+const SNAPSHOTS_DIR = join(ROOT, 'snapshots/en/content');
+const JA_CONTENT_DIR = join(ROOT, 'src/content/docs');
+
+// ---------------------------------------------------------------------------
+// ヘルパ: JA md の frontmatter を除去し本文だけを返す。
+// source_parity_source_usability_fixtures.test.mjs (PR3) と同じ実装を
+// 複製する。lib への切り出しは production code change を伴うため PR6 では
+// 行わない。
+// ---------------------------------------------------------------------------
+function extractJaBody(mdContent) {
+  const withoutFm = mdContent.replace(/^---[\s\S]*?---\n/m, '');
+  return withoutFm.trim();
+}
+
+// ---------------------------------------------------------------------------
+// ヘルパ: 代表ページを読み込んで structure issue だけを返す。
+// ---------------------------------------------------------------------------
+function runStructureComparator(slug) {
+  const rawEnHtml = readFileSync(join(SNAPSHOTS_DIR, `${slug}.html`), 'utf8');
+  const jaMd = readFileSync(join(JA_CONTENT_DIR, `${slug}.md`), 'utf8');
+  const jaBody = extractJaBody(jaMd);
+
+  const enSegments = extractSegmentsFromHtml(rawEnHtml);
+  const jaSegments = extractSegmentsFromMarkdown(jaBody);
+  const alignment = alignSegments(enSegments, jaSegments);
+  const issues = parityDiffsToIssues(alignment.diffs);
+  const structureIssues = issues.filter(
+    (i) => i.type === 'section-structure-mismatch' || i.type === 'segment-order-mismatch',
+  );
+  return { alignment, issues, structureIssues };
+}
+
+// ---------------------------------------------------------------------------
+// pin 値 (Step 3 の実測で確定)
+// ---------------------------------------------------------------------------
+
+const PINNED_THE_CLI = Object.freeze({
+  slug: 'running-tests/the-command-line-cli',
+  structureIssueCount: 10,
+  byType: { 'section-structure-mismatch': 10, 'segment-order-mismatch': 0 },
+  byCategory: {
+    'kind-multiset': 10,
+    'kind-sequence': 0,
+    'content-order': 0,
+  },
+  firstIssue: {
+    type: 'section-structure-mismatch',
+    structureCategory: 'kind-multiset',
+    sectionPath: 'CLI Installation > Basic CLI command',
+    sectionIndex: 3,
+    enKinds: [
+      'paragraph', 'ordered-list', 'paragraph', 'paragraph', 'paragraph',
+      'paragraph', 'paragraph', 'paragraph', 'paragraph', 'paragraph',
+      'paragraph', 'paragraph', 'ordered-list',
+    ],
+    jaKinds: [
+      'paragraph', 'paragraph', 'ordered-list', 'paragraph', 'paragraph', 'ordered-list',
+    ],
+    enSegmentCount: 13,
+    jaSegmentCount: 6,
+  },
+});
+
+const PINNED_NETWORK_LOGS = Object.freeze({
+  slug: 'results/test-results/network-logs',
+  structureIssueCount: 2,
+  byType: { 'section-structure-mismatch': 2, 'segment-order-mismatch': 0 },
+  byCategory: {
+    'kind-multiset': 2,
+    'kind-sequence': 0,
+    'content-order': 0,
+  },
+  firstIssue: {
+    type: 'section-structure-mismatch',
+    structureCategory: 'kind-multiset',
+    sectionPath: 'Viewing the network logs at the step level > Filtering request results',
+    sectionIndex: 2,
+    enKinds: [
+      'paragraph', 'ordered-list', 'paragraph', 'paragraph', 'paragraph',
+      'paragraph', 'paragraph', 'paragraph', 'ordered-list', 'paragraph',
+      'callout-body', 'paragraph', 'ordered-list', 'paragraph',
+    ],
+    jaKinds: [
+      'paragraph', 'ordered-list', 'paragraph', 'paragraph',
+      'ordered-list', 'paragraph', 'callout-body', 'paragraph', 'ordered-list', 'paragraph',
+    ],
+    enSegmentCount: 14,
+    jaSegmentCount: 10,
+  },
+});
+
+const PINNED_EMAIL_VALIDATION = Object.freeze({
+  slug: 'advanced-editing/validations/email-validation',
+  structureIssueCount: 2,
+  byType: { 'section-structure-mismatch': 2, 'segment-order-mismatch': 0 },
+  byCategory: {
+    'kind-multiset': 2,
+    'kind-sequence': 0,
+    'content-order': 0,
+  },
+  firstIssue: {
+    type: 'section-structure-mismatch',
+    structureCategory: 'kind-multiset',
+    sectionPath: '',
+    sectionIndex: 0,
+    enKinds: [
+      'paragraph', 'callout-body', 'paragraph', 'table',
+      'paragraph', 'unordered-list', 'paragraph', 'callout-body',
+    ],
+    jaKinds: [
+      'paragraph', 'paragraph', 'callout-body', 'paragraph', 'table',
+      'paragraph', 'unordered-list', 'paragraph', 'callout-body',
+    ],
+    enSegmentCount: 8,
+    jaSegmentCount: 9,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// 共通アサーションヘルパ。3 page で同じ構造の pin を assert するので 1 つに集約する。
+// ---------------------------------------------------------------------------
+function assertStructurePin(slug, pinned) {
+  const { structureIssues } = runStructureComparator(slug);
+
+  // 件数 contract
+  assert.equal(
+    structureIssues.length,
+    pinned.structureIssueCount,
+    `${slug}: structure issue 件数 drift (pin=${pinned.structureIssueCount}, actual=${structureIssues.length})`,
+  );
+
+  // 少なくとも 1 件は出るはず (false red 回帰ガード)
+  assert.ok(
+    structureIssues.length >= 1,
+    `${slug}: structure issue が 0 件になった — PR5 baseline では active であるべき`,
+  );
+
+  // type 別内訳
+  const byType = structureIssues.reduce((acc, i) => {
+    acc[i.type] = (acc[i.type] || 0) + 1;
+    return acc;
+  }, {});
+  for (const [type, expected] of Object.entries(pinned.byType)) {
+    assert.equal(
+      byType[type] || 0,
+      expected,
+      `${slug}: ${type} の件数 drift (pin=${expected}, actual=${byType[type] || 0})`,
+    );
+  }
+
+  // category 別内訳
+  const byCategory = structureIssues.reduce((acc, i) => {
+    acc[i.structureCategory] = (acc[i.structureCategory] || 0) + 1;
+    return acc;
+  }, {});
+  for (const [cat, expected] of Object.entries(pinned.byCategory)) {
+    assert.equal(
+      byCategory[cat] || 0,
+      expected,
+      `${slug}: structureCategory=${cat} の件数 drift (pin=${expected}, actual=${byCategory[cat] || 0})`,
+    );
+  }
+
+  // 先頭 issue の payload contract
+  const first = structureIssues[0];
+  assert.equal(first.type, pinned.firstIssue.type, `${slug}: firstIssue.type drift`);
+  assert.equal(
+    first.structureCategory,
+    pinned.firstIssue.structureCategory,
+    `${slug}: firstIssue.structureCategory drift`,
+  );
+  assert.equal(first.sectionPath, pinned.firstIssue.sectionPath, `${slug}: firstIssue.sectionPath drift`);
+  assert.equal(first.sectionIndex, pinned.firstIssue.sectionIndex, `${slug}: firstIssue.sectionIndex drift`);
+  assert.deepEqual(first.enKinds, pinned.firstIssue.enKinds, `${slug}: firstIssue.enKinds drift`);
+  assert.deepEqual(first.jaKinds, pinned.firstIssue.jaKinds, `${slug}: firstIssue.jaKinds drift`);
+  assert.equal(
+    first.enSegmentCount,
+    pinned.firstIssue.enSegmentCount,
+    `${slug}: firstIssue.enSegmentCount drift`,
+  );
+  assert.equal(
+    first.jaSegmentCount,
+    pinned.firstIssue.jaSegmentCount,
+    `${slug}: firstIssue.jaSegmentCount drift`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 代表ページ 1: running-tests/the-command-line-cli
+// ---------------------------------------------------------------------------
+describe('source_parity_structure_fixtures: running-tests/the-command-line-cli', () => {
+  it('structure issue 件数 / category / 先頭 issue の payload が PR5 baseline と一致する', () => {
+    assertStructurePin(PINNED_THE_CLI.slug, PINNED_THE_CLI);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 代表ページ 2: results/test-results/network-logs
+// ---------------------------------------------------------------------------
+describe('source_parity_structure_fixtures: results/test-results/network-logs', () => {
+  it('structure issue 件数 / category / 先頭 issue の payload が PR5 baseline と一致する', () => {
+    assertStructurePin(PINNED_NETWORK_LOGS.slug, PINNED_NETWORK_LOGS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 代表ページ 3: advanced-editing/validations/email-validation
+// ---------------------------------------------------------------------------
+describe('source_parity_structure_fixtures: advanced-editing/validations/email-validation', () => {
+  it('structure issue 件数 / category / 先頭 issue の payload が PR5 baseline と一致する', () => {
+    assertStructurePin(PINNED_EMAIL_VALIDATION.slug, PINNED_EMAIL_VALIDATION);
+  });
+});


### PR DESCRIPTION
## Summary

Issue #247 PR6 — PR1〜PR5 で導入した structure gate / source usability 検出 / baseline migration の **実ページ fixture 回帰 pin** と docs 追記。**production code には一切手を入れず**、新規 test 3 本と docs 2 ファイルの変更のみ。

### 追加する fixture
- `scripts/__tests__/source_parity_structure_fixtures.test.mjs` — 3 代表ページ (`the-command-line-cli` / `network-logs` / `email-validation`) の structure mismatch 件数 / payload 契約を pin (false red sentinel)
- `scripts/__tests__/source_parity_clean_page_fixtures.test.mjs` — 2 confirmed zero-drift ページ (`settings/cli-prerequisites` / `salesforce-testing/salesforce-testing-getting-started`) の 0 件契約を pin (false positive sentinel)
- `scripts/__tests__/source_parity_representative_summary.test.mjs` — 6 代表ページの end-to-end summary counter を pin

### docs 更新
- `docs/OPS_DESIGN.md` — Structure comparator / Source unusable 節の追記
- `scripts/README.md` — issue 表 4 行追加 + structure comparator / source usability gate のサブ節追記

### Stacked PR 順序
PR1 (taxonomy) → PR2 (structure comparator) → PR3 (source usability) → PR4 (baseline migration tool) → PR5 (baseline migration / gate cutover) → **PR6 (この PR: fixture pin + docs)**

## Test plan

### 新規テスト (21 tests 追加)
- [x] Task 1: `source_parity_structure_fixtures.test.mjs` — 3 tests pass
- [x] Task 2: `source_parity_clean_page_fixtures.test.mjs` — 6 tests pass (2 slug × 3 it)
- [x] Task 3: `source_parity_representative_summary.test.mjs` — 12 tests pass (6 slug × 2 it)

### フル検証
- [x] `npm test` — 1532 tests pass (0 fail)
- [x] `npm run lint` — 0 error / 0 warning
- [x] `npm run build` — astro check 0 error → 290 pages built
- [x] `npm run check:parity` → exit code 0

### gate contract (不変条件)
| counter | 実測値 |
| --- | --- |
| `reportableActiveFiles` | 0 |
| `reportableActiveActionableFiles` | 0 |
| `activeErrorFiles` | 0 |
| `structureMismatchIssues` | 0 |
| `snapshotUnusableIssues` | 0 |

### 6 代表ページ checkSourceParity 実測値サマリ (Task 3 Step 3)

| slug | exitCode | reportableActiveFiles | baselinedIssues | baselinedByType (抜粋) |
| --- | --- | --- | --- | --- |
| `running-tests/the-command-line-cli` | 0 | 0 | 39 | section-structure-mismatch:10, segment-missing:17, ... |
| `results/test-results/network-logs` | 0 | 0 | 8 | section-structure-mismatch:2, segment-missing:5, ... |
| `advanced-editing/validations/email-validation` | 0 | 0 | 7 | section-structure-mismatch:2, ... |
| `salesforce-testing/faq` | 0 | 0 | 1 | source-unusable:1 |
| `salesforce-testing/salesforce-testing-overview` | 0 | 0 | 1 | snapshot-incomplete:1 |
| `advanced-editing/custom-action-step-mobile` | 0 | 0 | 10 | section-structure-mismatch:3, segment-extra:4, ... |

参考値: `summary.baselinedIssues` (全体) = 1314 件 — 絶対値は base rebase / baseline 再生成で drift しうるため pin しない。


## 実装詳細設計

# Issue #247 PR6 — Fixture 仕上げ + Representative Full Verification 実装詳細設計書

> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

**Goal:** Issue #247 の structure gate 切替 (PR1〜PR5) を実ページ fixture で回帰固定し、今回問題になった代表ページ (`the-command-line-cli` / `network-logs` / `email-validation` / `salesforce-testing/faq` / `salesforce-testing-overview` / `custom-action-step-mobile`) の期待分類をテストで pin するとともに、運用ドキュメントに「何を structure mismatch とみなすか / 何を source unusable とみなすか」を追記する。

**Architecture:** 既存 `source_parity_source_usability_fixtures.test.mjs` (PR3) と同じ **実 snapshot ファイル + 実 JA md を読み込んで pipeline helper を直接呼ぶ in-process fixture テスト** のパターンを structure comparator に拡張する。gate exit code の end-to-end 挙動は `checkSourceParity()` を直接 import して代表ページ集合に対して実行し、`summarizeParityResults()` と同じ summary counter を pin する。実装コードは **PR1〜PR5 で完了済み** のため PR6 では production コードは変更せず、新規テスト・docs 追記のみを行う (production code change があるなら refactor ではなく別 PR の範疇)。

**Tech Stack:** Node 22 `node:test` ランナー / `node:assert/strict` / 既存 `source_parity_*.mjs` pure API (`compareSectionStructure` / `alignSegments` / `parityDiffsToIssues` / `extractSegmentsFromHtml` / `extractSegmentsFromMarkdown` / `detectSourceUsability` / `checkSourceParity` / `summarizeParityResults`) / `parity-baseline.json` / `parity-acknowledgements.json`.

---

## スコープ外 (PR6 では扱わない)

以下は Issue #247 の PR6 セクションに含まれていないため意図的に **含めない**。

- mutation corpus への structure-level mutation 追加 (paragraph merge / list→paragraph collapse など) — 既存 recall test は segment-level mutation で 100% recall を保っており、PR6 完了条件 (実ページ fixture による回帰固定) には structure-level mutation は不要
- `isReportableParityIssue` / `BASELINE_ELIGIBLE_TYPES` など gate 契約の再変更 — PR5 cutover 済み
- 新 issue type の追加 — PR1 で taxonomy 固定済み
- `WRITING_GUIDE.md` の翻訳者向け加筆 — 「docs に何を structure mismatch とみなすか追記」の完了条件は OPS_DESIGN.md + scripts/README.md で満たせる
- production code の変更 (comparator / summary / baseline / runtime) — PR6 で追加テストを書いた結果として bug が見つかった場合は **別 PR (PR6-followup)** として切り出す。PR6 は regression pin の PR
- `parity-baseline.json` / `parity-acknowledgements.json` の entry 追加 — 既存 baseline entry で reportableActiveFiles=0 が成立することを PR5 で確認済みのため、PR6 はその状態を **読み取って pin するだけ**

---

## 前提 (PR5 時点の状態と PR6 が信頼する計測値)

PR5 (`pr5-baseline-migration-gate-cutover`) を base に PR6 ブランチを切る。PR5 完了時点で以下が **既に成立している** ことを前提とする。

| 項目 | 値 (PR5 測定値) | 出典 |
| --- | --- | --- |
| `npm run check:parity` exit code | `0` | PR5 body |
| `summary.reportableActiveFiles` | `0` | PR5 body |
| `summary.baselinedIssues` | `1314` (PR5 body 執筆時点の参考値 — base rebase / baseline 再生成で drift しうるため Task 6 では equality pin しない) | PR5 body |
| `parity-baseline.json` total entries | `1317` (うち schema 差 3) | 本 plan 検証時 `wc -l` |
| `section-structure-mismatch` baseline entries | `274` (196 slugs) | `parity-baseline.json` 集計 |
| `segment-order-mismatch` baseline entries | `5` (5 slugs) | 同上 |
| `snapshot-incomplete` baseline entries | `2` (2 slugs) | 同上 |
| `source-unusable` baseline entries | `1` (1 slug: `salesforce-testing/faq`) | 同上 |
| 代表ページ `running-tests/the-command-line-cli` の `section-structure-mismatch` baseline | `10` 件 | PR4 test plan |
| 代表ページ `results/test-results/network-logs` の `section-structure-mismatch` baseline | `2` 件 | PR4 test plan |
| 代表ページ `advanced-editing/validations/email-validation` の `section-structure-mismatch` baseline | `2` 件 | PR4 test plan |
| `salesforce-testing/faq` の `detectSourceUsability` 結果 | `source-unusable` / `escaped-details-residue` | PR3 fixture test |
| `salesforce-testing/salesforce-testing-overview` の `detectSourceUsability` 結果 | `snapshot-incomplete` / `shallow-snapshot` | PR3 fixture test |
| `advanced-editing/custom-action-step-mobile` baseline entry 種別 | `section-structure-mismatch` × 3 + `segment-*` × 7 (= 10 件すべて baseline 済み)。**0 件 ではない** — 過去 plan の前提誤り。本 plan では representative summary 側で「baseline 吸収済みの structure mismatch ページ」として扱う | `parity-baseline.json` 集計 |
| `settings/cli-prerequisites` の runtime 出力 | enSegments=10 / jaSegments=10 / `structureIssueCount=0` / `totalIssueCount=0` / inconclusive=false。**baseline エントリも無し**。Task 2 の confirmed zero-case として使用 | plan 作成時に `node --input-type=module -e '...'` で実測 |
| `salesforce-testing/salesforce-testing-getting-started` の runtime 出力 | enSegments=79 / jaSegments=79 / `structureIssueCount=0` / `totalIssueCount=0` / inconclusive=false。**baseline エントリも無し**。Task 2 の confirmed zero-case として使用 | plan 作成時に `node --input-type=module -e '...'` で実測 |

**注意**: 上記の具体的な件数 (10 / 2 / 2) は **PR6 実装時に再計測してから pin する**。PR5 body の数値は執筆時点のスナップショットで、base branch が rebase される場合に drift する可能性がある。pinning の前に必ず `node -e` 診断コマンド (§Task 1 Step 3 参照) で actual 値を確認してから固定する。

---

## File Structure

### 新規作成ファイル (3 本)

| ファイル | 責務 | サイズ目安 |
| --- | --- | --- |
| `scripts/__tests__/source_parity_structure_fixtures.test.mjs` | 代表ページに対して `extractSegmentsFromHtml` + `extractSegmentsFromMarkdown` + `alignSegments` + `parityDiffsToIssues` を in-process で走らせ、`section-structure-mismatch` / `segment-order-mismatch` の件数 / `structureCategory` / `sectionPath` / `enKinds` / `jaKinds` などの payload contract を pin する (false red 側の回帰) | ~350 行 |
| `scripts/__tests__/source_parity_clean_page_fixtures.test.mjs` | PR5 base で **実測済み** の zero-drift ページ (`settings/cli-prerequisites` / `salesforce-testing/salesforce-testing-getting-started`) に対して同じ pipeline を走らせ、**structure mismatch 0 件** かつ **総 issue 数 0 件** であることを pin する。将来 comparator が degrade して健全ページで false positive を出すようになったら即赤化する false-positive sentinel。**`custom-action-step-mobile` / `results/test-runs` はどちらも実測で 0 件にはならないため本 fixture の対象外** — `custom-action-step-mobile` は Task 3 (representative summary) で「baseline 吸収済み structure mismatch ページ」として扱う | ~140 行 |
| `scripts/__tests__/source_parity_representative_summary.test.mjs` | `checkSourceParity({ slug })` を代表ページ分だけ順次呼び、生成された `parity-check-status.json` を読み取って ページ単位に `summary.structureMismatchIssues` / `summary.snapshotUnusableIssues` / `summary.reportableActiveFiles` / 各 issue type 件数を pin。end-to-end な baseline tagging + acknowledgement tagging を経由した **representative full run の expected summary** を契約として固定する | ~280 行 |

### 修正ファイル (2 本)

| ファイル | 修正内容 |
| --- | --- |
| `docs/OPS_DESIGN.md` | `## Source Parity チェック` 配下に「structure comparator と block-sequence 保持」と「source unusable の 3 理由」のサブ節を追記。`## チェックの保証範囲` の表の「保証する」列に structure 保持の 1 項目を追記 |
| `scripts/README.md` | `check_source_parity.mjs` の issue 表に 4 行追加 (`section-structure-mismatch` / `segment-order-mismatch` / `snapshot-incomplete` / `source-unusable`) + 「structure comparator 概要」と「block 単位 kind 語彙」のサブ節を追記 |

### 意図的に変更しないファイル

以下は PR6 では **変更禁止**。触る必要があると判断した場合は別 PR に分離する。

- `scripts/lib/source_parity_*.mjs` (全 production module)
- `scripts/check_source_parity.mjs` (runtime)
- `parity-baseline.json` / `parity-acknowledgements.json`
- `docs/WRITING_GUIDE.md` / `docs/TRANSLATION_GUIDE.md`
- `scripts/__tests__/source_parity_source_usability_fixtures.test.mjs` (PR3 の assets。structure comparator 側から参照する場合でも import のみ)

---

## Task 1: 代表ページ fixture integration test (structure mismatch 系)

**Files:**
- Create: `scripts/__tests__/source_parity_structure_fixtures.test.mjs`

**目的:** Issue #247 で問題になった 3 ページ (`running-tests/the-command-line-cli` / `results/test-results/network-logs` / `advanced-editing/validations/email-validation`) を実 snapshot + 実 JA md から pipeline 全体に通し、`section-structure-mismatch` が意図した section で意図した category / kinds と共に emit されることを pin する。**これにより将来 comparator の挙動が static な意味で drift した場合にテストが赤化する**。

**前提となる API 読み取り:**

```js
// scripts/lib/source_parity.mjs (barrel)
import {
  alignSegments,               // (enSegments, jaSegments) => { diffs, inconclusive, ... }
  parityDiffsToIssues,         // (diffs) => issues[]
  extractSegmentsFromHtml,     // (rawHtml) => segments[]
  extractSegmentsFromMarkdown, // (body) => segments[]
} from '../lib/source_parity.mjs';

// issue payload contract (source_parity_structure.mjs の JSDoc より):
// {
//   type: 'section-structure-mismatch' | 'segment-order-mismatch',
//   severity: 'actionable',
//   scope: 'section',
//   sectionPath: string,
//   sectionIndex: number,          // 0-based document order
//   structureCategory: 'kind-multiset' | 'kind-sequence' | 'content-order',
//   enKinds: string[],             // STRUCTURE_COMPARATOR_KINDS: paragraph | ordered-list | unordered-list | callout-body | table | details-summary
//   jaKinds: string[],
//   enSegmentCount: number,
//   jaSegmentCount: number,
//   detail: string,                // 人間向け自由記述 (契約外)
//   contentPermutation?: Array<{enIndex, jaIndex, score}>,
// }
```

- [x] **Step 1: 失敗するテストの骨格を書く**

`scripts/__tests__/source_parity_structure_fixtures.test.mjs` を新規作成。最初は placeholder `assert.fail('pin me')` を入れて意図的に赤化させる。frontmatter 除去ヘルパは PR3 の既存 fixture test (`source_parity_source_usability_fixtures.test.mjs`) と同じ実装を複製する (pure で小さい) — PR6 は production コードに触らない契約のため、ヘルパを lib に切り出すのも避ける。

```js
/**
 * Issue #247 PR6 — 代表ページに対する canonical block sequence comparator
 * の実 snapshot + 実 JA md 回帰 fixture テスト。
 *
 * 対象 3 ページ (Issue #247 本文で structure mismatch として明示されたもの):
 *   - running-tests/the-command-line-cli
 *   - results/test-results/network-logs
 *   - advanced-editing/validations/email-validation
 *
 * pin する契約:
 *   1. alignSegments → parityDiffsToIssues 経由で section-structure-mismatch /
 *      segment-order-mismatch が **少なくとも 1 件** emit される (false red
 *      回帰の防止)
 *   2. 各 page で emit される structure issue の件数が PR5 baseline と一致する
 *      (drift 発生時のシグナル)
 *   3. 先頭 issue の structureCategory / sectionPath / enKinds / jaKinds が
 *      固定の期待値と一致する (comparator の出力契約の固定)
 *
 * このテストは gate 側の挙動 (baseline tagging / acknowledgement tagging /
 * exit code) には触れない — それは §Task 3 の representative summary test が
 * 担当する。ここは **comparator の raw 出力** だけを pin する。
 */
import { before, describe, it } from 'node:test';
import assert from 'node:assert/strict';
import { readFileSync } from 'node:fs';
import { join } from 'node:path';

let alignSegments;
let parityDiffsToIssues;
let extractSegmentsFromHtml;
let extractSegmentsFromMarkdown;

before(async () => {
  ({
    alignSegments,
    parityDiffsToIssues,
    extractSegmentsFromHtml,
    extractSegmentsFromMarkdown,
  } = await import('../lib/source_parity.mjs'));
});

const ROOT = join(import.meta.dirname, '../../');
const SNAPSHOTS_DIR = join(ROOT, 'snapshots/en/content');
const JA_CONTENT_DIR = join(ROOT, 'src/content/docs');

// ---------------------------------------------------------------------------
// ヘルパ: JA md の frontmatter を除去し本文だけを返す。
// source_parity_source_usability_fixtures.test.mjs (PR3) と同じ実装を
// 複製する。lib への切り出しは production code change を伴うため PR6 では
// 行わない。
// ---------------------------------------------------------------------------
function extractJaBody(mdContent) {
  const withoutFm = mdContent.replace(/^---[\s\S]*?---\n/m, '');
  return withoutFm.trim();
}

// ---------------------------------------------------------------------------
// ヘルパ: 代表ページを読み込んで structure issue だけを返す。
// ---------------------------------------------------------------------------
function runStructureComparator(slug) {
  const rawEnHtml = readFileSync(join(SNAPSHOTS_DIR, `${slug}.html`), 'utf8');
  const jaMd = readFileSync(join(JA_CONTENT_DIR, `${slug}.md`), 'utf8');
  const jaBody = extractJaBody(jaMd);

  const enSegments = extractSegmentsFromHtml(rawEnHtml);
  const jaSegments = extractSegmentsFromMarkdown(jaBody);
  const alignment = alignSegments(enSegments, jaSegments);
  const issues = parityDiffsToIssues(alignment.diffs);
  const structureIssues = issues.filter(
    (i) => i.type === 'section-structure-mismatch' || i.type === 'segment-order-mismatch',
  );
  return { alignment, issues, structureIssues };
}

// ---------------------------------------------------------------------------
// 代表ページ 1: running-tests/the-command-line-cli
// ---------------------------------------------------------------------------
describe('source_parity_structure_fixtures: running-tests/the-command-line-cli', () => {
  it('section-structure-mismatch が pin された件数で emit される', () => {
    assert.fail('pin me — Step 3 で実測後に固定');
  });
});

// ---------------------------------------------------------------------------
// 代表ページ 2: results/test-results/network-logs
// ---------------------------------------------------------------------------
describe('source_parity_structure_fixtures: results/test-results/network-logs', () => {
  it('section-structure-mismatch が pin された件数で emit される', () => {
    assert.fail('pin me — Step 3 で実測後に固定');
  });
});

// ---------------------------------------------------------------------------
// 代表ページ 3: advanced-editing/validations/email-validation
// ---------------------------------------------------------------------------
describe('source_parity_structure_fixtures: advanced-editing/validations/email-validation', () => {
  it('section-structure-mismatch が pin された件数で emit される', () => {
    assert.fail('pin me — Step 3 で実測後に固定');
  });
});
```

- [x] **Step 2: テストが失敗することを確認する**

```bash
node --test scripts/__tests__/source_parity_structure_fixtures.test.mjs
```
Expected: 3 failures, all from `assert.fail('pin me — Step 3 で実測後に固定')`。

- [x] **Step 3: 実測して pin する値を確定する**

新規 production code を書かずに actual 値を得るため、以下を一度だけ実行する (結果を step 4 にコピーする用)。

```bash
node --input-type=module -e '
import { readFileSync } from "node:fs";
import { join } from "node:path";
import {
  alignSegments,
  parityDiffsToIssues,
  extractSegmentsFromHtml,
  extractSegmentsFromMarkdown,
} from "./scripts/lib/source_parity.mjs";

const SLUGS = [
  "running-tests/the-command-line-cli",
  "results/test-results/network-logs",
  "advanced-editing/validations/email-validation",
];

function extractBody(md) { return md.replace(/^---[\\s\\S]*?---\\n/m, "").trim(); }

for (const slug of SLUGS) {
  const html = readFileSync(`snapshots/en/content/${slug}.html`, "utf8");
  const ja   = extractBody(readFileSync(`src/content/docs/${slug}.md`, "utf8"));
  const en   = extractSegmentsFromHtml(html);
  const js   = extractSegmentsFromMarkdown(ja);
  const al   = alignSegments(en, js);
  const iss  = parityDiffsToIssues(al.diffs);
  const st   = iss.filter((i) => i.type === "section-structure-mismatch" || i.type === "segment-order-mismatch");
  console.log("===", slug, "===");
  console.log("  structureIssueCount:", st.length);
  console.log("  byCategory:", Object.fromEntries(
    Object.entries(st.reduce((a, i) => (a[i.structureCategory] = (a[i.structureCategory] || 0) + 1, a), {}))
  ));
  console.log("  byType:", Object.fromEntries(
    Object.entries(st.reduce((a, i) => (a[i.type] = (a[i.type] || 0) + 1, a), {}))
  ));
  if (st.length > 0) {
    const first = st[0];
    console.log("  first:", {
      type: first.type,
      structureCategory: first.structureCategory,
      sectionPath: first.sectionPath,
      sectionIndex: first.sectionIndex,
      enKinds: first.enKinds,
      jaKinds: first.jaKinds,
      enSegmentCount: first.enSegmentCount,
      jaSegmentCount: first.jaSegmentCount,
    });
  }
}
'
```

Expected output shape:
```
=== running-tests/the-command-line-cli ===
  structureIssueCount: <NUMBER>
  byCategory: { "kind-multiset": <n>, ... }
  byType: { "section-structure-mismatch": <n>, ... }
  first: { type: "section-structure-mismatch", structureCategory: "kind-multiset", sectionPath: "...", sectionIndex: <n>, enKinds: [...], jaKinds: [...], ... }
=== results/test-results/network-logs ===
  ...
=== advanced-editing/validations/email-validation ===
  ...
```

この出力を step 4 で `PINNED_<slug>` 定数としてテストに埋め込む。

- [x] **Step 4: pin 値を埋め込んで test を完成させる**

前段の actual 値を使って 3 page 分の `it()` 本文を書く。テンプレートは以下 (実値は step 3 の実測で差し替える)。

```js
// 各 page の pin 値は __const__ としてトップに集約する。drift 発生時に
// 差分が読みやすくするため、const の **名前と構造を page 間で揃える**。
const PINNED_THE_CLI = Object.freeze({
  slug: 'running-tests/the-command-line-cli',
  // 合計 structure issue 件数 (section-structure-mismatch + segment-order-mismatch)
  structureIssueCount: /* Step 3 で計測した整数 */,
  // type 別内訳 (欠落 key はゼロ扱い)
  byType: { 'section-structure-mismatch': /* int */, 'segment-order-mismatch': /* int */ },
  // category 別内訳 (欠落 key はゼロ扱い)
  byCategory: {
    'kind-multiset': /* int */,
    'kind-sequence': /* int */,
    'content-order': /* int */,
  },
  // 先頭 (document order) の structure issue payload
  firstIssue: {
    type: 'section-structure-mismatch',                   // Step 3 の実測値
    structureCategory: 'kind-multiset',                   // 同上
    sectionPath: /* 実測文字列 */,
    sectionIndex: /* 実測整数 */,
    enKinds: /* 実測配列 */,
    jaKinds: /* 実測配列 */,
    enSegmentCount: /* 実測整数 */,
    jaSegmentCount: /* 実測整数 */,
  },
});

const PINNED_NETWORK_LOGS = Object.freeze({
  slug: 'results/test-results/network-logs',
  structureIssueCount: /* 実測 */,
  byType: { 'section-structure-mismatch': /* int */, 'segment-order-mismatch': /* int */ },
  byCategory: { 'kind-multiset': /* int */, 'kind-sequence': /* int */, 'content-order': /* int */ },
  firstIssue: {
    type: /* 実測 */,
    structureCategory: /* 実測 */,
    sectionPath: /* 実測 */,
    sectionIndex: /* 実測 */,
    enKinds: /* 実測 */,
    jaKinds: /* 実測 */,
    enSegmentCount: /* 実測 */,
    jaSegmentCount: /* 実測 */,
  },
});

const PINNED_EMAIL_VALIDATION = Object.freeze({
  slug: 'advanced-editing/validations/email-validation',
  structureIssueCount: /* 実測 */,
  byType: { 'section-structure-mismatch': /* int */, 'segment-order-mismatch': /* int */ },
  byCategory: { 'kind-multiset': /* int */, 'kind-sequence': /* int */, 'content-order': /* int */ },
  firstIssue: {
    type: /* 実測 */,
    structureCategory: /* 実測 */,
    sectionPath: /* 実測 */,
    sectionIndex: /* 実測 */,
    enKinds: /* 実測 */,
    jaKinds: /* 実測 */,
    enSegmentCount: /* 実測 */,
    jaSegmentCount: /* 実測 */,
  },
});

// 共通アサーションヘルパ。3 page で同じ構造の pin を assert するので 1 つに集約する。
function assertStructurePin(slug, pinned) {
  const { structureIssues } = runStructureComparator(slug);

  // 件数 contract
  assert.equal(
    structureIssues.length,
    pinned.structureIssueCount,
    `${slug}: structure issue 件数 drift (pin=${pinned.structureIssueCount}, actual=${structureIssues.length})`,
  );

  // 少なくとも 1 件は出るはず (false red 回帰ガード)
  assert.ok(
    structureIssues.length >= 1,
    `${slug}: structure issue が 0 件になった — PR5 baseline では active であるべき`,
  );

  // type 別内訳
  const byType = structureIssues.reduce((acc, i) => {
    acc[i.type] = (acc[i.type] || 0) + 1;
    return acc;
  }, {});
  for (const [type, expected] of Object.entries(pinned.byType)) {
    assert.equal(
      byType[type] || 0,
      expected,
      `${slug}: ${type} の件数 drift (pin=${expected}, actual=${byType[type] || 0})`,
    );
  }

  // category 別内訳
  const byCategory = structureIssues.reduce((acc, i) => {
    acc[i.structureCategory] = (acc[i.structureCategory] || 0) + 1;
    return acc;
  }, {});
  for (const [cat, expected] of Object.entries(pinned.byCategory)) {
    assert.equal(
      byCategory[cat] || 0,
      expected,
      `${slug}: structureCategory=${cat} の件数 drift (pin=${expected}, actual=${byCategory[cat] || 0})`,
    );
  }

  // 先頭 issue の payload contract
  const first = structureIssues[0];
  assert.equal(first.type, pinned.firstIssue.type, `${slug}: firstIssue.type drift`);
  assert.equal(
    first.structureCategory,
    pinned.firstIssue.structureCategory,
    `${slug}: firstIssue.structureCategory drift`,
  );
  assert.equal(first.sectionPath, pinned.firstIssue.sectionPath, `${slug}: firstIssue.sectionPath drift`);
  assert.equal(first.sectionIndex, pinned.firstIssue.sectionIndex, `${slug}: firstIssue.sectionIndex drift`);
  assert.deepEqual(first.enKinds, pinned.firstIssue.enKinds, `${slug}: firstIssue.enKinds drift`);
  assert.deepEqual(first.jaKinds, pinned.firstIssue.jaKinds, `${slug}: firstIssue.jaKinds drift`);
  assert.equal(
    first.enSegmentCount,
    pinned.firstIssue.enSegmentCount,
    `${slug}: firstIssue.enSegmentCount drift`,
  );
  assert.equal(
    first.jaSegmentCount,
    pinned.firstIssue.jaSegmentCount,
    `${slug}: firstIssue.jaSegmentCount drift`,
  );
}

// 3 page を同じアサーションで pin する。describe 文字列は slug ごとに分け、
// 失敗時にどのページが drift しているか一目で分かるようにする。
describe('source_parity_structure_fixtures: running-tests/the-command-line-cli', () => {
  it('structure issue 件数 / category / 先頭 issue の payload が PR5 baseline と一致する', () => {
    assertStructurePin(PINNED_THE_CLI.slug, PINNED_THE_CLI);
  });
});

describe('source_parity_structure_fixtures: results/test-results/network-logs', () => {
  it('structure issue 件数 / category / 先頭 issue の payload が PR5 baseline と一致する', () => {
    assertStructurePin(PINNED_NETWORK_LOGS.slug, PINNED_NETWORK_LOGS);
  });
});

describe('source_parity_structure_fixtures: advanced-editing/validations/email-validation', () => {
  it('structure issue 件数 / category / 先頭 issue の payload が PR5 baseline と一致する', () => {
    assertStructurePin(PINNED_EMAIL_VALIDATION.slug, PINNED_EMAIL_VALIDATION);
  });
});
```

- [x] **Step 5: テストが通ることを確認する**

```bash
node --test scripts/__tests__/source_parity_structure_fixtures.test.mjs
```
Expected: 3 tests pass。1 件でも failing なら step 3 の実測値と step 4 の埋め込みが食い違っている — **pin 値を実測値に合わせる**、実測値を pin 値に合わせてはいけない (production code 未変更のため)。

- [x] **Step 6: コミット**

```bash
git add scripts/__tests__/source_parity_structure_fixtures.test.mjs
git commit -m "test: Issue #247 PR6 — structure mismatch fixture pin (3 代表ページ)"
```

---

## Task 2: Confirmed zero-drift fixture test (false positive sentinels)

**Files:**
- Create: `scripts/__tests__/source_parity_clean_page_fixtures.test.mjs`

**目的:** PR5 base で **実測済みに zero-drift** な代表 2 ページを fixture として固定し、将来 comparator が degrade して健全ページで structure mismatch / segment-* diff を false positive で emit するようになったら即赤化する sentinel を置く。

対象ページ (**plan 作成時に実測で確定済み**):
- `settings/cli-prerequisites` — enSegments=10 / jaSegments=10 / structureIssueCount=0 / totalIssueCount=0 / inconclusive=false / baseline エントリ 0 件
- `salesforce-testing/salesforce-testing-getting-started` — enSegments=79 / jaSegments=79 / structureIssueCount=0 / totalIssueCount=0 / inconclusive=false / baseline エントリ 0 件

**設計上のポイント:**
- 両ページとも「既知 artifact を comparator が黙らせている」のではなく、**実データで EN/JA が完全整合している clean page**。従って pin 対象は `structureIssues.length === 0` (必須) に加えて `issues.length === 0` (より厳しい不変条件) まで効かせられる
- レビュー指摘通り「実測してから判断」の未確定候補は排除 — 候補ページは **plan 作成時点で固定**、実装時に再実測は不要 (Step 3 は回帰確認のため残すが、値が変動していたら plan 前提が崩れているサインとして赤化扱い)
- 当初候補だった `advanced-editing/custom-action-step-mobile` と `results/test-runs` は両方 0 件にならないことが実測で確認されているため本 fixture からは除外。`custom-action-step-mobile` は Task 3 (representative summary) で「baseline 吸収済み structure mismatch ページ」として扱う

- [x] **Step 1: 失敗するテストの骨格を書く**

`scripts/__tests__/source_parity_clean_page_fixtures.test.mjs` を新規作成。

```js
/**
 * Issue #247 PR6 — Confirmed zero-drift ページの false-positive sentinel。
 *
 * 対象ページ (plan 作成時に実測で確定):
 *   - settings/cli-prerequisites
 *     (enSegments=10, jaSegments=10, structureIssues=0, totalIssues=0)
 *   - salesforce-testing/salesforce-testing-getting-started
 *     (enSegments=79, jaSegments=79, structureIssues=0, totalIssues=0)
 *
 * 両ページとも EN/JA が完全整合している clean page で、PR5 base で
 * parity-baseline.json / parity-acknowledgements.json のどちらにも
 * エントリが無い。comparator が正しく動いている限り、structure issue は
 * 0 件かつ segment-* diff も 0 件のはず。
 *
 * pin する契約:
 *   1. section-structure-mismatch / segment-order-mismatch が 0 件
 *      (false positive の主たるガード)
 *   2. 総 issue 数も 0 件 (clean page なので drift が無い — より強い不変条件)
 *   3. alignment が inconclusive にならない (健全ページで解析不能になる
 *      のは regress のサイン)
 *
 * 当初検討された `advanced-editing/custom-action-step-mobile` と
 * `results/test-runs` は両方とも実測で structure issue が 0 件ではない
 * ため本 fixture からは除外。前者は Task 3 (representative summary) で
 * 「baseline 吸収済み structure mismatch ページ」として扱う。
 */
import { before, describe, it } from 'node:test';
import assert from 'node:assert/strict';
import { readFileSync } from 'node:fs';
import { join } from 'node:path';

let alignSegments;
let parityDiffsToIssues;
let extractSegmentsFromHtml;
let extractSegmentsFromMarkdown;

before(async () => {
  ({
    alignSegments,
    parityDiffsToIssues,
    extractSegmentsFromHtml,
    extractSegmentsFromMarkdown,
  } = await import('../lib/source_parity.mjs'));
});

const ROOT = join(import.meta.dirname, '../../');
const SNAPSHOTS_DIR = join(ROOT, 'snapshots/en/content');
const JA_CONTENT_DIR = join(ROOT, 'src/content/docs');

function extractJaBody(mdContent) {
  const withoutFm = mdContent.replace(/^---[\s\S]*?---\n/m, '');
  return withoutFm.trim();
}

// Task 1 の同名ヘルパと **完全に同一** の shape を返すように合わせる。
// 具体的には alignment / issues / structureIssues の 3 フィールドを返す。
// Step 4 の「alignment が inconclusive にならない」アサーションが
// `const { alignment } = runStructureComparator(slug)` で destructure する
// ため、alignment を含めていないと TypeError で落ちる (レビュー P2 指摘)。
function runStructureComparator(slug) {
  const rawEnHtml = readFileSync(join(SNAPSHOTS_DIR, `${slug}.html`), 'utf8');
  const jaMd = readFileSync(join(JA_CONTENT_DIR, `${slug}.md`), 'utf8');
  const jaBody = extractJaBody(jaMd);
  const enSegments = extractSegmentsFromHtml(rawEnHtml);
  const jaSegments = extractSegmentsFromMarkdown(jaBody);
  const alignment = alignSegments(enSegments, jaSegments);
  const issues = parityDiffsToIssues(alignment.diffs);
  const structureIssues = issues.filter(
    (i) => i.type === 'section-structure-mismatch' || i.type === 'segment-order-mismatch',
  );
  return { alignment, issues, structureIssues };
}

// plan 作成時に実測で zero-drift を確定した 2 ページ。配列の順序と要素は
// レビュー指摘に従って固定 — Step 3 は回帰確認のために残すが、選定済みの
// 候補を変える目的ではない。
const CLEAN_PAGE_SLUGS = Object.freeze([
  'settings/cli-prerequisites',
  'salesforce-testing/salesforce-testing-getting-started',
]);

for (const slug of CLEAN_PAGE_SLUGS) {
  describe(`source_parity_clean_page_fixtures: ${slug}`, () => {
    it('pin me (Step 3 で実測値が 0 件のままであることを確認してから完成させる)', () => {
      assert.fail('Step 3 でフル rerun して前提が崩れていないことを確認する');
    });
  });
}
```

- [x] **Step 2: テストが失敗することを確認する**

```bash
node --test scripts/__tests__/source_parity_clean_page_fixtures.test.mjs
```
Expected: 2 failures (両 slug の placeholder)。

- [x] **Step 3: 2 page の zero-drift 前提が現ブランチで崩れていないことを確認する**

レビュー指摘に従い「実測してから判断」は plan 作成時に完了済みだが、実装時に base rebase 等で前提が崩れていないことを回帰確認するため、同じ診断コマンドを 1 度走らせる。

```bash
node --input-type=module -e '
import { readFileSync } from "node:fs";
import {
  alignSegments, parityDiffsToIssues,
  extractSegmentsFromHtml, extractSegmentsFromMarkdown,
} from "./scripts/lib/source_parity.mjs";

const SLUGS = [
  "settings/cli-prerequisites",
  "salesforce-testing/salesforce-testing-getting-started",
];
function body(md) { return md.replace(/^---[\\s\\S]*?---\\n/m, "").trim(); }

for (const slug of SLUGS) {
  const html = readFileSync(`snapshots/en/content/${slug}.html`, "utf8");
  const ja   = body(readFileSync(`src/content/docs/${slug}.md`, "utf8"));
  const en   = extractSegmentsFromHtml(html);
  const js   = extractSegmentsFromMarkdown(ja);
  const al   = alignSegments(en, js);
  const iss  = parityDiffsToIssues(al.diffs);
  const st   = iss.filter((i) => i.type === "section-structure-mismatch" || i.type === "segment-order-mismatch");
  console.log("===", slug, "===");
  console.log("  structureIssueCount:", st.length);
  console.log("  totalIssueCount:", iss.length);
  console.log("  inconclusive:", al.inconclusive ?? false);
}
'
```

**期待値 (plan 前提)**:
```
=== settings/cli-prerequisites ===
  structureIssueCount: 0
  totalIssueCount: 0
  inconclusive: false
=== salesforce-testing/salesforce-testing-getting-started ===
  structureIssueCount: 0
  totalIssueCount: 0
  inconclusive: false
```

**前提が崩れている場合** (どちらかのページで structure issue > 0 または total issue > 0 になった場合):
- PR6 作業を **中断** し、fall-back として Task 2 を自分 (plan 作成者) の手で再実測する
- 別の confirmed zero-case 候補を探す必要がある。`parity-baseline.json` 集計で「baseline 0 件のページ」を抽出した上で、上位数ページを `node -e` で実測して新候補を選定する
- production code を触っていない状態で前提が崩れるのは、base branch の rebase か `snapshots/en/content/` の更新が原因のはず。`git log` で変化点を確認する

- [x] **Step 4: 0 件 pin を埋め込んで test を完成させる**

```js
for (const slug of CLEAN_PAGE_SLUGS) {
  describe(`source_parity_clean_page_fixtures: ${slug}`, () => {
    it('alignment が inconclusive にならない (健全 page の最低保証)', () => {
      const { alignment } = runStructureComparator(slug);
      assert.equal(
        alignment.inconclusive ?? false,
        false,
        `${slug}: alignment.inconclusive === true になった — PR5 base では解析成功していたはず`,
      );
    });

    it('section-structure-mismatch / segment-order-mismatch が 0 件 (false positive sentinel)', () => {
      const { structureIssues } = runStructureComparator(slug);
      assert.equal(
        structureIssues.length,
        0,
        `${slug}: structure issue が ${structureIssues.length} 件検出された — ` +
          `plan 前提 (zero-drift clean page) が崩れている。` +
          `最初の issue: ${JSON.stringify(structureIssues[0] ?? null)}`,
      );
    });

    it('総 issue 数も 0 件 (clean page の強い不変条件)', () => {
      const { issues } = runStructureComparator(slug);
      assert.equal(
        issues.length,
        0,
        `${slug}: 総 issue 数が ${issues.length} 件 — ` +
          `plan 前提では EN/JA が完全整合しており 0 件のはず。` +
          `最初の issue: ${JSON.stringify(issues[0] ?? null)}`,
      );
    });
  });
}
```

**注意**: `runStructureComparator(slug)` は Task 1 と同じ helper を使い回す想定だが、Task 2 は独立した test file なので同じヘルパを **複製する** (production code を触らない契約のため lib 切り出しはしない)。具体的には Task 1 Step 1 で書いた `extractJaBody` と `runStructureComparator` の 2 関数を Task 2 test file の上部にそのままコピペする。3 ヶ所目の複製になるが、pure で小さいため許容する (PR3 の fixture test も同様に複製している)。

- [x] **Step 5: テストが通ることを確認する**

```bash
node --test scripts/__tests__/source_parity_clean_page_fixtures.test.mjs
```
Expected: 2 slug × 3 it = **6 tests pass**。

- [x] **Step 6: コミット**

```bash
git add scripts/__tests__/source_parity_clean_page_fixtures.test.mjs
git commit -m "test: Issue #247 PR6 — confirmed zero-drift clean page sentinels (false positive ガード)"
```

---

## Task 3: representative full-run summary contract test

**Files:**
- Create: `scripts/__tests__/source_parity_representative_summary.test.mjs`

**目的:** Task 1 / Task 2 は comparator の raw 出力を pin するだけで、**baseline tagging + acknowledgement tagging + gate exit code** の end-to-end 契約までは固定しない。本タスクは `checkSourceParity({ slug })` を代表 6 ページに対して **順次** 実行し、生成された `parity-check-status.json` を読み取って各ページの summary counter を pin する。これにより以下が表現される:

1. `running-tests/the-command-line-cli` / `network-logs` / `email-validation` の `section-structure-mismatch` は **baseline で完全にカバーされ** `reportableActiveFiles === 0` / `structureMismatchIssues === 0` に収まる (PR5 cutover が live であり active drift が 0 であることの契約)
2. `salesforce-testing/faq` の `source-unusable` と `salesforce-testing/salesforce-testing-overview` の `snapshot-incomplete` は `reportableActiveFiles` には入らず `snapshotUnusableIssues` も baseline で 0 に収まる (advisory 契約 + baseline 吸収)
3. `advanced-editing/custom-action-step-mobile` は **`section-structure-mismatch` を 3 件含む** (segment-* と合わせて全 10 件) 形で baseline 化されており、active counter (`structureMismatchIssues` / `snapshotUnusableIssues` / `reportableActiveFiles`) が全て 0 になることを pin する。**structureMismatchIssues は active counter** なので、baseline 化された structure mismatch はここに含まれず 0 になる — レビュー指摘 (P1) の前提誤り訂正

**設計上の選択:**
- 既存 `source_parity_align_runtime.test.mjs` は `spawnSync('node', ['scripts/check_source_parity.mjs', ...])` で subprocess 経由で検証しているが、本タスクでは **`checkSourceParity()` を直接 import** して in-process で呼ぶ。理由は以下:
  1. PR6 は 6 slug を順に検証するため、subprocess overhead (Node 起動 × 6) が無視できない
  2. `checkSourceParity` は既に `export async function` として露出済み
  3. `parity-check-status.json` を介した I/O は不要 — in-process なら `checkSourceParity` の副作用 (file write) だけを利用し、関数呼び出し後に毎回 read して read → assert → 次の slug のフローにできる
  4. 既存 runtime test はバックアップロジックを実装済み (`STATUS_BACKUP_PATH`)。本テストも同じ guard を使う
- **注意**: `checkSourceParity()` は内部で `process.exit()` を呼ばない。戻り値が exit code (`0`/`1`) で、status file への書き込みは常に行われる。`source_parity_align_runtime.test.mjs:48` の `STATUS_BACKUP_PATH` パターンを踏襲してテスト実行前後で退避する

- [x] **Step 1: 失敗するテストの骨格を書く**

```js
/**
 * Issue #247 PR6 — representative full-run summary contract test.
 *
 * 代表 6 ページに対して checkSourceParity({ slug }) を in-process で順次呼び、
 * 生成された parity-check-status.json を読み取って各 page の summary
 * counter を pin する。
 *
 * 対象 slug と期待分類:
 *
 *   | slug                                               | expected counters             |
 *   | -------------------------------------------------- | ----------------------------- |
 *   | running-tests/the-command-line-cli                 | structure baselined           |
 *   | results/test-results/network-logs                  | structure baselined           |
 *   | advanced-editing/validations/email-validation      | structure baselined           |
 *   | salesforce-testing/faq                             | source-unusable baselined     |
 *   | salesforce-testing/salesforce-testing-overview     | snapshot-incomplete baselined |
 *   | advanced-editing/custom-action-step-mobile         | structure baselined (3 件) + segment-* baselined |
 *
 * pin する契約:
 *   1. 全 slug で reportableActiveFiles === 0 (PR5 gate cutover が live
 *      かつ baseline が有効)
 *   2. structure 系 4 slug (the-command-line-cli / network-logs /
 *      email-validation / custom-action-step-mobile) で structureMismatchIssues
 *      === 0 (全件 baselined。active counter なので baseline 化されたものは
 *      含まれず 0)
 *   3. source-unusable 系 2 slug で snapshotUnusableIssues === 0 (全件
 *      baselined) かつ reportableActiveFiles === 0
 *   4. 全 slug で baselinedByType に「期待される type」が 1 件以上含まれている
 *      ことを確認 (structure 系 4 slug は section-structure-mismatch、
 *      source-unusable 系 2 slug は source-unusable / snapshot-incomplete)
 *
 * 手法:
 *   既存 source_parity_align_runtime.test.mjs のバックアップパターンを使って
 *   parity-check-status.json を退避し、slug ごとに checkSourceParity() を
 *   呼んで read → assert → 次の slug に進む。
 */
import { before, after, describe, it } from 'node:test';
import assert from 'node:assert/strict';
import { readFileSync, existsSync, copyFileSync, unlinkSync } from 'node:fs';
import { join } from 'node:path';

let checkSourceParity;

before(async () => {
  ({ checkSourceParity } = await import('../check_source_parity.mjs'));
});

const ROOT = join(import.meta.dirname, '../../');
const STATUS_PATH = join(ROOT, 'parity-check-status.json');
const STATUS_BACKUP_PATH = join(ROOT, 'parity-check-status.pr6-test-backup.json');

before(() => {
  if (existsSync(STATUS_PATH)) {
    copyFileSync(STATUS_PATH, STATUS_BACKUP_PATH);
  }
});

after(() => {
  if (existsSync(STATUS_BACKUP_PATH)) {
    copyFileSync(STATUS_BACKUP_PATH, STATUS_PATH);
    unlinkSync(STATUS_BACKUP_PATH);
  }
});

// ---------------------------------------------------------------------------
// ヘルパ: slug 絞りで checkSourceParity を呼び、status JSON を読み取って返す。
// ---------------------------------------------------------------------------
async function runForSlug(slug) {
  const exitCode = await checkSourceParity({ slug, json: true });
  if (!existsSync(STATUS_PATH)) {
    throw new Error(
      `checkSourceParity({ slug: ${JSON.stringify(slug)} }) が status file を書かなかった`,
    );
  }
  const status = JSON.parse(readFileSync(STATUS_PATH, 'utf8'));
  return { exitCode, status };
}

describe('source_parity_representative_summary: 代表ページ full-run contract', () => {
  it('Step 3 で実測後に pin を埋める', async () => {
    assert.fail('pin me — Step 3 で実測後に固定');
  });
});
```

- [x] **Step 2: テストが失敗することを確認する**

```bash
node --test scripts/__tests__/source_parity_representative_summary.test.mjs
```
Expected: 1 failure from `assert.fail('pin me ...')`。

- [x] **Step 3: 各 slug を実測する**

```bash
node --input-type=module -e '
import { readFileSync } from "node:fs";
import { checkSourceParity } from "./scripts/check_source_parity.mjs";

const SLUGS = [
  "running-tests/the-command-line-cli",
  "results/test-results/network-logs",
  "advanced-editing/validations/email-validation",
  "salesforce-testing/faq",
  "salesforce-testing/salesforce-testing-overview",
  "advanced-editing/custom-action-step-mobile",
];

for (const slug of SLUGS) {
  const exit = await checkSourceParity({ slug, json: true });
  const st   = JSON.parse(readFileSync("parity-check-status.json", "utf8"));
  const s    = st.summary;
  console.log("===", slug, "===");
  console.log("  exitCode:", exit);
  console.log("  reportableActiveFiles:", s.reportableActiveFiles);
  console.log("  structureMismatchIssues:", s.structureMismatchIssues, " files:", s.structureMismatchFiles);
  console.log("  snapshotUnusableIssues:", s.snapshotUnusableIssues, " files:", s.snapshotUnusableFiles);
  console.log("  baselinedIssues:", s.baselinedIssues, " files:", s.baselinedFiles);
  console.log("  auditSignalIssues:", s.auditSignalIssues);
  console.log("  baselinedByType:", s.baselinedByType);
  console.log("  structureMismatchByType:", s.structureMismatchByType);
  console.log("  snapshotUnusableByType:", s.snapshotUnusableByType);
}
'
```

Expected: 各 slug について上記 key=value が並ぶ。以下を確認する:
- `exitCode === 0` (全 slug で gate pass)
- `reportableActiveFiles === 0` (全 slug で)
- `structureMismatchIssues === 0` (全 slug で — baseline でカバーされている)
- `snapshotUnusableIssues === 0` (全 slug で — baseline でカバーされている)
- `baselinedIssues` が各 slug で想定される分だけ > 0 (特に structure mismatch 系 3 slug と source-unusable 系 2 slug で `baselinedByType['section-structure-mismatch']` / `baselinedByType['source-unusable']` / `baselinedByType['snapshot-incomplete']` が 1 以上)

**1 つでも上記と食い違った場合 (例: reportableActiveFiles > 0)**:
- PR5 cutover の baseline が drift している可能性がある
- PR6 の前提が崩れている → **plan の前提を見直す** ため plan 作成者 (この worktree 上の自分) に fallback する
- 具体的には:
  - `git log origin/pr5-baseline-migration-gate-cutover` を参照して PR5 body の計測値と現状を比較
  - 食い違いの原因が「PR6 branch を切った後の base rebase」なら `git merge origin/pr5-baseline-migration-gate-cutover` で同期
  - それでも食い違う場合は PR6 作業を中断し、root cause を調査

この step は **production code が変わっていない前提** の確認でもあるため、食い違いをテストで黙殺してはならない。

- [x] **Step 4: pin 値を埋め込んで test を完成させる**

Step 3 の実測結果を元に、各 slug の期待値を `PINNED_*` 定数として埋め込む。共通パターンとして、**全 slug で `reportableActiveFiles === 0` かつ `structureMismatchIssues === 0` かつ `snapshotUnusableIssues === 0`** は変わらないので共通ヘルパにまとめる。slug ごとに違うのは `baselinedByType` の内訳。

```js
// 代表 slug の共通契約 (全 slug で 0 になる counter)
const COMMON_ZERO_COUNTERS = Object.freeze({
  reportableActiveFiles: 0,
  structureMismatchIssues: 0,
  snapshotUnusableIssues: 0,
  reportableActiveActionableFiles: 0,
});

// slug ごとの baselinedByType 下限。drift を許容しない equality ではなく
// 「少なくともこの type が baseline に含まれていること」を pin する。
// それは「代表 slug で advisory ではなく baseline でカバーされている」
// という契約を pin するのが目的で、segment-* の個別件数の drift は別の
// test (Task 1 の structure fixture) が捕まえるため。
const PINNED_PAGES = Object.freeze([
  {
    slug: "running-tests/the-command-line-cli",
    requiredBaselinedTypes: ["section-structure-mismatch"],
    // Step 3 の実測で `baselinedByType` を確認し、最低限含まれるべき type を
    // ここに列挙する。ページに segment-* も baseline 化されていれば追加する。
  },
  {
    slug: "results/test-results/network-logs",
    requiredBaselinedTypes: ["section-structure-mismatch"],
  },
  {
    slug: "advanced-editing/validations/email-validation",
    requiredBaselinedTypes: ["section-structure-mismatch"],
  },
  {
    slug: "salesforce-testing/faq",
    requiredBaselinedTypes: ["source-unusable"],
  },
  {
    slug: "salesforce-testing/salesforce-testing-overview",
    requiredBaselinedTypes: ["snapshot-incomplete"],
  },
  {
    slug: "advanced-editing/custom-action-step-mobile",
    // PR5 base で section-structure-mismatch × 3 + segment-* × 7 が全て baseline
    // 化されている。representative summary 上は active counter が全て 0 になる
    // (= 共通ゼロ条件を満たす) ので、ここでは「baseline で structure mismatch を
    // 吸収しているページ」として section-structure-mismatch を必須型に含める。
    // segment-* baseline は別の summary key で pin されるため requiredBaselinedTypes
    // に含めない (Task 1 のように個別 segment 内訳を hard-pin するわけではない)。
    requiredBaselinedTypes: ["section-structure-mismatch"],
  },
]);

// slug ごとの checkSourceParity() 結果を `before()` で 1 度だけ実行し、
// 同一 describe 内の 2 つの `it()` で使い回す。6 slug × 2 it = 12 回呼ぶと
// subprocess を避けていても ~60 秒かかるため、呼び出しを半減させる。
for (const pin of PINNED_PAGES) {
  describe(`source_parity_representative_summary: ${pin.slug}`, () => {
    let cached = null;
    before(async () => {
      cached = await runForSlug(pin.slug);
    });

    it("gate exit code が 0 かつ reportable*/structure/unusable counter が 0", () => {
      const { exitCode, status } = cached;
      const s = status.summary;
      assert.equal(exitCode, 0, `${pin.slug}: exitCode drift (pin=0, actual=${exitCode})`);
      for (const [key, expected] of Object.entries(COMMON_ZERO_COUNTERS)) {
        assert.equal(
          s[key] || 0,
          expected,
          `${pin.slug}: summary.${key} drift (pin=${expected}, actual=${s[key] || 0})`,
        );
      }
    });

    it("baseline に必要な issue type が含まれている (advisory ではなく baselined で吸収)", () => {
      const byType = cached.status.summary.baselinedByType || {};
      for (const requiredType of pin.requiredBaselinedTypes) {
        assert.ok(
          (byType[requiredType] || 0) >= 1,
          `${pin.slug}: baselinedByType[${requiredType}] が 0 — PR5 baseline で吸収されるべき ` +
            `(actual: ${JSON.stringify(byType)})`,
        );
      }
    });
  });
}
```

- [x] **Step 5: テストが通ることを確認する**

```bash
node --test scripts/__tests__/source_parity_representative_summary.test.mjs
```
Expected: 6 × 2 = 12 tests pass。

**注意**: `checkSourceParity()` は単一スラグでも full sidebar / snapshot / baseline をロードする。6 slug を順に呼ぶと実行時間は ~10-30 秒想定。もし 60 秒を超える場合は test timeout を明示する (`node --test --test-timeout=120000`)。

- [x] **Step 6: コミット**

```bash
git add scripts/__tests__/source_parity_representative_summary.test.mjs
git commit -m "test: Issue #247 PR6 — representative full-run summary contract (6 代表ページ)"
```

---

## Task 4: docs/OPS_DESIGN.md に structure comparator と source unusable の節を追記

**Files:**
- Modify: `docs/OPS_DESIGN.md` (現状 349 行)

**目的:** Issue #247 PR6 完了条件「docs に『何を structure mismatch とみなすか』を追記」を満たす。

- [x] **Step 1: 既存セクション境界を読み、挿入位置を確定する**

```bash
grep -n "^## \|^### " docs/OPS_DESIGN.md
```

`## Source Parity チェック` (L46) の配下、`### EN アーティファクト注釈` (L78) の **後**、`## チェックの保証範囲` (L85) の **前** が自然な挿入位置。新しい 2 つのサブ節をここに追加する。

- [x] **Step 2: 新規サブ節を追記する**

`### EN アーティファクト注釈` ブロックの直後 (空行 1 行を挟んで `## チェックの保証範囲` の直前) に以下を挿入する。

```markdown
### Structure comparator (canonical block sequence)

`alignSegments` が weighted LCS を走らせる前に、heading path が一致する section ごとに `compareSectionStructure()` を呼び、**原文 block 列の並びと多重集合** を比較する。この比較器は Issue #247 で導入され、`paragraph-count-mismatch` などの count heuristic を降格した後の **構造保持の主判定** を担う。

**比較対象の block 語彙 (凍結)**: `paragraph` / `ordered-list` / `unordered-list` / `callout-body` / `table` / `details-summary`。segment 単位の `ordered-list-item` / `unordered-list-item` / `table-cell` は比較前に list / table block に畳み込まれる (block 内部の件数差は別 comparator の責務)。

**3 段階の fall-through**:

| Stage | 条件 | emit type | structureCategory |
| --- | --- | --- | --- |
| A | EN/JA で block kind の **多重集合** が違う (cross-kind merge/split/collapse) | `section-structure-mismatch` | `kind-multiset` |
| B | multiset は一致するが **並び順** が違う (mixed-kind reorder) | `segment-order-mismatch` | `kind-sequence` |
| C | kind 列は完全一致しているが **content bijection が monotonic でない** (same-kind の swap / rotation) | `segment-order-mismatch` | `content-order` |

どの stage も発火しなければ比較器は空配列を返し、alignSegments は従来通り weighted LCS にフォールスルーする。section あたり最大 1 件までしか emit しない — 先に発火した stage が勝ち、後続 stage は short-circuit でスキップされる (gate 契約を予測可能にするため)。

**gate 分類**: `section-structure-mismatch` と `segment-order-mismatch` は PR5 cutover 以降 **reportable** (gate 対象)。`parity-baseline.json` に entry が無ければ `--fail-on=any` と `--fail-on=actionable` の両方で exit code 1。

**baseline identity**: structure 系 entry の machine identity は **`sectionIndex` + `structureCategory` + `structureFingerprint`** の 3 つ組で構成する (`buildBaselineKey` / `buildBaselineKeyFromEntry`)。`structureFingerprint` は `structureCategory` + `enKinds` + `jaKinds` (+ content-order の場合は `contentPermutation` の `enIndex→jaIndex` pair) を sha256 に畳み込んだもの。`sectionPath` は **reviewer 可読性のために entry に保存するが identity key には含めない** — 同一ページ内で同じ heading text が複数現れる場合に sectionPath だけだと一意にならないため (PR5 Finding 2)。

### Source unusable 判定

比較前に `detectSourceUsability()` が EN snapshot の **比較可能性** を判定する。比較不能と判定されたページはその 1 件だけを emit し、後続の alignSegments / structure comparator は呼ばれない (translation drift と snapshot/source debt を混ぜないため)。

**3 つの reason (凍結)**:

| reason | 発火条件 | emit type |
| --- | --- | --- |
| `shallow-snapshot` | raw EN ≤ 800 bytes かつ EN body ≤ 2 かつ JA body ≥ 5 かつ ratio ≥ 4 | `snapshot-incomplete` |
| `extractor-empty` | clean HTML なのに EN body が 0 で JA body ≥ 3 | `snapshot-incomplete` |
| `escaped-details-residue` | (通常経路) `&lt;/details&gt;` 残存 **または** open/close 不均衡 (= broken details tree) **かつ** `enHeadingSegmentCount === 0` で JA heading ≥ 2 (= section anchor failure) を **両方** 満たす。(extractError 経路) open/close 不均衡 (`open !== close`) のみで判定 | `source-unusable` |

`escaped-details-residue` の判定が **狭く** なっているのは、`advanced-editing/coding-assistant` のように `<details>` の使用例を本文に含むため preprocessEnHtml 後も balanced な escaped marker が残るが extractor / comparator は正常に動く合法ケースを誤発火させないため (PR3 P1 fix)。「escaped marker が残るだけ」では unusable と判定しない。

**gate 分類**: `snapshot-incomplete` と `source-unusable` は **advisory のみ** — `summary.snapshotUnusableIssues` / `summary.snapshotUnusableFiles` に集計されるが `summary.reportableActiveFiles` には入らない。そのため active な source unusable が何件あっても exit code は 0。これは「翻訳者責任外の snapshot / source sync 側の debt」を翻訳者 gate で失敗させないためで、PR5 cutover 後も同じ契約。`parity-baseline.json` には `usabilityReason` を key として entry を置けるので、人手管理の枠としては活用できる。
```

- [x] **Step 3: 既存の「保証する」表に 1 行追加する**

`## チェックの保証範囲` の表 (現状 L87-L93) の「保証する」列に、以下の 1 行を追加する。

```diff
 | 原文構造差分 | セマンティックな翻訳精度 |
+| block 列レベルの構造保持 (paragraph / list / callout / table / details の並びと多重集合) |  |
```

- [x] **Step 4: lint と build で link / syntax を確認する**

```bash
npm run lint:md
```
Expected: 0 error。新規追加した見出しレベル / list / table が markdown lint を通ること。

- [x] **Step 5: コミット**

```bash
git add docs/OPS_DESIGN.md
git commit -m "docs: Issue #247 PR6 — OPS_DESIGN に structure comparator / source unusable 節を追記"
```

---

## Task 5: scripts/README.md に structure comparator 関連の表行と説明を追記

**Files:**
- Modify: `scripts/README.md` (現状 740 行)

**目的:** Issue #247 PR6 完了条件 (docs 追記) のうち、開発者向け reference の部分を担当する。

- [x] **Step 1: 既存 issue 表を見つけて挿入位置を決める**

`scripts/README.md:81-94` の「スナップショット構造比較（signal）」テーブルが対象。structure comparator の 2 行と source unusable の 2 行を、表の下 (または既存行の末尾) に **reportable / advisory 列を明示して** 追加する。

- [x] **Step 2: 既存表に 4 行を追記する**

L81〜L94 の表の直後 (L94 の `missing-snapshot` 行の **後**) に以下を追加する。

```diff
 | `table-cell-token-mismatch` | テーブルセルの invariant token 不一致              | audit-only   |
 | `missing-snapshot`            | EN snapshot が存在しないページ                     | gate signal  |
+| `section-structure-mismatch`  | EN/JA の section body で block kind 多重集合が違う | **reportable** |
+| `segment-order-mismatch`      | section 内の block kind 並びまたは content bijection が違う | **reportable** |
+| `snapshot-incomplete`         | EN snapshot が shallow / extractor-empty で比較不能 | advisory     |
+| `source-unusable`             | EN snapshot が malformed details で復元不能       | advisory     |
```

- [x] **Step 3: structure comparator の概要サブ節を追記する**

L96 の `**audit-only signals**:` パラグラフの **直後** (L97 の acknowledgements パラグラフの **前**) に、新規サブ節を 1 つ追加する。

```markdown
**structure comparator (Issue #247)**: `alignSegments` が weighted LCS を走らせる前に、heading path が一致する section ごとに canonical block sequence を比較する。block 単位の語彙は `paragraph` / `ordered-list` / `unordered-list` / `callout-body` / `table` / `details-summary` の 6 種に凍結されており、segment 単位の list item / table cell は比較前に対応する list / table block に畳まれる。

3 段階の fall-through で section あたり最大 1 件の diff を emit する:

1. **kind-multiset** (`section-structure-mismatch`) — block 種別の多重集合が違う
2. **kind-sequence** (`segment-order-mismatch`) — 多重集合は一致するが並び順が違う
3. **content-order** (`segment-order-mismatch`) — kind 列は同じだが content bijection が monotonic でない

いずれかが発火すると後続 stage は short-circuit され、alignSegments の weighted LCS も呼ばれない (section body に対して structure issue と segment diff が二重発火しないため)。

**baseline identity**: structure 系 entry の machine identity は **`sectionIndex` + `structureCategory` + `structureFingerprint`** の 3 つ組 (`buildBaselineKey` / `buildBaselineKeyFromEntry`)。`structureFingerprint` は `structureCategory` + `enKinds` + `jaKinds` (content-order では `contentPermutation`) を sha256 に畳み込む。`sectionPath` は entry に保存するが identity key には含めない (同一ページ内で同じ heading text が複数現れる場合に sectionPath が一意にならないため、PR5 Finding 2)。

**source unusability gate**: `detectSourceUsability()` は alignSegments 呼び出し前に EN snapshot の比較可能性を判定する。判定条件は以下:

- `shallow-snapshot` (`snapshot-incomplete`) — raw EN HTML が 800 bytes 以下かつ EN body ≤ 2 かつ JA body ≥ 5 かつ JA/EN ratio ≥ 4
- `extractor-empty` (`snapshot-incomplete`) — clean HTML なのに EN body が 0 で JA body ≥ 3
- `escaped-details-residue` (`source-unusable`) — (通常経路) `&lt;/details&gt;` 残存 **または** open/close 不均衡 **かつ** `enHeadingSegmentCount === 0 && jaHeadingSegmentCount >= 2` を **両方** 満たす / (extractError 経路) `open !== close` の不均衡のみで判定

`escaped-details-residue` は **狭く** narrowing されており、`<details>` 例を本文に含む合法ページ (`advanced-editing/coding-assistant` 等) は false positive にならない。発火したページでは alignSegments が呼ばれない (translation drift と snapshot debt を混ぜないため)。両者とも **advisory のみ** で gate exit code には寄与しないが、`summary.snapshotUnusable*` の独立 counter に集計される。
```

- [x] **Step 4: lint で markdown 構文を確認する**

```bash
npm run lint:md
```
Expected: 0 error。

- [x] **Step 5: コミット**

```bash
git add scripts/README.md
git commit -m "docs: Issue #247 PR6 — scripts/README に structure comparator / source unusable 表行と説明を追記"
```

---

## Task 6: フル検証 (Issue #247 PR6 の完了条件)

**Files:**
- (修正なし — 既存テスト + 新規テストの green 確認のみ)

**目的:** PR6 の全 TDD step 終了後、代表フロー (`npm test` / `npm run lint` / `npm run build` / `npm run check:parity`) を走らせて PR5 base からの回帰が 0 件であること、かつ PR6 で追加したテストが green であることを確認する。

- [x] **Step 1: 全テストを実行する**

```bash
npm test
```
Expected:
- PR5 base の全 test が引き続き pass
- Task 1 の `source_parity_structure_fixtures.test.mjs` が 3 tests pass
- Task 2 の `source_parity_clean_page_fixtures.test.mjs` が 6 tests pass (2 slug × 3 it ブロック)
- Task 3 の `source_parity_representative_summary.test.mjs` が 12 tests pass (6 slug × 2 test case)
- **合計追加 test 数: 21 tests**

- [x] **Step 2: lint を実行する**

```bash
npm run lint
```
Expected: 0 error / 0 warning (md + docs lint)。新規 test file 自体は対象外、docs 変更 (Task 4/5) が lint 対象。

- [x] **Step 3: astro 型チェック + build を実行する**

```bash
npm run build
```
Expected: `astro check` 0 error → build 成功。test file は astro build の対象外のため、このステップは Task 4/5 の docs 変更が astro プリレンダリングや link 解決を壊していないことの確認。

- [x] **Step 4: 代表 full parity run で gate contract が成立していることを確認する**

```bash
npm run check:parity
```

**完了条件 (gate contract — drift しない不変条件)**:
- `exit code 0`
- `summary.reportableActiveFiles === 0`
- `summary.reportableActiveActionableFiles === 0`
- `summary.activeErrorFiles === 0`
- `summary.structureMismatchIssues === 0` (active な structure mismatch が無い = baseline で全件吸収)
- `summary.snapshotUnusableIssues === 0` (active な source unusable が無い = baseline で全件吸収)

**参考値 (drift しうる — pin しない)**:
- `summary.baselinedIssues` の絶対値 (PR5 base 執筆時点で 1314 件だが、base rebase や baseline 再生成で変動しうる。Task 6 では equality でチェックしない)
- `summary.baselinedByType` の各 type 別件数

理由: PR6 は **production code を変更しない PR** だが、`parity-baseline.json` 自体は base branch の rebase / 再生成で変わることがあるため、絶対件数を pin すると PR6 とは無関係な base churn で赤化する。完了条件は **gate contract** (= active counter が 0 / exit code 0) に絞り、絶対 baseline 件数は PR body の Test plan に「参考値」として記録するに留める。

もし上記 active counter の不変条件が成立しない場合:
1. `git diff origin/pr5-baseline-migration-gate-cutover...HEAD -- scripts/` で production code 変更が混入していないか確認
2. 混入していなければ、base branch の `parity-baseline.json` が rebase / regen で変わった可能性 → `git log origin/pr5-baseline-migration-gate-cutover -- parity-baseline.json` を確認し、base sync が必要なら `git merge origin/pr5-baseline-migration-gate-cutover` で同期

- [x] **Step 5: PR を作成する (実装完了後)**

PR6 のブランチは `pr6-fixture-representative-verification`、base は PR5 branch。PR body には:

- 本 plan (docs/superpowers/plans/2026-04-08-issue-247-pr6-fixture-representative-verification-design.md) の full text を含める (PR5 と同じ運用。**md ファイル自体は commit しない**)
- Task 3 Step 3 で得た 6 slug の実測値サマリを Test plan セクションに列挙
- 既存 PR4 / PR5 / PR3 / PR2 / PR1 との関係 (stacked PR の順序) を明示

PR body のテンプレート:

```markdown
## Summary

Issue #247 PR6 — PR1〜PR5 で導入した structure gate / source usability 検出 /
baseline migration の **実ページ fixture 回帰 pin** と docs 追記。**production
code には一切手を入れず**、新規 test 3 本と docs 2 ファイルの変更のみ。

### 追加する fixture
- `scripts/__tests__/source_parity_structure_fixtures.test.mjs` — 3 代表ページの structure mismatch 件数 / payload 契約を pin (false red sentinel)
- `scripts/__tests__/source_parity_clean_page_fixtures.test.mjs` — 2 confirmed zero-drift ページ (`settings/cli-prerequisites` / `salesforce-testing/salesforce-testing-getting-started`) の 0 件契約を pin (false positive sentinel)
- `scripts/__tests__/source_parity_representative_summary.test.mjs` — 6 代表ページの end-to-end summary counter を pin

### docs 更新
- `docs/OPS_DESIGN.md` — Structure comparator / Source unusable 節の追記
- `scripts/README.md` — issue 表 4 行追加 + structure comparator / source usability gate のサブ節追記

## Test plan

- [x] `npm test` — 既存 + 新規 tests green
- [x] `npm run lint` — 0 error
- [x] `npm run build` — astro check + build green
- [x] `npm run check:parity` full run → exit code 0 / `reportableActiveFiles=0` / `structureMismatchIssues=0` / `snapshotUnusableIssues=0`
- 参考値: `summary.baselinedIssues` (絶対値は drift しうるため pin しない)

## 実装詳細設計

(docs/superpowers/plans/2026-04-08-issue-247-pr6-fixture-representative-verification-design.md の全文を貼り付け)
```

**コミットは作らない** (md ファイル自体は commit しない運用)。plan file は worktree 上に local で残して PR body 投稿後に手動削除する。

---

## Self-Review (plan 作成者自身が実行する)

plan 保存後、以下の self-check を順に確認する。

### 1. spec 網羅チェック

Issue #247 の PR6 セクションを逐条で refer し、plan のどの Task がカバーしているかを埋める:

| Issue #247 PR6 項目 | カバーする Task |
| --- | --- |
| 実ページ fixture を固定 | Task 1 (structure mismatch raw 出力) + Task 2 (confirmed zero-drift sentinel) + Task 3 (end-to-end summary) |
| representative run の expected summary を test 化 | Task 3 (6 slug の active counter pin) |
| docs に「何を structure mismatch とみなすか」を追記 | Task 4 (OPS_DESIGN) + Task 5 (README) |
| 実ページ fixture で false red が把握できる | Task 1 (3 ページの structure mismatch payload pin) + Task 3 (6 ページの active counter pin) |
| 実ページ fixture で false positive が把握できる | Task 2 (2 ページの confirmed zero-drift sentinel — plan 作成時に実測で確定済み) |
| 今回問題になった pages の期待分類が test で固定される | Task 1 (3 ページの raw 出力) + Task 3 (6 ページの end-to-end summary) — `custom-action-step-mobile` は Task 3 で「baseline 吸収済み structure mismatch ページ」として扱う |
| 対象: `scripts/__tests__/fixtures/...` | 注: Task 1〜3 は既存 `snapshots/en/content/` と `src/content/docs/` を直接読むため新規 fixture ディレクトリは作らない (golden JSON を追加する必要がないため) — これは issue 本文の「対象」を緩く解釈した決定 |
| 対象: representative parity tests | Task 3 |
| 対象: 必要なら docs/README/OPS 更新 | Task 4 + Task 5 (両方) |

**ギャップ**: なし。Task 1 / Task 2 / Task 3 / Task 4 / Task 5 の全必須 Task で Issue #247 PR6 セクションを full coverage。未確定候補は plan 作成時に実測で排除済み。

### 2. placeholder scan

plan 全文を検索して、以下の禁じ手が残っていないか確認する:

- [x] `TBD` / `TODO` / `FIXME`
- [x] "implement later" / "fill in details"
- [x] "add error handling" (一般化された指示だけ)
- [x] "similar to Task N" (コードを繰り返していない)
- [x] コード step で code block が空
- [x] 未定義の関数 / メソッド / 型の参照

**既知の「placeholder っぽいが意図的」な箇所**:
- Task 1 Step 4 の `PINNED_THE_CLI` / `PINNED_NETWORK_LOGS` / `PINNED_EMAIL_VALIDATION` 内の `/* Step 3 で計測した整数 */` — **これは TDD の一部で、Step 3 で実測した値を Step 4 で埋めるフロー**。この 3 ページは現時点で baseline entry を持っているため各 issue の payload (enKinds / jaKinds / sectionIndex 等) を plan 作成時に事前列挙するのは過剰と判断。実装時の Step 3 診断でまとめて取得する
- Task 2 の対象 2 ページ (`settings/cli-prerequisites` / `salesforce-testing/salesforce-testing-getting-started`) は **plan 作成時に runtime で structureIssueCount=0 / totalIssueCount=0 を実測確認済み**。Step 3 の診断は回帰確認のため残しているだけで、新しい候補探索は含まない
- Task 3 の `requiredBaselinedTypes` の値は **plan 作成時の review feedback で `custom-action-step-mobile` を含む 6 slug 全てを `["section-structure-mismatch"]` または `["source-unusable"]` / `["snapshot-incomplete"]` に確定済み** — 実装段階の追加実測は不要

Task 1 の payload-level pin だけが **pin-after-measure** パターンとして意図的に残っている。他の placeholder は無いことを plan 内を全文検索して確認済み。

### 3. 型一貫性チェック

Task 間で method / field 名が揃っているかチェック:

- `runStructureComparator(slug)` — Task 1 / Task 2 の両方で同じシグネチャで定義 (各 test file 内で独立に定義)
- `assertStructurePin(slug, pinned)` — Task 1 のみで定義、Task 2 では使わない
- `runForSlug(slug)` — Task 3 のみで定義
- `extractJaBody(mdContent)` — Task 1 / Task 2 / (Task 3 は checkSourceParity 経由なので不要) で同じ実装を複製 — PR3 test と同じ pattern

`summary.reportableActiveFiles` / `summary.structureMismatchIssues` / `summary.snapshotUnusableIssues` / `summary.baselinedIssues` / `summary.baselinedByType` — 全て `scripts/lib/source_parity_summary.mjs:197-231` の `summarizeParityResults` return value に実在することを事前確認済み。

`section-structure-mismatch` / `segment-order-mismatch` / `snapshot-incomplete` / `source-unusable` — `scripts/lib/source_parity_structure.mjs:322,336,354` と `scripts/lib/source_parity_baseline.mjs:59,71` の定数で固定されていることを事前確認済み。

`STRUCTURE_COMPARATOR_KINDS` の語彙 (`paragraph` / `ordered-list` / `unordered-list` / `callout-body` / `table` / `details-summary`) — Task 4 (OPS_DESIGN) と Task 5 (README) の表記で一致していることを確認。

**結論**: 型 / 名前の不一致は plan 内に見つからず。

---

## 実装順 (subagent-driven / executing-plans どちらでも可)

推奨順: **Task 1 → Task 2 → Task 3 → Task 4 → Task 5 → Task 6**。

Task 1〜3 は互いに独立 (共通ヘルパの複製を許容しているため) で、並列実行可能だが、実測コマンド (`node --input-type=module -e ...`) が同じ `parity-check-status.json` を書き換える副作用を持つため、Task 3 の実測中は他 Task の実測を走らせないほうが安全。

Task 4 / Task 5 は production code / テストと独立なので最後にまとめて実施。

Task 6 (最終検証) は全 Task 完了後に 1 回だけ実施。

---

## 完了条件 (PR6 が merge 可能とみなす条件)

Issue #247 PR6 セクションの完了条件を以下のように `plan` 側の check list にマップする。全項目が **必須** — confirmed zero-case が plan 作成時に確定したため、以前「ベストエフォート」としていた Task 2 も必須に昇格した。

### 必須 (これが揃わないと PR6 として merge 不可)

- [x] 実ページ fixture で false red が把握できる (**Task 1** の 3 slug が pin されている)
- [x] 実ページ fixture で false positive が把握できる (**Task 2** の confirmed zero-case 2 slug が pin されている)
- [x] 今回問題になった pages の期待分類が test で固定される (**Task 1** の 3 slug + **Task 3** の 6 slug)
- [x] representative run の expected summary が test 化されている (**Task 3** の 6 slug の active counter pin)
- [x] docs に「何を structure mismatch とみなすか」を追記している (**Task 4** の OPS_DESIGN + **Task 5** の README)
- [x] PR5 cutover 後の gate contract が維持されている (**Task 6** の `npm run check:parity` が exit 0 / `reportableActiveFiles=0` / `reportableActiveActionableFiles=0` / `activeErrorFiles=0` / `structureMismatchIssues=0` / `snapshotUnusableIssues=0`)
- [x] `npm test` / `npm run lint` / `npm run build` が全て green (**Task 6**)

### 意図的に外している (drift しうる絶対値 — 不変条件にしない)

- ~~`summary.baselinedIssues === 1314`~~ — base rebase / baseline 再生成で変動するため pin しない (Test plan の参考値として記録のみ)
- ~~`summary.baselinedByType.section-structure-mismatch === 274`~~ — 同上
- ~~`results/test-runs` / `advanced-editing/custom-action-step-mobile` の zero-fixture 化~~ — どちらも実測で 0 件にならないため除外済み。`custom-action-step-mobile` は Task 3 で「baseline 吸収済み structure mismatch ページ」として再分類
