### PR TITLE
feat: Issue #255 — broken upstream を source-side debt registry で隔離 + workflow 日本語化

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,6 +48,7 @@ Full reference: `scripts/README.md`
   - **Content**: Extracts `#mc-main-content` from each EN page HTML, saves to `snapshots/en/content/{folder}/{basename}.html`.
   - **Sidebar**: Parses MadCap Flare TOC data (`scripts/lib/madcap_toc.mjs`), saves to `snapshots/en/sidebar.json`.
   - **Parity comparison**: Converts HTML snapshots to Markdown via `turndown`, then compares structure with JA translations.
+  - **Source-side debt**: broken upstream EN ソースは `scripts/lib/source_sync_exclusions.mjs` の registry で隔離し、snapshot 上書きを抑止して `source-sync-status.json` の `excludedPages` counter で可視化する (詳細は `docs/DOCS_DATE_TRACKING.md`)。
 
 ## Authority Sources
 

--- a/.github/workflows/scheduled-actionable.yml
+++ b/.github/workflows/scheduled-actionable.yml
@@ -73,23 +73,23 @@ jobs:
         if: always()
         run: |
           if [ "$SNAPSHOTS_OUTCOME" = "failure" ]; then
-            echo "::warning::Snapshot fetch/diff reported issues (exit code non-zero)"
+            echo "::warning::スナップショット取得または差分検出で問題を報告しました (exit code 非 0)"
           fi
           if [ "$PARITY_OUTCOME" = "failure" ]; then
-            echo "::warning::Parity check reported issues (exit code non-zero)"
+            echo "::warning::パリティ検査で問題を報告しました (exit code 非 0)"
           fi
           if [ "$SUMMARY_OUTCOME" = "failure" ]; then
-            echo "::error::Detection input validation failed — sync will be skipped"
+            echo "::error::検出入力の検証に失敗しました — 管理 issue の同期はスキップされます"
             {
-              echo "## ❌ Detection input validation failed"
+              echo "## ❌ 検出入力の検証に失敗しました"
               echo ""
-              echo "Strict --strict validation rejected one or more of:"
+              echo "strict モードの検証が以下のいずれかを拒否しました:"
               echo "- snapshot-diff-status.json"
               echo "- parity-check-status.json"
-              echo "- source-sync-status.json (when present)"
+              echo "- source-sync-status.json (存在する場合)"
               echo ""
-              echo "Managed detection issues will NOT be synced from this run."
-              echo "Inspect the artifact bundle and the previous step logs."
+              echo "この run から管理 detection issue の同期は行われません。"
+              echo "アーティファクトと前ステップのログを確認してください。"
             } >> "$GITHUB_STEP_SUMMARY"
           fi
         env:

--- a/docs/DOCS_DATE_TRACKING.md
+++ b/docs/DOCS_DATE_TRACKING.md
@@ -115,7 +115,7 @@ upstream 英語原文自体が broken で parity comparator の前提を満た�
 
 - snapshot fetch は毎回実行する（復旧監視のため）
 - snapshot file は上書きしない（hand-authored snapshot を凍結参照として温存）
-- fetch 結果に対して `detectSourceUsability` で recovery probe を実行する
+- fetch 結果に対して EN-only recovery probe を実行する (現在 `extractor-empty` のみ自動判定、他は fail-close)
 - probe 結果は `source-sync-status.json` の `fetchStatus` に反映される:
   - `excluded-broken` — 依然 broken（未復旧）
   - `excluded-recovered` — upstream 復旧候補（人間が確認の上、registry から削除）
@@ -128,7 +128,7 @@ upstream 英語原文自体が broken で parity comparator の前提を満た�
 
 - **自動除外はしない**（false negative を避けるため）
 - 人間が upstream broken と目視確認した slug のみ `SOURCE_SYNC_EXCLUSIONS` に追加する
-- `expectedIssueType` / `expectedReason` は実際の `detectSourceUsability` 出力と合致させる
+- `expectedIssueType` / `expectedReason` は EN-only recovery probe の判定に使用される (現在 `extractor-empty` のみ自動判定)
 - 復旧候補は人間判断で registry から削除する（自動解除はしない）
 
 ## 出力ファイル

--- a/docs/DOCS_DATE_TRACKING.md
+++ b/docs/DOCS_DATE_TRACKING.md
@@ -107,15 +107,40 @@ node scripts/fetch_translate_images.mjs --mode=full
 2. `snapshot_diff` が `page-removed` として検出
 3. 対応: 日本語ドキュメントの扱いを判断（削除 or アーカイブ）
 
+### Source-side debt（broken upstream）の隔離 (Issue #255)
+
+upstream 英語原文自体が broken で parity comparator の前提を満たさないページ（例: `testops/testops-version-control/pull-requests`）は、 `scripts/lib/source_sync_exclusions.mjs` の **明示 registry** で管理し、通常の翻訳同期レーンから分離します。
+
+**運用契約:**
+
+- snapshot fetch は毎回実行する（復旧監視のため）
+- snapshot file は上書きしない（hand-authored snapshot を凍結参照として温存）
+- fetch 結果に対して `detectSourceUsability` で recovery probe を実行する
+- probe 結果は `source-sync-status.json` の `fetchStatus` に反映される:
+  - `excluded-broken` — 依然 broken（未復旧）
+  - `excluded-recovered` — upstream 復旧候補（人間が確認の上、registry から削除）
+- excluded ページは `fetchedPages` / `notFoundPages` / `errorPages` のどのカウンタにも含まれない
+- 独立カウンタ `excludedPages` / `excludedBrokenPages` / `excludedRecoveredPages` に集計される
+- `freshnessState` の計算から完全に除外されるため、既知 debt だけ残っていても `fresh` 扱い
+- `docs-update-summary.md` の `## ソース側 debt` セクションで日本語可視化される
+
+**新規 entry 追加のルール:**
+
+- **自動除外はしない**（false negative を避けるため）
+- 人間が upstream broken と目視確認した slug のみ `SOURCE_SYNC_EXCLUSIONS` に追加する
+- `expectedIssueType` / `expectedReason` は実際の `detectSourceUsability` 出力と合致させる
+- 復旧候補は人間判断で registry から削除する（自動解除はしない）
+
 ## 出力ファイル
 
-| ファイル                      | 内容                                 |
-| ----------------------------- | ------------------------------------ |
-| `snapshot-diff-status.json`   | 変更検知結果（ページごとの差分分類） |
-| `parity-check-status.json`    | ローカル parity チェック結果         |
-| `docs-actionable-report.json` | Issue 作成用レポート                 |
-| `docs-update-summary.md`      | 人間向けサマリー                     |
-| `docs-audit-manifest.json`    | レビュー計画用マニフェスト           |
+| ファイル | 内容 |
+| --- | --- |
+| `snapshot-diff-status.json` | 変更検知結果（ページごとの差分分類） |
+| `source-sync-status.json` | fetch metadata + freshness + source-side debt カウンタ (`excludedPages` 等、Issue #255) |
+| `parity-check-status.json` | ローカル parity チェック結果 |
+| `docs-actionable-report.json` | Issue 作成用レポート |
+| `docs-update-summary.md` | 人間向けサマリー（`## ソース側 debt` セクションを含む） |
+| `docs-audit-manifest.json` | レビュー計画用マニフェスト |
 
 ## 初回セットアップ
 
@@ -135,11 +160,13 @@ git commit -m "feat: 初回英語原文スナップショット"
 ## 関連ファイル
 
 - `scripts/lib/madcap_toc.mjs` — MadCap Flare TOC データ解析
-- `scripts/snapshot_update.mjs` — HTML フェッチ & 保存（コンテンツ HTML + サイドバー JSON）
+- `scripts/lib/source_sync_exclusions.mjs` — Source-side debt registry (Issue #255)
+- `scripts/lib/source_sync_health.mjs` — `source-sync-status.json` 生成と freshness 判定
+- `scripts/snapshot_update.mjs` — HTML フェッチ & 保存（コンテンツ HTML + サイドバー JSON + exclusion 分岐）
 - `scripts/snapshot_diff.mjs` — 比較 & レポート
-- `.github/workflows/scheduled-actionable.yml` — 3 日ごとの定期チェック
+- `.github/workflows/scheduled-actionable.yml` — 3 日ごとの定期チェック（日本語 warning/error メッセージ）
 - `.github/workflows/deep-audit.yml` — 手動 deep audit
 
 ---
 
-最終更新: 2026-03-27
+最終更新: 2026-04-09

--- a/docs/DOCS_DATE_TRACKING.md
+++ b/docs/DOCS_DATE_TRACKING.md
@@ -115,7 +115,7 @@ upstream 英語原文自体が broken で parity comparator の前提を満た�
 
 - snapshot fetch は毎回実行する（復旧監視のため）
 - snapshot file は上書きしない（hand-authored snapshot を凍結参照として温存）
-- fetch 結果に対して EN-only recovery probe を実行する (現在 `extractor-empty` のみ自動判定、他は fail-close)
+- fetch 結果に対して recovery probe を実行する (`detectSourceUsability()` を再利用し、`extractor-empty` / `shallow-snapshot` / `escaped-details-residue` をそのまま判定)
 - probe 結果は `source-sync-status.json` の `fetchStatus` に反映される:
   - `excluded-broken` — 依然 broken（未復旧）
   - `excluded-recovered` — upstream 復旧候補（人間が確認の上、registry から削除）
@@ -128,7 +128,7 @@ upstream 英語原文自体が broken で parity comparator の前提を満た�
 
 - **自動除外はしない**（false negative を避けるため）
 - 人間が upstream broken と目視確認した slug のみ `SOURCE_SYNC_EXCLUSIONS` に追加する
-- `expectedIssueType` / `expectedReason` は EN-only recovery probe の判定に使用される (現在 `extractor-empty` のみ自動判定)
+- `expectedIssueType` / `expectedReason` は recovery probe の `detectSourceUsability()` 出力との照合に使用される
 - 復旧候補は人間判断で registry から削除する（自動解除はしない）
 
 ## 出力ファイル

--- a/docs/DOCS_DATE_TRACKING.md
+++ b/docs/DOCS_DATE_TRACKING.md
@@ -115,13 +115,13 @@ upstream 英語原文自体が broken で parity comparator の前提を満た�
 
 - snapshot fetch は毎回実行する（復旧監視のため）
 - snapshot file は上書きしない（hand-authored snapshot を凍結参照として温存）
-- fetch 結果に対して recovery probe を実行する (`detectSourceUsability()` を再利用し、`extractor-empty` / `shallow-snapshot` / `escaped-details-residue` をそのまま判定)
+- fetch 成功時は recovery probe を実行する (`detectSourceUsability()` を再利用し、`extractor-empty` / `shallow-snapshot` / `escaped-details-residue` をそのまま判定。JA 非依存 — synthetic segments を使用)
 - probe 結果は `source-sync-status.json` の `fetchStatus` に反映される:
   - `excluded-broken` — 依然 broken（未復旧）
   - `excluded-recovered` — upstream 復旧候補（人間が確認の上、registry から削除）
-- excluded ページは `fetchedPages` / `notFoundPages` / `errorPages` のどのカウンタにも含まれない
-- 独立カウンタ `excludedPages` / `excludedBrokenPages` / `excludedRecoveredPages` に集計される
-- `freshnessState` の計算から完全に除外されるため、既知 debt だけ残っていても `fresh` 扱い
+  - `excluded-fetch-error` — fetch 失敗（live EN を観測できなかった。`errorPages` に計上し freshness を劣化させる）
+- `excluded-broken` / `excluded-recovered` は `excludedPages` counter に集計され、`freshnessState` の計算から除外される
+- `excluded-fetch-error` は `errorPages` に計上され、freshness を劣化させる（観測能力の欠如は source-sync 劣化）
 - `docs-update-summary.md` の `## ソース側 debt` セクションで日本語可視化される
 
 **新規 entry 追加のルール:**

--- a/docs/OPS_DESIGN.md
+++ b/docs/OPS_DESIGN.md
@@ -454,7 +454,7 @@ baseline entry 0 で clean green に到達:
 
 | slug | 状態 | 運用 |
 | --- | --- | --- |
-| `testops/testops-version-control/pull-requests` | EN live HTML が body 全体を `<code>` ブロックで wrap した broken output (extractor-empty) を返し、MadCap Flare extractor が 0 body segment に落ちる。Issue #247 では hand-authored snapshot で一時的に clean に見せたが、次回の snapshot fetch で必ず再破壊される | Issue #255 で `scripts/lib/source_sync_exclusions.mjs` registry に登録し、`snapshot_update` は fetch するが snapshot file を上書きしない。fetch 結果に対して recovery probe (`detectSourceUsability()` を再利用し、`extractor-empty` / `shallow-snapshot` / `escaped-details-residue` をそのまま判定) を実行し、`excluded-broken` / `excluded-recovered` として `source-sync-status.json` に報告する。hand-authored snapshot は凍結参照として温存 |
+| `testops/testops-version-control/pull-requests` | EN live HTML が body 全体を `<code>` ブロックで wrap した broken output (extractor-empty) を返し、MadCap Flare extractor が 0 body segment に落ちる。Issue #247 では hand-authored snapshot で一時的に clean に見せたが、次回の snapshot fetch で必ず再破壊される | Issue #255 で `scripts/lib/source_sync_exclusions.mjs` registry に登録し、`snapshot_update` は fetch するが snapshot file を上書きしない。fetch 成功時は recovery probe (`detectSourceUsability()` を再利用、synthetic JA で EN-only 判定) を実行し `excluded-broken` / `excluded-recovered` として報告。fetch 失敗時は `excluded-fetch-error` として errors に計上し freshness を劣化させる。hand-authored snapshot は凍結参照として温存 |
 
 source-side debt の契約は `scripts/__tests__/source_parity_source_side_debt.test.mjs`
 で pin される。representative test (`source_parity_representative_summary.test.mjs`)

--- a/docs/OPS_DESIGN.md
+++ b/docs/OPS_DESIGN.md
@@ -464,13 +464,21 @@ source-side debt の契約は `scripts/__tests__/source_parity_source_side_debt.
 
 ##### 新規 slug の除外登録 (upstream broken を確認したとき)
 
+注意: `check:parity` は `snapshots/en/content/` の**凍結 snapshot** を読むため、
+live EN の broken 確認には使えない。live EN の状態は `check:snapshots:fetch` の
+`--dry-run` 出力と、ブラウザでの目視で確認する。
+
 1. **目視確認**: ブラウザで `sourceUrl` を開き、本文が `<code>` ブロックに
    collapsed / `<details>` が壊れている / 本文がほぼ空 など、MadCap Flare
    extractor が正常にパースできない状態であることを確認する
-2. **detector 確認**: `npm run check:parity -- --slug=<slug>` を実行し、
-   `snapshot-incomplete` または `source-unusable` が出ることを確認する。
+2. **live fetch 確認**: `npm run check:snapshots:fetch -- --slug=<slug> --dry-run`
+   を実行し、出力に `SKIP` (mc-main-content not found) または取得された
+   HTML が broken であることを確認する。dry-run なので snapshot file は変更されない
+3. **detector 確認** (任意): 取得された live HTML を一時的に snapshot file に
+   コピーし `npm run check:parity -- --slug=<slug>` で `snapshot-incomplete`
+   / `source-unusable` が出ることを確認する。確認後は `git restore` で戻す。
    出力の `usabilitySignals.reason` が registry の `expectedReason` になる
-3. **registry 追加**: `scripts/lib/source_sync_exclusions.mjs` の
+4. **registry 追加**: `scripts/lib/source_sync_exclusions.mjs` の
    `SOURCE_SYNC_EXCLUSIONS` に entry を追加する:
 
    ```js
@@ -484,19 +492,22 @@ source-side debt の契約は `scripts/__tests__/source_parity_source_side_debt.
    }),
    ```
 
-4. **hand-authored snapshot**: 必要なら
+5. **hand-authored snapshot**: 必要なら
    `snapshots/en/content/<slug>.html` に正しい HTML を手動作成する
    (registry が write をブロックするため以後上書きされない)
-5. **テスト更新**:
+6. **テスト更新**:
    - `source_parity_source_side_debt.test.mjs` が新 slug を自動検出する
    - representative test から対象 slug を外す (必要な場合)
-6. **検証**: `npm run lint && npm run test && npm run build` を通す
-7. **PR 作成**: 証跡として PR 本文に以下を含める:
+7. **検証**: `npm run lint && npm run test && npm run build` を通す
+8. **PR 作成**: 証跡として PR 本文に以下を含める:
    - sourceUrl と壊れ方のスクリーンショットまたは説明
-   - `check:parity` 出力の `usabilitySignals` 全文
+   - live fetch の dry-run 出力
    - 追加した registry entry
 
 ##### 除外解除 (upstream が復旧したとき)
+
+注意: excluded slug は registry に載っている限り snapshot file を上書きしない。
+そのため**registry 削除を先に行い**、その後に snapshot fetch で最新 HTML を取得する。
 
 1. **復旧候補の検知**: workflow summary (`docs-update-summary.md`) または
    managed issue body の `## ソース原文の既知問題` セクションで
@@ -505,17 +516,19 @@ source-side debt の契約は `scripts/__tests__/source_parity_source_side_debt.
    起きない — `body-appeared-inconclusive` が出たら復旧の可能性を疑う
 2. **目視確認**: ブラウザで `sourceUrl` を開き、本文が正常な HTML 構造
    (`<h2>` / `<p>` / `<ol>` 等) に戻っていることを確認する
-3. **detector 確認**: `npm run check:parity -- --slug=<slug>` を実行し、
-   `snapshot-incomplete` / `source-unusable` が出ないことを確認する
-4. **snapshot 更新**: `npm run check:snapshots:fetch -- --slug=<slug>` で
-   最新 HTML を取得する (registry から外すと write が有効になる)
-5. **registry 削除**: `SOURCE_SYNC_EXCLUSIONS` から該当 entry を削除する
+3. **live fetch 確認**: `npm run check:snapshots:fetch -- --slug=<slug> --dry-run`
+   で live HTML が正常であることを確認する (dry-run なのでまだ上書きしない)
+4. **registry 削除**: `SOURCE_SYNC_EXCLUSIONS` から該当 entry を削除する
+   (これにより snapshot_update の write-block が解除される)
+5. **snapshot 更新**: `npm run check:snapshots:fetch -- --slug=<slug>` で
+   最新 HTML を取得する (registry から外したので write が有効)
 6. **parity 確認**: `npm run check:parity -- --slug=<slug>` で JA との
    構造差分を確認し、必要なら JA ファイルを修正する
 7. **テスト更新**: representative test に slug を戻す (必要な場合)
 8. **検証**: `npm run lint && npm run test && npm run build` を通す
 9. **PR 作成**: 証跡として PR 本文に以下を含める:
    - sourceUrl が正常に戻ったことのスクリーンショットまたは説明
+   - live fetch の dry-run 出力
    - `check:parity` 出力が 0 issues であること
    - 削除した registry entry と理由
 

--- a/docs/OPS_DESIGN.md
+++ b/docs/OPS_DESIGN.md
@@ -454,7 +454,7 @@ baseline entry 0 で clean green に到達:
 
 | slug | 状態 | 運用 |
 | --- | --- | --- |
-| `testops/testops-version-control/pull-requests` | EN live HTML が body 全体を `<code>` ブロックで wrap した broken output (extractor-empty) を返し、MadCap Flare extractor が 0 body segment に落ちる。Issue #247 では hand-authored snapshot で一時的に clean に見せたが、次回の snapshot fetch で必ず再破壊される | Issue #255 で `scripts/lib/source_sync_exclusions.mjs` registry に登録し、`snapshot_update` は fetch するが snapshot file を上書きしない。fetch 結果に対して EN-only recovery probe を実行し (現在 `extractor-empty` のみ自動判定、他は fail-close)、`excluded-broken` / `excluded-recovered` として `source-sync-status.json` に報告する。hand-authored snapshot は凍結参照として温存 |
+| `testops/testops-version-control/pull-requests` | EN live HTML が body 全体を `<code>` ブロックで wrap した broken output (extractor-empty) を返し、MadCap Flare extractor が 0 body segment に落ちる。Issue #247 では hand-authored snapshot で一時的に clean に見せたが、次回の snapshot fetch で必ず再破壊される | Issue #255 で `scripts/lib/source_sync_exclusions.mjs` registry に登録し、`snapshot_update` は fetch するが snapshot file を上書きしない。fetch 結果に対して recovery probe (`detectSourceUsability()` を再利用し、`extractor-empty` / `shallow-snapshot` / `escaped-details-residue` をそのまま判定) を実行し、`excluded-broken` / `excluded-recovered` として `source-sync-status.json` に報告する。hand-authored snapshot は凍結参照として温存 |
 
 source-side debt の契約は `scripts/__tests__/source_parity_source_side_debt.test.mjs`
 で pin される。representative test (`source_parity_representative_summary.test.mjs`)
@@ -511,9 +511,9 @@ live EN の broken 確認には使えない。live EN の状態は `check:snapsh
 
 1. **復旧候補の検知**: workflow summary (`docs-update-summary.md`) または
    managed issue body の `## ソース原文の既知問題` セクションで
-   `expectedMatch: false` (想定と不一致) を確認する。
-   現在の probe は全分岐 fail-close なので `excluded-recovered` は自動では
-   起きない — `body-appeared-inconclusive` が出たら復旧の可能性を疑う
+   `excluded-recovered` を確認する。recovery probe は `detectSourceUsability()`
+   を再利用するため、detector が「比較可能」と判定したページは自動で
+   `excluded-recovered` に遷移する
 2. **目視確認**: ブラウザで `sourceUrl` を開き、本文が正常な HTML 構造
    (`<h2>` / `<p>` / `<ol>` 等) に戻っていることを確認する
 3. **live fetch 確認**: `npm run check:snapshots:fetch -- --slug=<slug> --dry-run`

--- a/docs/OPS_DESIGN.md
+++ b/docs/OPS_DESIGN.md
@@ -454,7 +454,7 @@ baseline entry 0 で clean green に到達:
 
 | slug | 状態 | 運用 |
 | --- | --- | --- |
-| `testops/testops-version-control/pull-requests` | EN live HTML が body 全体を `<code>` ブロックで wrap した broken output (extractor-empty) を返し、MadCap Flare extractor が 0 body segment に落ちる。Issue #247 では hand-authored snapshot で一時的に clean に見せたが、次回の snapshot fetch で必ず再破壊される | Issue #255 で `scripts/lib/source_sync_exclusions.mjs` registry に登録し、`snapshot_update` は fetch するが snapshot file を上書きしない。fetch 結果に対して `detectSourceUsability` で recovery probe を実行し、`excluded-broken` / `excluded-recovered` として `source-sync-status.json` に報告する。hand-authored snapshot は凍結参照として温存 |
+| `testops/testops-version-control/pull-requests` | EN live HTML が body 全体を `<code>` ブロックで wrap した broken output (extractor-empty) を返し、MadCap Flare extractor が 0 body segment に落ちる。Issue #247 では hand-authored snapshot で一時的に clean に見せたが、次回の snapshot fetch で必ず再破壊される | Issue #255 で `scripts/lib/source_sync_exclusions.mjs` registry に登録し、`snapshot_update` は fetch するが snapshot file を上書きしない。fetch 結果に対して EN-only recovery probe を実行し (現在 `extractor-empty` のみ自動判定、他は fail-close)、`excluded-broken` / `excluded-recovered` として `source-sync-status.json` に報告する。hand-authored snapshot は凍結参照として温存 |
 
 source-side debt の契約は `scripts/__tests__/source_parity_source_side_debt.test.mjs`
 で pin される。representative test (`source_parity_representative_summary.test.mjs`)

--- a/docs/OPS_DESIGN.md
+++ b/docs/OPS_DESIGN.md
@@ -561,7 +561,9 @@ post-merge PR に対する完全解消レビューで以下の gap が判明し�
    / `structureMismatchIssues` / `snapshotUnusableIssues` の 0 + `baselinedByType`
    の空のみを pin していたが、signal-only drift (paragraph-count-mismatch /
    bullet-count-mismatch) も 0 件であることを追加 pin。`f.issues.length === 0`
-   を全 8 slug に課すことで、原文構造を保ったまま翻訳する契約を明示化した。
+   を代表 slug に課すことで、原文構造を保ったまま翻訳する契約を明示化した。
+   (Issue #255 により pull-requests は representative から除外され 7 slug に縮小。
+   debt ページの契約は `source_parity_source_side_debt.test.mjs` に分離。)
 
 8. **WRITING_GUIDE 更新** — (a) リスト節に「step 配下 nested list を圧縮しない」
    (b) その他節に「count 系 signal は補助で、原文構造を崩してよい意味では

--- a/docs/OPS_DESIGN.md
+++ b/docs/OPS_DESIGN.md
@@ -418,11 +418,14 @@ pin する。repo-global な baseline/status file を奪い合わないよう、
 `checkSourceParity({ baselinePath, outputPath })` の test-only 注入 hook を
 使って `mkdtemp` 上の temp copy だけを操作する。
 
-### Issue #247 完了条件の着地点 (End-to-End 完全解消, 2026-04-09)
+### Issue #247 完了条件の着地点 (Issue #255 で source-side debt 分離, 2026-04-09)
 
 Issue #247 は PR1-6 のタクソノミー / gate cutover 後、post-merge レビュー →
-re-review で段階的に絞り込み、最終的に **8 代表ページすべてを baseline 0 件の
-clean green** まで解消した (完全 End-to-End 達成):
+re-review で段階的に絞り込み、**7 代表ページを baseline 0 件の clean green** まで
+解消した。残る 1 ページ (`testops/testops-version-control/pull-requests`) は
+upstream EN source 自体が broken で parity comparator の前提を満たさないため、
+Issue #255 で **source-side debt** として representative から分離し、別レーンで
+管理することにした。
 
 **完了条件 #2 (4 slug が structure mismatch として reportable)**: 4 slug すべてが
 baseline entry 0 で clean green に到達:
@@ -441,12 +444,21 @@ baseline entry 0 で clean green に到達:
 | `advanced-editing/custom-action-step-mobile` | JA 側を EN plain-text 構造に揃える | baseline entry 0 |
 | `results/test-runs` | preface の extra paragraph 削除 + 関連修正 | baseline entry 0 |
 
-**追加: upstream snapshot debt 2 slug** (re-review で完全解消):
+**追加: upstream snapshot debt 1 slug** (JA trim で完全解消):
 
 | slug | 方針 | 着地点 |
 | --- | --- | --- |
 | `salesforce-testing/salesforce-testing-overview` | EN source が h1 + 1 paragraph のみの shallow snapshot だったため、JA も同じ minimal 構造に trim (source-first 原則) | baseline entry 0 |
-| `testops/testops-version-control/pull-requests` | EN source の body 全体が `<code>` ブロックで wrap された broken output (extractor-empty) だったため、正しい HTML snapshot を手動で書き起こして置き換え | baseline entry 0 |
+
+**Issue #255 で分離: source-side debt 1 slug**:
+
+| slug | 状態 | 運用 |
+| --- | --- | --- |
+| `testops/testops-version-control/pull-requests` | EN live HTML が body 全体を `<code>` ブロックで wrap した broken output (extractor-empty) を返し、MadCap Flare extractor が 0 body segment に落ちる。Issue #247 では hand-authored snapshot で一時的に clean に見せたが、次回の snapshot fetch で必ず再破壊される | Issue #255 で `scripts/lib/source_sync_exclusions.mjs` registry に登録し、`snapshot_update` は fetch するが snapshot file を上書きしない。fetch 結果に対して `detectSourceUsability` で recovery probe を実行し、`excluded-broken` / `excluded-recovered` として `source-sync-status.json` に報告する。hand-authored snapshot は凍結参照として温存 |
+
+source-side debt の契約は `scripts/__tests__/source_parity_source_side_debt.test.mjs`
+で pin される。representative test (`source_parity_representative_summary.test.mjs`)
+は 7 slug 版に縮小された。
 
 **完了条件の保証 (regression guard)**:
 
@@ -459,8 +471,17 @@ baseline entry 0 で clean green に到達:
 - `scripts/__tests__/source_parity_clean_page_fixtures.test.mjs` — 4 clean sentinel ページで
   structure / segment 共に 0 件を pin (false-positive 回帰ガード)
 - `scripts/__tests__/source_parity_representative_summary.test.mjs` — Issue #247
-  End-to-End 解消後の全 8 slug summary counter を `RESOLVED_PAGES` で pin
-  (`RESIDUAL_PAGES = []`)
+  End-to-End 解消後の 7 slug summary counter を `RESOLVED_PAGES` で pin
+  (Issue #255 で pull-requests が除外され `RESIDUAL_PAGES = []`)
+- `scripts/__tests__/source_parity_source_side_debt.test.mjs` — Issue #255 の
+  source-side debt registry 契約と凍結 snapshot / JA file の存在を pin
+- `scripts/__tests__/source_sync_exclusions.test.mjs` — exclusion registry の
+  shape と lookup helper を pin
+- `scripts/__tests__/source_sync_health.test.mjs` — excluded ページが freshness
+  計算から除外され、`excludedPages` / `excludedBrokenPages` / `excludedRecoveredPages`
+  の独立 counter で可視化される契約を pin
+- `scripts/__tests__/snapshot_update.test.mjs` — excluded slug は fetch するが
+  snapshot file を書かず、recovery probe 結果を pageResults に載せる契約を pin
 - `scripts/__tests__/source_parity_orphan_integration.test.mjs` — orphan detection の
   E2E contract を pin
 - `scripts/__tests__/source_parity_usability_ack_integration.test.mjs` — detector → ack
@@ -485,7 +506,10 @@ post-merge PR に対する完全解消レビューで以下の gap が判明し�
 
 3. **2 snapshot debt の upstream 修正** — salesforce-testing-overview は JA trim、
    pull-requests は broken source を正しい HTML snapshot に手動書き換え。これにより
-   Issue #247 の 8 代表ページすべてを End-to-End で完全解消。
+   Issue #247 の 8 代表ページに対して一旦 End-to-End green を達成。ただし
+   pull-requests の hand-authored snapshot は次回の `check:snapshots:fetch` で必ず
+   再破壊されるため、Issue #255 で source-side debt registry 運用に切り替え、
+   representative から分離した。
 
 ### Issue #247 re-review 第二弾 での追加修正 (2026-04-09)
 

--- a/docs/OPS_DESIGN.md
+++ b/docs/OPS_DESIGN.md
@@ -460,6 +460,65 @@ source-side debt の契約は `scripts/__tests__/source_parity_source_side_debt.
 で pin される。representative test (`source_parity_representative_summary.test.mjs`)
 は 7 slug 版に縮小された。
 
+#### source-side debt 運用手順書
+
+##### 新規 slug の除外登録 (upstream broken を確認したとき)
+
+1. **目視確認**: ブラウザで `sourceUrl` を開き、本文が `<code>` ブロックに
+   collapsed / `<details>` が壊れている / 本文がほぼ空 など、MadCap Flare
+   extractor が正常にパースできない状態であることを確認する
+2. **detector 確認**: `npm run check:parity -- --slug=<slug>` を実行し、
+   `snapshot-incomplete` または `source-unusable` が出ることを確認する。
+   出力の `usabilitySignals.reason` が registry の `expectedReason` になる
+3. **registry 追加**: `scripts/lib/source_sync_exclusions.mjs` の
+   `SOURCE_SYNC_EXCLUSIONS` に entry を追加する:
+
+   ```js
+   '<category>/<slug>': Object.freeze({
+     reason: 'broken-upstream-source',
+     note: '<壊れ方の説明>',
+     expectedIssueType: '<detector の type>',
+     expectedReason: '<detector の reason>',
+     addedAt: '<YYYY-MM-DD>',
+     linkedIssue: <Issue 番号>,
+   }),
+   ```
+
+4. **hand-authored snapshot**: 必要なら
+   `snapshots/en/content/<slug>.html` に正しい HTML を手動作成する
+   (registry が write をブロックするため以後上書きされない)
+5. **テスト更新**:
+   - `source_parity_source_side_debt.test.mjs` が新 slug を自動検出する
+   - representative test から対象 slug を外す (必要な場合)
+6. **検証**: `npm run lint && npm run test && npm run build` を通す
+7. **PR 作成**: 証跡として PR 本文に以下を含める:
+   - sourceUrl と壊れ方のスクリーンショットまたは説明
+   - `check:parity` 出力の `usabilitySignals` 全文
+   - 追加した registry entry
+
+##### 除外解除 (upstream が復旧したとき)
+
+1. **復旧候補の検知**: workflow summary (`docs-update-summary.md`) または
+   managed issue body の `## ソース原文の既知問題` セクションで
+   `expectedMatch: false` (想定と不一致) を確認する。
+   現在の probe は全分岐 fail-close なので `excluded-recovered` は自動では
+   起きない — `body-appeared-inconclusive` が出たら復旧の可能性を疑う
+2. **目視確認**: ブラウザで `sourceUrl` を開き、本文が正常な HTML 構造
+   (`<h2>` / `<p>` / `<ol>` 等) に戻っていることを確認する
+3. **detector 確認**: `npm run check:parity -- --slug=<slug>` を実行し、
+   `snapshot-incomplete` / `source-unusable` が出ないことを確認する
+4. **snapshot 更新**: `npm run check:snapshots:fetch -- --slug=<slug>` で
+   最新 HTML を取得する (registry から外すと write が有効になる)
+5. **registry 削除**: `SOURCE_SYNC_EXCLUSIONS` から該当 entry を削除する
+6. **parity 確認**: `npm run check:parity -- --slug=<slug>` で JA との
+   構造差分を確認し、必要なら JA ファイルを修正する
+7. **テスト更新**: representative test に slug を戻す (必要な場合)
+8. **検証**: `npm run lint && npm run test && npm run build` を通す
+9. **PR 作成**: 証跡として PR 本文に以下を含める:
+   - sourceUrl が正常に戻ったことのスクリーンショットまたは説明
+   - `check:parity` 出力が 0 issues であること
+   - 削除した registry entry と理由
+
 **完了条件の保証 (regression guard)**:
 
 - `scripts/__tests__/source_parity_structure_fixtures.test.mjs` — 5 代表ページ

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,11 +48,12 @@ npm run check:snapshots:fetch -- --dry-run               # フェッチ経路検
 **Source-side debt の除外運用 (Issue #255)**: `scripts/lib/source_sync_exclusions.mjs` の registry に登録された slug は fetch は継続するが、以下の特別処理を受ける:
 
 - snapshot HTML file を上書きしない (hand-authored snapshot を凍結参照として温存)
-- fetch 結果に対して recovery probe を実行 (`detectSourceUsability()` を再利用し、`extractor-empty` / `shallow-snapshot` / `escaped-details-residue` をそのまま判定)
+- fetch 成功時は recovery probe を実行 (`detectSourceUsability()` を再利用し、`extractor-empty` / `shallow-snapshot` / `escaped-details-residue` をそのまま判定。JA 非依存 — synthetic segments を使用)
 - probe が issue を返す → `fetchStatus: "excluded-broken"` (既知 debt 継続)
 - probe が null を返す → `fetchStatus: "excluded-recovered"` (upstream 復旧候補)
-- `source-sync-status.json` の `excludedPages` / `excludedBrokenPages` / `excludedRecoveredPages` counter に流れる
-- freshness 計算 (`computeFreshnessState`) から除外される (既知 debt だけの run は `fresh`)
+- fetch 失敗 (HTTP error / 404 / mc-main-content missing / throw) → `fetchStatus: "excluded-fetch-error"` (errors に計上、freshness 劣化として可視化)
+- `excluded-broken` / `excluded-recovered` は `excludedPages` counter に流れ、freshness 計算から除外される
+- `excluded-fetch-error` は `errorPages` counter に流れ、freshness を劣化させる (live EN を観測できないため)
 - debt slug への新規追加は **人間が upstream broken と確認した場合のみ** — 自動除外はしない
 
 復旧候補 (`excluded-recovered`) が出ても自動では registry から削除せず、人間が確認の上 `SOURCE_SYNC_EXCLUSIONS` から該当 entry を削除する。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,6 +45,18 @@ npm run check:snapshots:fetch -- --dry-run               # フェッチ経路検
 
 **出力**: `snapshot-diff-status.json`。変更は `page-changed`（内容変更）、`page-added`（新規）、`page-removed`（404化）に分類され、差分行は `heading` / `image` / `code` / `callout` / `content` に自動分類される。
 
+**Source-side debt の除外運用 (Issue #255)**: `scripts/lib/source_sync_exclusions.mjs` の registry に登録された slug は fetch は継続するが、以下の特別処理を受ける:
+
+- snapshot HTML file を上書きしない (hand-authored snapshot を凍結参照として温存)
+- fetch 結果に対して `detectSourceUsability` で recovery probe を実行
+- probe が issue を返す → `fetchStatus: "excluded-broken"` (既知 debt 継続)
+- probe が null を返す → `fetchStatus: "excluded-recovered"` (upstream 復旧候補)
+- `source-sync-status.json` の `excludedPages` / `excludedBrokenPages` / `excludedRecoveredPages` counter に流れる
+- freshness 計算 (`computeFreshnessState`) から除外される (既知 debt だけの run は `fresh`)
+- debt slug への新規追加は **人間が upstream broken と確認した場合のみ** — 自動除外はしない
+
+復旧候補 (`excluded-recovered`) が出ても自動では registry から削除せず、人間が確認の上 `SOURCE_SYNC_EXCLUSIONS` から該当 entry を削除する。
+
 ---
 
 #### check_source_parity.mjs
@@ -633,7 +645,14 @@ npm run check:parity -- --include-audit-signals  # 詳細表示
 - **`source-sync-status.json`** (`schemaVersion: 1`) —
   必須 top-level: `runId`, `checkedAt`, `sourceInventoryFingerprint`,
   `sidebarFingerprint`, `freshnessState`, `runScope`, `summary`, `pages`,
-  `errors`
+  `errors`。
+  `summary` に Issue #255 で追加された counter: `excludedPages` (= 既知
+  source-side debt の合計) / `excludedBrokenPages` (未復旧) /
+  `excludedRecoveredPages` (upstream 復旧候補)。`pages[n]` には debt slug に
+  対してのみ `debtCategory: "source-side-debt"` と `recoveryProbe: {
+  issueType, reason } | null` が emit される。excluded は `fetchedPages`
+  / `notFoundPages` / `errorPages` のどれにも count されず、`freshnessState`
+  計算からも除外される (= 既知 debt だけの run は `fresh` 扱い)
 - **`parity-check-status.json`** (`schemaVersion: 1`) —
   必須 top-level: `summary` (含む `checkedAt` / `runScope` / `result` /
   `linkageState` / `freshnessState`), `files`
@@ -697,6 +716,8 @@ npm test    # node --test scripts/__tests__/*.mjs
 | `__tests__/source_parity_acknowledgements.test.mjs`  | lib/source_parity_acknowledgements.mjs  |
 | `__tests__/source_parity_page_coverage.test.mjs`     | lib/source_parity_page_coverage.mjs     |
 | `__tests__/source_sync_health.test.mjs`              | lib/source_sync_health.mjs              |
+| `__tests__/source_sync_exclusions.test.mjs`          | lib/source_sync_exclusions.mjs          |
+| `__tests__/source_parity_source_side_debt.test.mjs`  | Issue #255 source-side debt 契約統合    |
 | `__tests__/source_parity_segments_shared.test.mjs`   | lib/source_parity_segments_shared.mjs   |
 | `__tests__/source_parity_segments_en.test.mjs`       | lib/source_parity_segments_en.mjs       |
 | `__tests__/source_parity_segments_ja.test.mjs`       | lib/source_parity_segments_ja.mjs       |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -57,6 +57,10 @@ npm run check:snapshots:fetch -- --dry-run               # フェッチ経路検
 
 復旧候補 (`excluded-recovered`) が出ても自動では registry から削除せず、人間が確認の上 `SOURCE_SYNC_EXCLUSIONS` から該当 entry を削除する。
 
+**managed issue への可視化**: `excludedPages > 0` のとき、freshness が `fresh` であっても `source-sync-health` managed issue が open され、ソース側 debt セクションが issue body に載る。これにより step summary だけでなく GitHub Issue フローでも debt 状態が追跡可能。body 内容が前回と変わらなければ issue は更新されない (sync-detection-issues の body 比較ガード)。
+
+**recovery probe の expected 照合**: `recoveryProbe` には `expectedMatch: boolean` が付与される。registry の `expectedIssueType` / `expectedReason` と実際の detector 出力が一致すれば `true` (想定どおり broken)、不一致なら `false` (broken 理由が変わった — registry 更新を検討)。
+
 ---
 
 #### check_source_parity.mjs

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -646,7 +646,7 @@ npm run check:parity -- --include-audit-signals  # 詳細表示
 - **`snapshot-diff-status.json`** (`schemaVersion: 1`) —
   必須 top-level: `runId`, `sourceSyncRunId`, `sourceInventoryFingerprint`,
   `runScope`, `checkedAt`, `summary`, `changes`, `sidebar`
-- **`source-sync-status.json`** (`schemaVersion: 1`) —
+- **`source-sync-status.json`** (`schemaVersion: 2`) —
   必須 top-level: `runId`, `checkedAt`, `sourceInventoryFingerprint`,
   `sidebarFingerprint`, `freshnessState`, `runScope`, `summary`, `pages`,
   `errors`。

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,7 +48,7 @@ npm run check:snapshots:fetch -- --dry-run               # フェッチ経路検
 **Source-side debt の除外運用 (Issue #255)**: `scripts/lib/source_sync_exclusions.mjs` の registry に登録された slug は fetch は継続するが、以下の特別処理を受ける:
 
 - snapshot HTML file を上書きしない (hand-authored snapshot を凍結参照として温存)
-- fetch 結果に対して `detectSourceUsability` で recovery probe を実行
+- fetch 結果に対して EN-only recovery probe を実行 (現在 `extractor-empty` のみ自動判定対応、他は fail-close)
 - probe が issue を返す → `fetchStatus: "excluded-broken"` (既知 debt 継続)
 - probe が null を返す → `fetchStatus: "excluded-recovered"` (upstream 復旧候補)
 - `source-sync-status.json` の `excludedPages` / `excludedBrokenPages` / `excludedRecoveredPages` counter に流れる

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,7 +48,7 @@ npm run check:snapshots:fetch -- --dry-run               # フェッチ経路検
 **Source-side debt の除外運用 (Issue #255)**: `scripts/lib/source_sync_exclusions.mjs` の registry に登録された slug は fetch は継続するが、以下の特別処理を受ける:
 
 - snapshot HTML file を上書きしない (hand-authored snapshot を凍結参照として温存)
-- fetch 結果に対して EN-only recovery probe を実行 (現在 `extractor-empty` のみ自動判定対応、他は fail-close)
+- fetch 結果に対して recovery probe を実行 (`detectSourceUsability()` を再利用し、`extractor-empty` / `shallow-snapshot` / `escaped-details-residue` をそのまま判定)
 - probe が issue を返す → `fetchStatus: "excluded-broken"` (既知 debt 継続)
 - probe が null を返す → `fetchStatus: "excluded-recovered"` (upstream 復旧候補)
 - `source-sync-status.json` の `excludedPages` / `excludedBrokenPages` / `excludedRecoveredPages` counter に流れる

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -2846,7 +2846,7 @@ describe('Issue #255 — source-side debt section in summary markdown', () => {
     const md = renderSummaryMarkdown(emptySnapshot, emptyParity, report, [], sourceSync);
 
     // 日本語セクション見出しが emit される
-    assert.match(md, /## ソース側 debt/);
+    assert.match(md, /## ソース原文の既知問題/);
     // Counters (human-readable Japanese labels)
     assert.match(md, /除外ページ: 1/);
     assert.match(md, /未復旧: 1/);
@@ -2879,7 +2879,7 @@ describe('Issue #255 — source-side debt section in summary markdown', () => {
     const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
     const md = renderSummaryMarkdown(emptySnapshot, emptyParity, report, [], sourceSync);
 
-    assert.doesNotMatch(md, /## ソース側 debt/);
+    assert.doesNotMatch(md, /## ソース原文の既知問題/);
     assert.doesNotMatch(md, /excluded-broken/);
   });
 
@@ -2910,7 +2910,7 @@ describe('Issue #255 — source-side debt section in summary markdown', () => {
     const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
     const md = renderSummaryMarkdown(emptySnapshot, emptyParity, report, [], sourceSync);
 
-    assert.match(md, /## ソース側 debt/);
+    assert.match(md, /## ソース原文の既知問題/);
     assert.match(md, /復旧候補: 1/);
     assert.match(md, /### 復旧候補/);
     assert.match(md, /testops\/testops-version-control\/pull-requests/);
@@ -2994,7 +2994,7 @@ describe('Issue #255 — source-side debt section in summary markdown', () => {
     const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
 
     assert.equal(report.sourceSyncHealth.shouldOpenIssue, true);
-    assert.match(report.sourceSyncHealth.body, /ソース側 debt/);
+    assert.match(report.sourceSyncHealth.body, /ソース原文の既知問題/);
     assert.match(report.sourceSyncHealth.body, /testops\/testops-version-control\/pull-requests/);
     assert.match(report.sourceSyncHealth.body, /未復旧/);
   });
@@ -3030,7 +3030,7 @@ describe('Issue #255 — source-side debt section in summary markdown', () => {
     // fresh だが debt が残っているので issue は open される
     assert.equal(report.sourceSyncHealth.shouldOpenIssue, true);
     // body にソース側 debt セクションが含まれる
-    assert.match(report.sourceSyncHealth.body, /ソース側 debt/);
+    assert.match(report.sourceSyncHealth.body, /ソース原文の既知問題/);
     assert.match(report.sourceSyncHealth.body, /testops\/testops-version-control\/pull-requests/);
     assert.match(report.sourceSyncHealth.body, /未復旧: 1/);
   });

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -350,8 +350,8 @@ describe('buildActionableReport', () => {
     };
 
     const report = buildActionableReport(snapshot, parity, []);
-    assert.match(report.snapshotDiff.body, /Sidebar Changes/);
-    assert.match(report.snapshotDiff.body, /Pages added: 1/);
+    assert.match(report.snapshotDiff.body, /サイドバー変更/);
+    assert.match(report.snapshotDiff.body, /追加ページ: 1/);
   });
 
   it('does NOT open a parity issue when all issues are validly acknowledged', () => {
@@ -665,16 +665,16 @@ describe('renderSummaryMarkdown', () => {
     const auditManifest = [{}, {}, {}, {}];
 
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, auditManifest);
-    assert.match(md, /# Docs Detection Summary/);
-    assert.match(md, /## Snapshot Diff/);
-    assert.match(md, /Changed pages: 3/);
-    assert.match(md, /Added pages: 1/);
-    assert.match(md, /## Parity/);
-    assert.match(md, /Active actionable files: 2/);
-    assert.match(md, /## Audit Manifest/);
-    assert.match(md, /Page lifecycle: 1/);
-    assert.match(md, /Structural change: 1/);
-    assert.match(md, /Content only: 2/);
+    assert.match(md, /# ドキュメント検知サマリー/);
+    assert.match(md, /## スナップショット差分/);
+    assert.match(md, /変更ページ: 3/);
+    assert.match(md, /追加ページ: 1/);
+    assert.match(md, /## パリティ/);
+    assert.match(md, /active actionable ファイル: 2/);
+    assert.match(md, /## 監査マニフェスト/);
+    assert.match(md, /ページライフサイクル: 1/);
+    assert.match(md, /構造変更: 1/);
+    assert.match(md, /本文のみ: 2/);
     assert.match(md, /snapshot-diff-status\.json/);
   });
 
@@ -705,9 +705,9 @@ describe('renderSummaryMarkdown', () => {
     };
 
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
-    assert.match(md, /Active actionable files: 0/);
-    assert.match(md, /Active issue files: 0/);
-    assert.match(md, /Acknowledged \(non-blocking\): 41/);
+    assert.match(md, /active actionable ファイル: 0/);
+    assert.match(md, /active issue ファイル: 0/);
+    assert.match(md, /承認済み \(非ブロッキング\): 41/);
     // The legacy counters must not appear standalone in a way that contradicts activeFiles:0.
     assert.doesNotMatch(md, /^- Signal-only files: 22$/m);
   });
@@ -734,7 +734,7 @@ describe('renderSummaryMarkdown', () => {
     };
 
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
-    assert.match(md, /Expired acknowledgements: 1/);
+    assert.match(md, /期限切れ承認: 1/);
   });
 
   it('marks partial advisory queue summaries as not repo-wide', () => {
@@ -782,7 +782,7 @@ describe('renderSummaryMarkdown', () => {
     };
 
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
-    assert.match(md, /Advisory queue: 2 issues \(1 files, 1 blocking; partial scope: slug=overview\/page-a, not repo-wide\)/);
+    assert.match(md, /advisory キュー: 2 件 \(1 ファイル, 1 ブロッキング; 部分 scope: slug=overview\/page-a、リポジトリ全体ではない\)/);
   });
 });
 
@@ -864,7 +864,7 @@ describe('sourceSyncHealth in buildActionableReport', () => {
     };
     const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
     const md = renderSummaryMarkdown(emptySnapshot, emptyParity, report, [], sourceSync);
-    assert.match(md, /Source Sync Health/);
+    assert.match(md, /## ソース同期状態/);
     assert.match(md, /broken/);
   });
 });
@@ -963,10 +963,10 @@ describe('parityFollowup in buildActionableReport', () => {
       report.parityFollowup.summary.reviewHints.tokenlessNearTieExamples[0].slug,
       'overview/page-a',
     );
-    assert.match(report.parityFollowup.body, /Scope: full repo/);
+    assert.match(report.parityFollowup.body, /scope: リポジトリ全体/);
 
     const md = renderSummaryMarkdown(emptySnapshot, parity, report, []);
-    assert.match(md, /Advisory queue: 2 issues \(1 files, 1 blocking; full repo\)/);
+    assert.match(md, /advisory キュー: 2 件 \(1 ファイル, 1 ブロッキング; リポジトリ全体\)/);
   });
 
   it('shouldOpenIssue = false when advisory has blocking items but scope is not complete', () => {
@@ -1040,7 +1040,7 @@ describe('parityFollowup in buildActionableReport', () => {
     assert.doesNotMatch(report.parityFollowup.body, /partial-only/);
 
     const md = renderSummaryMarkdown(emptySnapshot, parity, report, []);
-    assert.match(md, /Advisory queue: 2 issues \(1 files, 1 blocking; partial scope: slug=overview\/page-a, not repo-wide\)/);
+    assert.match(md, /advisory キュー: 2 件 \(1 ファイル, 1 ブロッキング; 部分 scope: slug=overview\/page-a、リポジトリ全体ではない\)/);
   });
 
   it('parityFollowup body contains invalidated slugs', () => {
@@ -1290,8 +1290,8 @@ describe('Issue #247 PR4 — parityFollowup sourceUnusable subsection exposure',
     };
     const report = buildActionableReport(emptySnapshot, parity, []);
     assert.equal(report.parityFollowup.shouldOpenIssue, true);
-    assert.match(report.parityFollowup.body, /## Source Unusable \(advisory\)/);
-    assert.match(report.parityFollowup.body, /Total: 4 issues across 2 files/);
+    assert.match(report.parityFollowup.body, /## ソース使用不可 \(advisory\)/);
+    assert.match(report.parityFollowup.body, /合計: 4 件 \(2 ファイル\)/);
     // sort 順固定: snapshot-incomplete → source-unusable
     assert.match(report.parityFollowup.body, /snapshot-incomplete: 3/);
     assert.match(report.parityFollowup.body, /source-unusable: 1/);
@@ -1329,7 +1329,7 @@ describe('Issue #247 PR4 — parityFollowup sourceUnusable subsection exposure',
     };
     const report = buildActionableReport(emptySnapshot, parity, []);
     assert.equal(report.parityFollowup.shouldOpenIssue, true);
-    assert.doesNotMatch(report.parityFollowup.body, /## Source Unusable/);
+    assert.doesNotMatch(report.parityFollowup.body, /## ソース使用不可/);
   });
 });
 
@@ -1416,13 +1416,13 @@ describe('Issue #247 PR5 — renderSummaryMarkdown structure / source unusable s
     assert.doesNotMatch(md, /## Structure Mismatch/);
   });
 
-  it('includes "## Source Unusable (advisory)" section when snapshotUnusableIssues > 0', () => {
+  it('includes "## ソース使用不可 (advisory)" section when snapshotUnusableIssues > 0', () => {
     const { snapshot, parity, actionableReport } = makeBaseInputs();
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
-    assert.match(md, /## Source Unusable \(advisory\)/);
-    assert.match(md, /Total: 2 issues across 2 files/);
+    assert.match(md, /## ソース使用不可 \(advisory\)/);
+    assert.match(md, /合計: 2 件 \(2 ファイル\)/);
     // 翻訳者責任外であることの注意文
-    assert.match(md, /translation failure|snapshot.*source sync|翻訳/);
+    assert.match(md, /翻訳失敗|snapshot.*source sync|翻訳/);
     // type 別内訳 (alpha sort)
     assert.match(md, /snapshot-incomplete: 1/);
     assert.match(md, /source-unusable: 1/);
@@ -1473,17 +1473,17 @@ describe('Issue #247 PR5 — renderSummaryMarkdown structure / source unusable s
     };
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
     assert.doesNotMatch(md, /## Structure Mismatch/);
-    assert.doesNotMatch(md, /## Source Unusable/);
+    assert.doesNotMatch(md, /## ソース使用不可/);
   });
 
-  it('## Parity section の "Active issue files" は structure mismatch も含む値 (PR5 cutover)', () => {
+  it('## パリティ section の "active issue ファイル" は structure mismatch も含む値 (PR5 cutover)', () => {
     // PR5 cutover で structure mismatch が reportable になったため、
     // structureMismatchFiles ぶんが `reportableActiveFiles` 経由で
-    // "Active issue files" にも反映される。
+    // "active issue ファイル" にも反映される。
     const { snapshot, parity, actionableReport } = makeBaseInputs();
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
-    assert.match(md, /Active issue files: 3/);
-    assert.match(md, /Active actionable files: 3/);
+    assert.match(md, /active issue ファイル: 3/);
+    assert.match(md, /active actionable ファイル: 3/);
   });
 });
 
@@ -2072,22 +2072,22 @@ describe('Phase 8 — family count and audit manifest invariants', () => {
     };
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
 
-    // Parity section: active counts must reflect Phase 8 reportable
+    // パリティ section: active counts must reflect Phase 8 reportable
     // counters, NOT the legacy ones that include coarse signals.
-    assert.match(md, /## Parity/);
-    assert.match(md, /Active actionable files: 0/);
-    assert.match(md, /Active issue files: 0/);
+    assert.match(md, /## パリティ/);
+    assert.match(md, /active actionable ファイル: 0/);
+    assert.match(md, /active issue ファイル: 0/);
 
-    // Audit Signals section exists and lists the coarse breakdown.
-    assert.match(md, /## Audit Signals/);
+    // 監査シグナル section exists and lists the coarse breakdown.
+    assert.match(md, /## 監査シグナル/);
     assert.match(md, /paragraph-count-mismatch: 2/);
     assert.match(md, /heading-mismatch: 1/);
 
-    // Sanity: coarse signal labels must NOT show up inside the Parity
-    // section. The simplest way to test this is to extract the Parity
+    // Sanity: coarse signal labels must NOT show up inside the パリティ
+    // section. The simplest way to test this is to extract the パリティ
     // section text and check it for the coarse type names.
-    const paritySectionMatch = md.match(/## Parity\n([\s\S]*?)(?:\n## |$)/);
-    assert.ok(paritySectionMatch, 'Parity section must exist');
+    const paritySectionMatch = md.match(/## パリティ\n([\s\S]*?)(?:\n## |$)/);
+    assert.ok(paritySectionMatch, 'パリティ section must exist');
     const paritySection = paritySectionMatch[1];
     assert.doesNotMatch(paritySection, /paragraph-count-mismatch/);
     assert.doesNotMatch(paritySection, /heading-mismatch/);
@@ -2496,5 +2496,210 @@ describe('§1 cleanup — loadDetectionInputs strict mode', () => {
     // Skipped here because the helper assumes filesystem inputs; the
     // direct validateDetectionInputs tests above already cover the
     // failure logic.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #255 Phase 4 — source-side debt visibility and Japanization
+// ---------------------------------------------------------------------------
+
+describe('Issue #255 — source-side debt section in summary markdown', () => {
+  const emptySnapshot = {
+    checkedAt: '2026-04-09T00:00:00Z',
+    summary: { totalSnapshots: 100, changed: 0, added: 0, removed: 0, unchanged: 100 },
+    changes: [],
+    sidebar: { changed: false, addedPages: [], removedPages: [] },
+  };
+  const emptyParity = {
+    summary: {
+      checkedAt: '2026-04-09T00:00:00Z',
+      actionableFiles: 0,
+      signalFiles: 0,
+      errorFiles: 0,
+    },
+    files: [],
+  };
+
+  it('emits "## Source-side debt" (日本語) section when excluded pages exist', () => {
+    const sourceSync = {
+      schemaVersion: 1,
+      freshnessState: 'fresh',
+      summary: {
+        targetPages: 100,
+        fetchedPages: 99,
+        notFoundPages: 0,
+        errorPages: 0,
+        excludedPages: 1,
+        excludedBrokenPages: 1,
+        excludedRecoveredPages: 0,
+        sidebarVerified: true,
+      },
+      pages: [
+        {
+          slug: 'testops/testops-version-control/pull-requests',
+          fetchStatus: 'excluded-broken',
+          debtCategory: 'source-side-debt',
+          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        },
+      ],
+      errors: [],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+    const md = renderSummaryMarkdown(emptySnapshot, emptyParity, report, [], sourceSync);
+
+    // 日本語セクション見出しが emit される
+    assert.match(md, /## ソース側 debt/);
+    // Counters (human-readable Japanese labels)
+    assert.match(md, /除外ページ: 1/);
+    assert.match(md, /未復旧: 1/);
+    assert.match(md, /復旧候補: 0/);
+    // Slug listing subsection
+    assert.match(md, /### 未復旧/);
+    assert.match(md, /testops\/testops-version-control\/pull-requests/);
+    // Recovery probe 結果
+    assert.match(md, /snapshot-incomplete/);
+    assert.match(md, /extractor-empty/);
+  });
+
+  it('omits the section entirely when no excluded pages exist', () => {
+    const sourceSync = {
+      schemaVersion: 1,
+      freshnessState: 'fresh',
+      summary: {
+        targetPages: 100,
+        fetchedPages: 100,
+        notFoundPages: 0,
+        errorPages: 0,
+        excludedPages: 0,
+        excludedBrokenPages: 0,
+        excludedRecoveredPages: 0,
+        sidebarVerified: true,
+      },
+      pages: [],
+      errors: [],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+    const md = renderSummaryMarkdown(emptySnapshot, emptyParity, report, [], sourceSync);
+
+    assert.doesNotMatch(md, /## ソース側 debt/);
+    assert.doesNotMatch(md, /excluded-broken/);
+  });
+
+  it('lists recovery-candidate subsection (復旧候補) when excluded-recovered exists', () => {
+    const sourceSync = {
+      schemaVersion: 1,
+      freshnessState: 'fresh',
+      summary: {
+        targetPages: 100,
+        fetchedPages: 99,
+        notFoundPages: 0,
+        errorPages: 0,
+        excludedPages: 1,
+        excludedBrokenPages: 0,
+        excludedRecoveredPages: 1,
+        sidebarVerified: true,
+      },
+      pages: [
+        {
+          slug: 'testops/testops-version-control/pull-requests',
+          fetchStatus: 'excluded-recovered',
+          debtCategory: 'source-side-debt',
+          recoveryProbe: null,
+        },
+      ],
+      errors: [],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+    const md = renderSummaryMarkdown(emptySnapshot, emptyParity, report, [], sourceSync);
+
+    assert.match(md, /## ソース側 debt/);
+    assert.match(md, /復旧候補: 1/);
+    assert.match(md, /### 復旧候補/);
+    assert.match(md, /testops\/testops-version-control\/pull-requests/);
+    // recovered は「復旧したので registry から削除を検討」説明を含む
+    assert.match(md, /registry|登録解除|除外解除/);
+  });
+
+  it('exposes sourceSideDebt counters on actionable report JSON', () => {
+    // JSON consumer (sync-detection-issues / dashboards) が独立に
+    // counter を読めるように、docs-actionable-report.json にも露出する
+    const sourceSync = {
+      schemaVersion: 1,
+      freshnessState: 'fresh',
+      summary: {
+        targetPages: 100,
+        fetchedPages: 98,
+        notFoundPages: 0,
+        errorPages: 0,
+        excludedPages: 2,
+        excludedBrokenPages: 1,
+        excludedRecoveredPages: 1,
+        sidebarVerified: true,
+      },
+      pages: [
+        {
+          slug: 'a',
+          fetchStatus: 'excluded-broken',
+          debtCategory: 'source-side-debt',
+          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        },
+        {
+          slug: 'b',
+          fetchStatus: 'excluded-recovered',
+          debtCategory: 'source-side-debt',
+          recoveryProbe: null,
+        },
+      ],
+      errors: [],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+
+    assert.ok(
+      report.sourceSyncHealth.sourceSideDebt,
+      'actionable report must expose sourceSideDebt under sourceSyncHealth',
+    );
+    assert.equal(report.sourceSyncHealth.sourceSideDebt.excludedPages, 2);
+    assert.equal(report.sourceSyncHealth.sourceSideDebt.excludedBrokenPages, 1);
+    assert.equal(report.sourceSyncHealth.sourceSideDebt.excludedRecoveredPages, 1);
+
+    // brokenSlugs / recoveredSlugs が slug list として露出している
+    assert.deepEqual(report.sourceSyncHealth.sourceSideDebt.brokenSlugs, ['a']);
+    assert.deepEqual(report.sourceSyncHealth.sourceSideDebt.recoveredSlugs, ['b']);
+  });
+
+  it('Source Sync Health issue body surfaces source-side debt info in 日本語', () => {
+    // freshnessState=partial (broken 以外) で issue body が開いたとき、
+    // source-side debt 情報も日本語で body に入る
+    const sourceSync = {
+      schemaVersion: 1,
+      freshnessState: 'partial',
+      summary: {
+        targetPages: 100,
+        fetchedPages: 95,
+        notFoundPages: 0,
+        errorPages: 4,
+        excludedPages: 1,
+        excludedBrokenPages: 1,
+        excludedRecoveredPages: 0,
+        sidebarVerified: true,
+      },
+      pages: [
+        {
+          slug: 'testops/testops-version-control/pull-requests',
+          fetchStatus: 'excluded-broken',
+          debtCategory: 'source-side-debt',
+          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        },
+      ],
+      errors: [{ slug: 'x', detail: 'HTTP 500' }],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, true);
+    // Issue body is bilingual — heading can stay English for now (Phase 4b
+    // migrates the whole markdown), but the debt subsection is Japanese
+    assert.match(report.sourceSyncHealth.body, /ソース側 debt/);
+    assert.match(report.sourceSyncHealth.body, /testops\/testops-version-control\/pull-requests/);
+    assert.match(report.sourceSyncHealth.body, /未復旧/);
   });
 });

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -670,7 +670,7 @@ describe('renderSummaryMarkdown', () => {
     assert.match(md, /変更ページ: 3/);
     assert.match(md, /追加ページ: 1/);
     assert.match(md, /## パリティ/);
-    assert.match(md, /actionable ファイル: 2/);
+    assert.match(md, /要対応ファイル: 2/);
     assert.match(md, /## 監査マニフェスト/);
     assert.match(md, /ページライフサイクル: 1/);
     assert.match(md, /構造変更: 1/);
@@ -705,8 +705,8 @@ describe('renderSummaryMarkdown', () => {
     };
 
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
-    assert.match(md, /actionable ファイル: 0/);
-    assert.match(md, /issue ファイル: 0/);
+    assert.match(md, /要対応ファイル: 0/);
+    assert.match(md, /問題ファイル: 0/);
     assert.match(md, /承認済み \(非ブロッキング\): 41/);
     // The legacy counters must not appear standalone in a way that contradicts activeFiles:0.
     assert.doesNotMatch(md, /^- Signal-only files: 22$/m);
@@ -782,7 +782,7 @@ describe('renderSummaryMarkdown', () => {
     };
 
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
-    assert.match(md, /advisory キュー: 2 件 \(1 ファイル, 1 ブロッキング; 部分 scope: slug=overview\/page-a、リポジトリ全体ではない\)/);
+    assert.match(md, /アドバイザリキュー: 2 件 \(1 ファイル, 1 ブロッキング; 部分スコープ: slug=overview\/page-a、リポジトリ全体ではない\)/);
   });
 });
 
@@ -963,10 +963,10 @@ describe('parityFollowup in buildActionableReport', () => {
       report.parityFollowup.summary.reviewHints.tokenlessNearTieExamples[0].slug,
       'overview/page-a',
     );
-    assert.match(report.parityFollowup.body, /scope: リポジトリ全体/);
+    assert.match(report.parityFollowup.body, /スコープ: リポジトリ全体/);
 
     const md = renderSummaryMarkdown(emptySnapshot, parity, report, []);
-    assert.match(md, /advisory キュー: 2 件 \(1 ファイル, 1 ブロッキング; リポジトリ全体\)/);
+    assert.match(md, /アドバイザリキュー: 2 件 \(1 ファイル, 1 ブロッキング; リポジトリ全体\)/);
   });
 
   it('shouldOpenIssue = false when advisory has blocking items but scope is not complete', () => {
@@ -1040,7 +1040,7 @@ describe('parityFollowup in buildActionableReport', () => {
     assert.doesNotMatch(report.parityFollowup.body, /partial-only/);
 
     const md = renderSummaryMarkdown(emptySnapshot, parity, report, []);
-    assert.match(md, /advisory キュー: 2 件 \(1 ファイル, 1 ブロッキング; 部分 scope: slug=overview\/page-a、リポジトリ全体ではない\)/);
+    assert.match(md, /アドバイザリキュー: 2 件 \(1 ファイル, 1 ブロッキング; 部分スコープ: slug=overview\/page-a、リポジトリ全体ではない\)/);
   });
 
   it('parityFollowup body contains invalidated slugs', () => {
@@ -1259,7 +1259,7 @@ describe('Issue #247 PR4 — parityFollowup sourceUnusable subsection exposure',
     assert.equal(report.parityFollowup.body, '');
   });
 
-  it('parityFollowup.body contains "## Source Unusable (advisory)" section when sourceUnusable counts > 0 AND another signal opens the issue', () => {
+  it('parityFollowup.body contains "## ソース使用不可 (参考)" section when sourceUnusable counts > 0 AND another signal opens the issue', () => {
     // body は `shouldOpenIssue=true` のときだけ生成される。source-unusable
     // 単独では shouldOpenIssue が立たないので、別の signal (expired
     // baseline) と同居させて body を生成させる。
@@ -1290,8 +1290,8 @@ describe('Issue #247 PR4 — parityFollowup sourceUnusable subsection exposure',
     };
     const report = buildActionableReport(emptySnapshot, parity, []);
     assert.equal(report.parityFollowup.shouldOpenIssue, true);
-    assert.match(report.parityFollowup.body, /## ソース使用不可 \(advisory\)/);
-    assert.match(report.parityFollowup.body, /合計: 4 件 \(2 ファイル\)/);
+    assert.match(report.parityFollowup.body, /## ソース使用不可 \(参考\)/);
+    assert.match(report.parityFollowup.body, /合計: 4 件/);
     // sort 順固定: snapshot-incomplete → source-unusable
     assert.match(report.parityFollowup.body, /snapshot-incomplete: 3/);
     assert.match(report.parityFollowup.body, /source-unusable: 1/);
@@ -1329,7 +1329,7 @@ describe('Issue #247 PR4 — parityFollowup sourceUnusable subsection exposure',
     };
     const report = buildActionableReport(emptySnapshot, parity, []);
     assert.equal(report.parityFollowup.shouldOpenIssue, true);
-    assert.doesNotMatch(report.parityFollowup.body, /## ソース使用不可/);
+    assert.doesNotMatch(report.parityFollowup.body, /## ソース使用不可 \(参考\)/);
   });
 });
 
@@ -1419,7 +1419,7 @@ describe('Issue #247 PR5 — renderSummaryMarkdown structure / source unusable s
   it('includes "## ソース使用不可 (advisory)" section when snapshotUnusableIssues > 0', () => {
     const { snapshot, parity, actionableReport } = makeBaseInputs();
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
-    assert.match(md, /## ソース使用不可 \(advisory\)/);
+    assert.match(md, /## ソース使用不可 \(参考\)/);
     assert.match(md, /合計: 2 件 \(2 ファイル\)/);
     // 翻訳者責任外であることの注意文
     assert.match(md, /翻訳の問題ではなく|スナップショット.*ソース同期|翻訳 PR では修正できません/);
@@ -1482,8 +1482,8 @@ describe('Issue #247 PR5 — renderSummaryMarkdown structure / source unusable s
     // "issue ファイル" にも反映される。
     const { snapshot, parity, actionableReport } = makeBaseInputs();
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
-    assert.match(md, /issue ファイル: 3/);
-    assert.match(md, /actionable ファイル: 3/);
+    assert.match(md, /問題ファイル: 3/);
+    assert.match(md, /要対応ファイル: 3/);
   });
 });
 
@@ -2075,8 +2075,8 @@ describe('Phase 8 — family count and audit manifest invariants', () => {
     // パリティ section: active counts must reflect Phase 8 reportable
     // counters, NOT the legacy ones that include coarse signals.
     assert.match(md, /## パリティ/);
-    assert.match(md, /actionable ファイル: 0/);
-    assert.match(md, /issue ファイル: 0/);
+    assert.match(md, /要対応ファイル: 0/);
+    assert.match(md, /問題ファイル: 0/);
 
     // 監査シグナル section exists and lists the coarse breakdown.
     assert.match(md, /## 監査シグナル/);

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -1422,7 +1422,7 @@ describe('Issue #247 PR5 — renderSummaryMarkdown structure / source unusable s
     assert.match(md, /## ソース使用不可 \(advisory\)/);
     assert.match(md, /合計: 2 件 \(2 ファイル\)/);
     // 翻訳者責任外であることの注意文
-    assert.match(md, /翻訳失敗|snapshot.*source sync|翻訳/);
+    assert.match(md, /翻訳の問題ではなく|スナップショット.*ソース同期|翻訳 PR では修正できません/);
     // type 別内訳 (alpha sort)
     assert.match(md, /snapshot-incomplete: 1/);
     assert.match(md, /source-unusable: 1/);

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -2527,7 +2527,27 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
     assert.doesNotThrow(() => validateSourceSyncStatus(v));
   });
 
-  it('throws when recoveryProbe is a non-object primitive (shape validation)', () => {
+  // --- fetchStatus × recoveryProbe の組み合わせ契約 ---
+
+  it('throws when excluded-broken has recoveryProbe: null (不可能状態)', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: null,
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /recoveryProbe must be an object for excluded-broken/,
+    );
+  });
+
+  it('throws when excluded-broken has recoveryProbe as primitive', () => {
     const v = validSourceSyncStatus();
     v.summary.excludedPages = 1;
     v.summary.excludedBrokenPages = 1;
@@ -2541,47 +2561,11 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
     ];
     assert.throws(
       () => validateSourceSyncStatus(v),
-      /recoveryProbe must be object\|null/,
+      /recoveryProbe must be an object for excluded-broken/,
     );
   });
 
-  it('throws when recoveryProbe.issueType is not a string', () => {
-    const v = validSourceSyncStatus();
-    v.summary.excludedPages = 1;
-    v.summary.excludedBrokenPages = 1;
-    v.pages = [
-      {
-        slug: 'a',
-        fetchStatus: 'excluded-broken',
-        debtCategory: 'source-side-debt',
-        recoveryProbe: { issueType: null, reason: 'extractor-empty' },
-      },
-    ];
-    assert.throws(
-      () => validateSourceSyncStatus(v),
-      /recoveryProbe\.issueType must be a string/,
-    );
-  });
-
-  it('throws when recoveryProbe.reason is not a string', () => {
-    const v = validSourceSyncStatus();
-    v.summary.excludedPages = 1;
-    v.summary.excludedBrokenPages = 1;
-    v.pages = [
-      {
-        slug: 'a',
-        fetchStatus: 'excluded-broken',
-        debtCategory: 'source-side-debt',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 42 },
-      },
-    ];
-    assert.throws(
-      () => validateSourceSyncStatus(v),
-      /recoveryProbe\.reason must be a string/,
-    );
-  });
-
-  it('throws when recoveryProbe is an array', () => {
+  it('throws when excluded-broken has recoveryProbe as array', () => {
     const v = validSourceSyncStatus();
     v.summary.excludedPages = 1;
     v.summary.excludedBrokenPages = 1;
@@ -2595,7 +2579,115 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
     ];
     assert.throws(
       () => validateSourceSyncStatus(v),
-      /recoveryProbe must be object\|null/,
+      /recoveryProbe must be an object for excluded-broken/,
+    );
+  });
+
+  it('throws when excluded-broken recoveryProbe.expectedMatch is missing', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /recoveryProbe\.expectedMatch must be a boolean/,
+    );
+  });
+
+  it('throws when excluded-broken recoveryProbe.expectedMatch is not boolean', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedMatch: 'yes' },
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /recoveryProbe\.expectedMatch must be a boolean/,
+    );
+  });
+
+  it('throws when excluded-broken recoveryProbe.issueType is not a string', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: { issueType: null, reason: 'extractor-empty', expectedMatch: true },
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /recoveryProbe\.issueType must be a string/,
+    );
+  });
+
+  it('throws when excluded-broken recoveryProbe.reason is not a string', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 42, expectedMatch: true },
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /recoveryProbe\.reason must be a string/,
+    );
+  });
+
+  it('throws when excluded-recovered has non-null recoveryProbe (不可能状態)', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedRecoveredPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-recovered',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedMatch: true },
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /recoveryProbe must be null for excluded-recovered/,
+    );
+  });
+
+  it('throws when debtCategory is not "source-side-debt"', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'foo',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedMatch: true },
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /debtCategory must be "source-side-debt"/,
     );
   });
 });

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -2761,6 +2761,72 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
       /must have debtCategory "source-side-debt"/,
     );
   });
+
+  it('throws when summary.excludedPages disagrees with pages[]', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 0;
+    v.summary.excludedBrokenPages = 0;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: {
+          issueType: 'snapshot-incomplete',
+          reason: 'extractor-empty',
+          expectedIssueType: 'snapshot-incomplete',
+          expectedReason: 'extractor-empty',
+          expectedMatch: true,
+        },
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /summary\.excludedPages must equal pages\[\] excluded count/,
+    );
+  });
+
+  it('throws when summary.excludedBrokenPages disagrees with pages[]', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 0;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: {
+          issueType: 'snapshot-incomplete',
+          reason: 'extractor-empty',
+          expectedIssueType: 'snapshot-incomplete',
+          expectedReason: 'extractor-empty',
+          expectedMatch: true,
+        },
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /summary\.excludedBrokenPages must equal pages\[\] excluded-broken count/,
+    );
+  });
+
+  it('throws when summary.excludedRecoveredPages disagrees with pages[]', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedRecoveredPages = 0;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-recovered',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: null,
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /summary\.excludedRecoveredPages must equal pages\[\] excluded-recovered count/,
+    );
+  });
 });
 
 describe('§1 cleanup — validateDetectionInputs', () => {
@@ -2983,6 +3049,44 @@ describe('Issue #255 — source-side debt section in summary markdown', () => {
     // brokenSlugs / recoveredSlugs が slug list として露出している
     assert.deepEqual(report.sourceSyncHealth.sourceSideDebt.brokenSlugs, ['a']);
     assert.deepEqual(report.sourceSyncHealth.sourceSideDebt.recoveredSlugs, ['b']);
+  });
+
+  it('recomputes source-side debt counters from pages[] even when summary counters are stale', () => {
+    const sourceSync = {
+      schemaVersion: 2,
+      freshnessState: 'fresh',
+      summary: {
+        targetPages: 100,
+        fetchedPages: 100,
+        notFoundPages: 0,
+        errorPages: 0,
+        excludedPages: 0,
+        excludedBrokenPages: 0,
+        excludedRecoveredPages: 0,
+        sidebarVerified: true,
+      },
+      pages: [
+        {
+          slug: 'a',
+          fetchStatus: 'excluded-broken',
+          debtCategory: 'source-side-debt',
+          recoveryProbe: {
+            issueType: 'snapshot-incomplete',
+            reason: 'extractor-empty',
+            expectedIssueType: 'snapshot-incomplete',
+            expectedReason: 'extractor-empty',
+            expectedMatch: true,
+          },
+        },
+      ],
+      errors: [],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, true);
+    assert.equal(report.sourceSyncHealth.sourceSideDebt.excludedPages, 1);
+    assert.equal(report.sourceSyncHealth.sourceSideDebt.excludedBrokenPages, 1);
+    assert.deepEqual(report.sourceSyncHealth.sourceSideDebt.brokenSlugs, ['a']);
   });
 
   it('Source Sync Health issue body surfaces source-side debt info in 日本語', () => {

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -670,7 +670,7 @@ describe('renderSummaryMarkdown', () => {
     assert.match(md, /変更ページ: 3/);
     assert.match(md, /追加ページ: 1/);
     assert.match(md, /## パリティ/);
-    assert.match(md, /active actionable ファイル: 2/);
+    assert.match(md, /actionable ファイル: 2/);
     assert.match(md, /## 監査マニフェスト/);
     assert.match(md, /ページライフサイクル: 1/);
     assert.match(md, /構造変更: 1/);
@@ -705,8 +705,8 @@ describe('renderSummaryMarkdown', () => {
     };
 
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
-    assert.match(md, /active actionable ファイル: 0/);
-    assert.match(md, /active issue ファイル: 0/);
+    assert.match(md, /actionable ファイル: 0/);
+    assert.match(md, /issue ファイル: 0/);
     assert.match(md, /承認済み \(非ブロッキング\): 41/);
     // The legacy counters must not appear standalone in a way that contradicts activeFiles:0.
     assert.doesNotMatch(md, /^- Signal-only files: 22$/m);
@@ -1476,14 +1476,14 @@ describe('Issue #247 PR5 — renderSummaryMarkdown structure / source unusable s
     assert.doesNotMatch(md, /## ソース使用不可/);
   });
 
-  it('## パリティ section の "active issue ファイル" は structure mismatch も含む値 (PR5 cutover)', () => {
+  it('## パリティ section の "issue ファイル" は structure mismatch も含む値 (PR5 cutover)', () => {
     // PR5 cutover で structure mismatch が reportable になったため、
     // structureMismatchFiles ぶんが `reportableActiveFiles` 経由で
-    // "active issue ファイル" にも反映される。
+    // "issue ファイル" にも反映される。
     const { snapshot, parity, actionableReport } = makeBaseInputs();
     const md = renderSummaryMarkdown(snapshot, parity, actionableReport, []);
-    assert.match(md, /active issue ファイル: 3/);
-    assert.match(md, /active actionable ファイル: 3/);
+    assert.match(md, /issue ファイル: 3/);
+    assert.match(md, /actionable ファイル: 3/);
   });
 });
 
@@ -2075,8 +2075,8 @@ describe('Phase 8 — family count and audit manifest invariants', () => {
     // パリティ section: active counts must reflect Phase 8 reportable
     // counters, NOT the legacy ones that include coarse signals.
     assert.match(md, /## パリティ/);
-    assert.match(md, /active actionable ファイル: 0/);
-    assert.match(md, /active issue ファイル: 0/);
+    assert.match(md, /actionable ファイル: 0/);
+    assert.match(md, /issue ファイル: 0/);
 
     // 監査シグナル section exists and lists the coarse breakdown.
     assert.match(md, /## 監査シグナル/);
@@ -2249,6 +2249,9 @@ function validSourceSyncStatus() {
       fetchedPages: 100,
       notFoundPages: 0,
       errorPages: 0,
+      excludedPages: 0,
+      excludedBrokenPages: 0,
+      excludedRecoveredPages: 0,
       sidebarVerified: true,
     },
     pages: [],
@@ -2442,6 +2445,86 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
     const v = validSourceSyncStatus();
     v.errors = null;
     assert.throws(() => validateSourceSyncStatus(v), /errors must be an array/);
+  });
+
+  // Issue #255 — excluded counter の strict validation
+  it('throws when summary.excludedPages is not a number', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 'one';
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /summary\.excludedPages must be a number/,
+    );
+  });
+
+  it('throws when summary.excludedBrokenPages is not a number', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedBrokenPages = null;
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /summary\.excludedBrokenPages must be a number/,
+    );
+  });
+
+  it('throws when summary.excludedRecoveredPages is not a number', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedRecoveredPages = undefined;
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /summary\.excludedRecoveredPages must be a number/,
+    );
+  });
+
+  it('throws when a debt page has invalid fetchStatus', () => {
+    const v = validSourceSyncStatus();
+    v.pages = [
+      { slug: 'a', fetchStatus: 'excluded-typo', debtCategory: 'source-side-debt' },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /fetchStatus.*excluded-broken\|excluded-recovered/,
+    );
+  });
+
+  it('throws when a debt page is missing recoveryProbe', () => {
+    const v = validSourceSyncStatus();
+    v.pages = [
+      { slug: 'a', fetchStatus: 'excluded-broken', debtCategory: 'source-side-debt' },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /recoveryProbe/,
+    );
+  });
+
+  it('accepts valid debt page with recoveryProbe object', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedMatch: true },
+      },
+    ];
+    assert.doesNotThrow(() => validateSourceSyncStatus(v));
+  });
+
+  it('accepts valid debt page with recoveryProbe null (excluded-recovered)', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedRecoveredPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-recovered',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: null,
+      },
+    ];
+    assert.doesNotThrow(() => validateSourceSyncStatus(v));
   });
 });
 

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -2508,7 +2508,7 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
         slug: 'a',
         fetchStatus: 'excluded-broken',
         debtCategory: 'source-side-debt',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedMatch: true },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
       },
     ];
     assert.doesNotThrow(() => validateSourceSyncStatus(v));
@@ -2594,7 +2594,7 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
         slug: 'a',
         fetchStatus: 'excluded-broken',
         debtCategory: 'source-side-debt',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty' },
       },
     ];
     assert.throws(
@@ -2612,7 +2612,7 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
         slug: 'a',
         fetchStatus: 'excluded-broken',
         debtCategory: 'source-side-debt',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedMatch: 'yes' },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: 'yes' },
       },
     ];
     assert.throws(
@@ -2666,7 +2666,7 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
         slug: 'a',
         fetchStatus: 'excluded-recovered',
         debtCategory: 'source-side-debt',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedMatch: true },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
       },
     ];
     assert.throws(
@@ -2683,7 +2683,7 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
       {
         slug: 'a',
         fetchStatus: 'excluded-broken',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedMatch: true },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
       },
     ];
     assert.throws(
@@ -2733,7 +2733,7 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
         slug: 'a',
         fetchStatus: 'excluded-broken',
         debtCategory: 'foo',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedMatch: true },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
       },
     ];
     assert.throws(
@@ -2837,7 +2837,7 @@ describe('Issue #255 — source-side debt section in summary markdown', () => {
           slug: 'testops/testops-version-control/pull-requests',
           fetchStatus: 'excluded-broken',
           debtCategory: 'source-side-debt',
-          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
         },
       ],
       errors: [],
@@ -2939,7 +2939,7 @@ describe('Issue #255 — source-side debt section in summary markdown', () => {
           slug: 'a',
           fetchStatus: 'excluded-broken',
           debtCategory: 'source-side-debt',
-          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
         },
         {
           slug: 'b',
@@ -2986,7 +2986,7 @@ describe('Issue #255 — source-side debt section in summary markdown', () => {
           slug: 'testops/testops-version-control/pull-requests',
           fetchStatus: 'excluded-broken',
           debtCategory: 'source-side-debt',
-          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
         },
       ],
       errors: [{ slug: 'x', detail: 'HTTP 500' }],
@@ -3020,7 +3020,7 @@ describe('Issue #255 — source-side debt section in summary markdown', () => {
           slug: 'testops/testops-version-control/pull-requests',
           fetchStatus: 'excluded-broken',
           debtCategory: 'source-side-debt',
-          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
         },
       ],
       errors: [],
@@ -3056,5 +3056,93 @@ describe('Issue #255 — source-side debt section in summary markdown', () => {
 
     // debt なし + fresh → 従来通り issue は開かない
     assert.equal(report.sourceSyncHealth.shouldOpenIssue, false);
+  });
+
+  // --- Finding 2: expectedMatch が summary / issue body まで流れる ---
+
+  it('expectedMatch: true が summary markdown に「想定どおり」として出る', () => {
+    const sourceSync = {
+      schemaVersion: 1,
+      freshnessState: 'fresh',
+      summary: {
+        targetPages: 100, fetchedPages: 99, notFoundPages: 0, errorPages: 0,
+        excludedPages: 1, excludedBrokenPages: 1, excludedRecoveredPages: 0,
+        sidebarVerified: true,
+      },
+      pages: [{
+        slug: 'test/broken',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: {
+          issueType: 'snapshot-incomplete', reason: 'extractor-empty',
+          expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty',
+          expectedMatch: true,
+        },
+      }],
+      errors: [],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+    const md = renderSummaryMarkdown(emptySnapshot, emptyParity, report, [], sourceSync);
+
+    assert.match(md, /想定どおり/);
+    assert.match(md, /実際: snapshot-incomplete \/ extractor-empty/);
+    assert.match(md, /期待: snapshot-incomplete \/ extractor-empty/);
+  });
+
+  it('expectedMatch: false が summary markdown に「想定と不一致」+ actual/expected 両方出る', () => {
+    const sourceSync = {
+      schemaVersion: 1,
+      freshnessState: 'fresh',
+      summary: {
+        targetPages: 100, fetchedPages: 99, notFoundPages: 0, errorPages: 0,
+        excludedPages: 1, excludedBrokenPages: 1, excludedRecoveredPages: 0,
+        sidebarVerified: true,
+      },
+      pages: [{
+        slug: 'test/drifted',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: {
+          issueType: 'snapshot-incomplete', reason: 'shallow-snapshot',
+          expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty',
+          expectedMatch: false,
+        },
+      }],
+      errors: [],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+    const md = renderSummaryMarkdown(emptySnapshot, emptyParity, report, [], sourceSync);
+
+    assert.match(md, /想定と不一致/);
+    assert.match(md, /実際: snapshot-incomplete \/ shallow-snapshot/);
+    assert.match(md, /期待: snapshot-incomplete \/ extractor-empty/);
+  });
+
+  it('expectedMatch: false が issue body にも出る', () => {
+    const sourceSync = {
+      schemaVersion: 1,
+      freshnessState: 'fresh',
+      summary: {
+        targetPages: 100, fetchedPages: 99, notFoundPages: 0, errorPages: 0,
+        excludedPages: 1, excludedBrokenPages: 1, excludedRecoveredPages: 0,
+        sidebarVerified: true,
+      },
+      pages: [{
+        slug: 'test/drifted',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: {
+          issueType: 'snapshot-incomplete', reason: 'shallow-snapshot',
+          expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty',
+          expectedMatch: false,
+        },
+      }],
+      errors: [],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+
+    assert.match(report.sourceSyncHealth.body, /想定と不一致/);
+    assert.match(report.sourceSyncHealth.body, /実際: snapshot-incomplete \/ shallow-snapshot/);
+    assert.match(report.sourceSyncHealth.body, /期待: snapshot-incomplete \/ extractor-empty/);
   });
 });

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -2475,14 +2475,16 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
     );
   });
 
-  it('throws when a debt page has invalid fetchStatus', () => {
+  it('throws when non-excluded page carries debtCategory (e.g. fetchStatus typo)', () => {
+    // excluded-typo は excluded-* set に含まれないので non-excluded 扱いになり、
+    // debtCategory が残っていると "non-excluded page must not have debtCategory" で弾かれる
     const v = validSourceSyncStatus();
     v.pages = [
       { slug: 'a', fetchStatus: 'excluded-typo', debtCategory: 'source-side-debt' },
     ];
     assert.throws(
       () => validateSourceSyncStatus(v),
-      /fetchStatus.*excluded-broken\|excluded-recovered/,
+      /non-excluded page.*must not have debtCategory/,
     );
   });
 
@@ -2673,6 +2675,55 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
     );
   });
 
+  it('throws when excluded-broken page is missing debtCategory', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedMatch: true },
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /excluded page.*must have debtCategory/,
+    );
+  });
+
+  it('throws when excluded-recovered page is missing debtCategory', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedRecoveredPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-recovered',
+        recoveryProbe: null,
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /excluded page.*must have debtCategory/,
+    );
+  });
+
+  it('throws when non-excluded page carries recoveryProbe', () => {
+    const v = validSourceSyncStatus();
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'ok',
+        recoveryProbe: null,
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /non-excluded page.*must not have recoveryProbe/,
+    );
+  });
+
   it('throws when debtCategory is not "source-side-debt"', () => {
     const v = validSourceSyncStatus();
     v.summary.excludedPages = 1;
@@ -2687,7 +2738,7 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
     ];
     assert.throws(
       () => validateSourceSyncStatus(v),
-      /debtCategory must be "source-side-debt"/,
+      /must have debtCategory "source-side-debt"/,
     );
   });
 });

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -2696,10 +2696,67 @@ describe('Issue #255 — source-side debt section in summary markdown', () => {
     const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
 
     assert.equal(report.sourceSyncHealth.shouldOpenIssue, true);
-    // Issue body is bilingual — heading can stay English for now (Phase 4b
-    // migrates the whole markdown), but the debt subsection is Japanese
     assert.match(report.sourceSyncHealth.body, /ソース側 debt/);
     assert.match(report.sourceSyncHealth.body, /testops\/testops-version-control\/pull-requests/);
     assert.match(report.sourceSyncHealth.body, /未復旧/);
+  });
+
+  it('[P1] debt-only run (fresh) でも sourceSyncHealth issue が open する', () => {
+    // P1 フィードバック: freshness=fresh でも excludedPages > 0 なら
+    // managed issue に debt が載らないと運用契約が閉じない
+    const sourceSync = {
+      schemaVersion: 1,
+      freshnessState: 'fresh',
+      summary: {
+        targetPages: 100,
+        fetchedPages: 99,
+        notFoundPages: 0,
+        errorPages: 0,
+        excludedPages: 1,
+        excludedBrokenPages: 1,
+        excludedRecoveredPages: 0,
+        sidebarVerified: true,
+      },
+      pages: [
+        {
+          slug: 'testops/testops-version-control/pull-requests',
+          fetchStatus: 'excluded-broken',
+          debtCategory: 'source-side-debt',
+          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        },
+      ],
+      errors: [],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+
+    // fresh だが debt が残っているので issue は open される
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, true);
+    // body にソース側 debt セクションが含まれる
+    assert.match(report.sourceSyncHealth.body, /ソース側 debt/);
+    assert.match(report.sourceSyncHealth.body, /testops\/testops-version-control\/pull-requests/);
+    assert.match(report.sourceSyncHealth.body, /未復旧: 1/);
+  });
+
+  it('[P1] debt なし + fresh なら sourceSyncHealth issue は開かない (従来動作)', () => {
+    const sourceSync = {
+      schemaVersion: 1,
+      freshnessState: 'fresh',
+      summary: {
+        targetPages: 100,
+        fetchedPages: 100,
+        notFoundPages: 0,
+        errorPages: 0,
+        excludedPages: 0,
+        excludedBrokenPages: 0,
+        excludedRecoveredPages: 0,
+        sidebarVerified: true,
+      },
+      pages: [],
+      errors: [],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+
+    // debt なし + fresh → 従来通り issue は開かない
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, false);
   });
 });

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -2237,7 +2237,7 @@ function validActionableReport() {
 
 function validSourceSyncStatus() {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     runId: '2026-04-07T00:00:00Z#sync-deadbeef',
     checkedAt: '2026-04-07T00:00:00Z',
     sourceInventoryFingerprint: 'sha256:' + 'a'.repeat(64),
@@ -2391,6 +2391,26 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
     const v = validSourceSyncStatus();
     delete v.schemaVersion;
     assert.throws(() => validateSourceSyncStatus(v), /unsupported schemaVersion/);
+  });
+
+  it('accepts schemaVersion 1 (pre-#255 backward compat)', () => {
+    // v1 artifact は excluded* が無くても通る
+    const v = {
+      schemaVersion: 1,
+      runId: '2026-04-07T00:00:00Z#old',
+      checkedAt: '2026-04-07T00:00:00Z',
+      sourceInventoryFingerprint: 'sha256:' + 'a'.repeat(64),
+      sidebarFingerprint: 'sha256:' + 'b'.repeat(64),
+      freshnessState: 'fresh',
+      runScope: { type: 'full', isComplete: true, filters: { slug: null, section: null } },
+      summary: {
+        targetPages: 100, fetchedPages: 100, notFoundPages: 0, errorPages: 0,
+        sidebarVerified: true,
+      },
+      pages: [],
+      errors: [],
+    };
+    assert.doesNotThrow(() => validateSourceSyncStatus(v));
   });
 
   it('throws when runScope is missing', () => {

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -2526,6 +2526,78 @@ describe('§1 cleanup — validateSourceSyncStatus', () => {
     ];
     assert.doesNotThrow(() => validateSourceSyncStatus(v));
   });
+
+  it('throws when recoveryProbe is a non-object primitive (shape validation)', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: 123,
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /recoveryProbe must be object\|null/,
+    );
+  });
+
+  it('throws when recoveryProbe.issueType is not a string', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: { issueType: null, reason: 'extractor-empty' },
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /recoveryProbe\.issueType must be a string/,
+    );
+  });
+
+  it('throws when recoveryProbe.reason is not a string', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 42 },
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /recoveryProbe\.reason must be a string/,
+    );
+  });
+
+  it('throws when recoveryProbe is an array', () => {
+    const v = validSourceSyncStatus();
+    v.summary.excludedPages = 1;
+    v.summary.excludedBrokenPages = 1;
+    v.pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: ['snapshot-incomplete', 'extractor-empty'],
+      },
+    ];
+    assert.throws(
+      () => validateSourceSyncStatus(v),
+      /recoveryProbe must be object\|null/,
+    );
+  });
 });
 
 describe('§1 cleanup — validateDetectionInputs', () => {

--- a/scripts/__tests__/snapshot_update.test.mjs
+++ b/scripts/__tests__/snapshot_update.test.mjs
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { afterEach, before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
@@ -6,6 +7,7 @@ let extractMainContent;
 
 const originalFetch = global.fetch;
 const originalLog = console.log;
+const originalWriteFileSync = fs.writeFileSync;
 
 function createResponse({ ok = true, status = 200, text = '' } = {}) {
   return {
@@ -22,6 +24,7 @@ before(async () => {
 afterEach(() => {
   global.fetch = originalFetch;
   console.log = originalLog;
+  fs.writeFileSync = originalWriteFileSync;
 });
 
 describe('extractMainContent', () => {
@@ -136,5 +139,155 @@ describe('snapshot_update main', () => {
 
     assert.equal(result.fetched, 0);
     assert.equal(result.notFound, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #255 Phase 3b — source-side debt exclusion wiring
+//
+// pull-requests は registry に登録されているので、snapshot_update は
+//   1. fetch する
+//   2. snapshot file を上書きしない
+//   3. detectSourceUsability で recovery probe を実行する
+//   4. 結果を pageResults (excluded-broken / excluded-recovered) に流す
+// ---------------------------------------------------------------------------
+
+describe('snapshot_update — source-side debt exclusion', () => {
+  // broken upstream simulation: body 全体が <code> ブロックで wrap された
+  // 実際の live HTML を模して、extractMainContent が extract しても body が
+  // code/pre だけになるペイロード。detectSourceUsability は extractor-empty
+  // を発火する (EN body segment が 0)。
+  const BROKEN_PAGE_HTML =
+    '<html><body><div role="main" id="mc-main-content">' +
+    '<h1>Pull Requests</h1>' +
+    '<div class="codeSnippet"><div class="codeSnippetBody"><pre><code>' +
+    'Pull requests notify reviewers on changes introduced to a test.' +
+    '</code></pre></div></div>' +
+    '</div></body></html>';
+
+  // recovered upstream simulation: broken 状態から upstream が直り、
+  // 正しく <h2> / <p> / <ol> に分解された clean HTML が返る想定。
+  // detectSourceUsability は null (usable) を返すので excluded-recovered。
+  const CLEAN_PAGE_HTML =
+    '<html><body><div role="main" id="mc-main-content">' +
+    '<h1>Pull Requests</h1>' +
+    '<p>Pull requests notify reviewers on changes introduced to a test.</p>' +
+    '<h2>Creating a Pull Request</h2>' +
+    '<p>A pull request represents the difference between branches.</p>' +
+    '<h2>Reviewing a Pull Request</h2>' +
+    '<p>Reviewers are notified via email.</p>' +
+    '<h2>Resubmitting a Pull Request</h2>' +
+    '<p>If the reviewer sent back the PR you can respond.</p>' +
+    '</div></body></html>';
+
+  function mockTocFetchFor(pageHtml) {
+    const tocMainJs = "define({numchunks:1,prefix:'Mock_Chunk',tree:{n:[{i:0,c:0}]}});";
+    const tocChunkJs =
+      "define({'/content/testops/testops-version-control/pull-requests/index.htm':{i:[0],t:['Pull Requests'],b:['']}});";
+
+    return async (url) => {
+      const href = String(url);
+      if (href.includes('Main.js')) return createResponse({ text: tocMainJs });
+      if (href.includes('Mock_Chunk0.js')) return createResponse({ text: tocChunkJs });
+      return createResponse({ text: pageHtml });
+    };
+  }
+
+  it('broken upstream → fetchStatus excluded-broken with recovery probe', async () => {
+    global.fetch = mockTocFetchFor(BROKEN_PAGE_HTML);
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    // 1 target in scope
+    assert.equal(result.sourceSyncStatus.summary.targetPages, 1);
+    // excluded は ok / error / not-found のどれにも count されない
+    assert.equal(result.sourceSyncStatus.summary.fetchedPages, 0);
+    assert.equal(result.sourceSyncStatus.summary.errorPages, 0);
+    assert.equal(result.sourceSyncStatus.summary.notFoundPages, 0);
+    // 新 counter
+    assert.equal(result.sourceSyncStatus.summary.excludedPages, 1);
+    assert.equal(result.sourceSyncStatus.summary.excludedBrokenPages, 1);
+    assert.equal(result.sourceSyncStatus.summary.excludedRecoveredPages, 0);
+
+    // page 単位に debtCategory / recoveryProbe が載っている
+    const page = result.sourceSyncStatus.pages.find(
+      (p) => p.slug === 'testops/testops-version-control/pull-requests',
+    );
+    assert.ok(page);
+    assert.equal(page.fetchStatus, 'excluded-broken');
+    assert.equal(page.debtCategory, 'source-side-debt');
+    assert.ok(page.recoveryProbe);
+    assert.equal(page.recoveryProbe.issueType, 'snapshot-incomplete');
+    assert.equal(page.recoveryProbe.reason, 'extractor-empty');
+
+    // excluded は top-level errors に積まない
+    assert.equal(result.sourceSyncStatus.errors.length, 0);
+  });
+
+  it('recovered upstream → fetchStatus excluded-recovered and recoveryProbe is null', async () => {
+    global.fetch = mockTocFetchFor(CLEAN_PAGE_HTML);
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    assert.equal(result.sourceSyncStatus.summary.excludedPages, 1);
+    assert.equal(result.sourceSyncStatus.summary.excludedBrokenPages, 0);
+    assert.equal(result.sourceSyncStatus.summary.excludedRecoveredPages, 1);
+
+    const page = result.sourceSyncStatus.pages.find(
+      (p) => p.slug === 'testops/testops-version-control/pull-requests',
+    );
+    assert.ok(page);
+    assert.equal(page.fetchStatus, 'excluded-recovered');
+    assert.equal(page.debtCategory, 'source-side-debt');
+    assert.equal(page.recoveryProbe, null);
+  });
+
+  it('does not overwrite snapshot file even in non-dry-run mode', async () => {
+    global.fetch = mockTocFetchFor(BROKEN_PAGE_HTML);
+    console.log = () => {};
+
+    // fs.writeFileSync を完全にスパイし、全 write 呼び出しを record するが
+    // 実際のディスク書き込みは抑止する。これにより repo root 上の
+    // source-sync-status.json / sidebar.json / snapshot HTML が
+    // テスト実行で汚染されない。
+    const writeCalls = [];
+    fs.writeFileSync = (path, _content, ..._rest) => {
+      writeCalls.push(String(path));
+      // NOTE: 実 file には書かない — テストの目的は "どの path が write
+      // 対象として渡ってくるか" を observe することのみ。
+    };
+
+    await main(['--slug=pull-requests']);
+
+    const snapshotWrite = writeCalls.find((p) => p.includes('pull-requests.html'));
+    assert.equal(
+      snapshotWrite,
+      undefined,
+      `excluded slug の snapshot HTML を書き込んではならない — 書込発生: ${snapshotWrite}`,
+    );
+  });
+
+  it('exposes excluded counter on main() return value', async () => {
+    global.fetch = mockTocFetchFor(BROKEN_PAGE_HTML);
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    // main() が新 counter を返すことを契約として pin する
+    // (workflow / detection_reports から観測できるように)
+    assert.equal(result.excluded, 1);
+    assert.equal(result.fetched, 0);
+  });
+
+  it('debt-only run keeps freshnessState fresh (not broken)', async () => {
+    global.fetch = mockTocFetchFor(BROKEN_PAGE_HTML);
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    // excluded-only のみの scope でも sidebar さえ verified なら fresh
+    assert.equal(result.sourceSyncStatus.freshnessState, 'fresh');
   });
 });

--- a/scripts/__tests__/snapshot_update.test.mjs
+++ b/scripts/__tests__/snapshot_update.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 
 let main;
 let extractMainContent;
+let runRecoveryProbe;
 
 const originalFetch = global.fetch;
 const originalLog = console.log;
@@ -18,7 +19,7 @@ function createResponse({ ok = true, status = 200, text = '' } = {}) {
 }
 
 before(async () => {
-  ({ main, extractMainContent } = await import('../snapshot_update.mjs'));
+  ({ main, extractMainContent, runRecoveryProbe } = await import('../snapshot_update.mjs'));
 });
 
 afterEach(() => {
@@ -319,6 +320,47 @@ describe('snapshot_update — source-side debt exclusion', () => {
     const page = result.sourceSyncStatus.pages[0];
     assert.equal(page.fetchStatus, 'excluded-recovered');
     assert.equal(page.recoveryProbe, null);
+  });
+
+  it('extractor throw in recovery probe fails closed as excluded-broken', () => {
+    const result = runRecoveryProbe({
+      rawEnHtml: CLEAN_PAGE_HTML,
+      exclusionEntry: {
+        expectedIssueType: 'snapshot-incomplete',
+        expectedReason: 'extractor-empty',
+      },
+      extractSegments: () => {
+        throw new Error('simulated extractor failure');
+      },
+    });
+
+    assert.equal(result.fetchStatus, 'excluded-broken');
+    assert.deepEqual(result.recoveryProbe, {
+      issueType: 'probe-failed',
+      reason: 'extractor-throw',
+      expectedIssueType: 'snapshot-incomplete',
+      expectedReason: 'extractor-empty',
+      expectedMatch: false,
+    });
+  });
+
+  it('unsupported expectedReason in registry fails closed', () => {
+    const result = runRecoveryProbe({
+      rawEnHtml: CLEAN_PAGE_HTML,
+      exclusionEntry: {
+        expectedIssueType: 'snapshot-incomplete',
+        expectedReason: 'unknown-reason',
+      },
+    });
+
+    assert.equal(result.fetchStatus, 'excluded-broken');
+    assert.deepEqual(result.recoveryProbe, {
+      issueType: 'probe-failed',
+      reason: 'unsupported-expected-reason',
+      expectedIssueType: 'snapshot-incomplete',
+      expectedReason: 'unknown-reason',
+      expectedMatch: false,
+    });
   });
 
   // --- Finding 2: expectedMatch + actual/expected が probe output に載る ---

--- a/scripts/__tests__/snapshot_update.test.mjs
+++ b/scripts/__tests__/snapshot_update.test.mjs
@@ -101,7 +101,7 @@ describe('snapshot_update main', () => {
     const result = await main(['--dry-run', '--slug=testim-overview']);
 
     assert.ok(result.sourceSyncStatus, 'should include sourceSyncStatus');
-    assert.equal(result.sourceSyncStatus.schemaVersion, 1);
+    assert.equal(result.sourceSyncStatus.schemaVersion, 2);
     assert.equal(result.sourceSyncStatus.freshnessState, 'fresh');
     assert.equal(result.sourceSyncStatus.summary.targetPages, 1);
     assert.equal(result.sourceSyncStatus.summary.fetchedPages, 1);
@@ -166,9 +166,10 @@ describe('snapshot_update — source-side debt exclusion', () => {
     '</code></pre></div></div>' +
     '</div></body></html>';
 
-  // recovered upstream simulation: broken 状態から upstream が直り、
+  // clean upstream simulation: broken 状態から upstream が直り、
   // 正しく <h2> / <p> / <ol> に分解された clean HTML が返る想定。
-  // detectSourceUsability は null (usable) を返すので excluded-recovered。
+  // ただし EN-only probe は全分岐 fail-close なので excluded-broken
+  // (body-appeared-inconclusive) に倒れる。excluded-recovered は自動では起きない。
   const CLEAN_PAGE_HTML =
     '<html><body><div role="main" id="mc-main-content">' +
     '<h1>Pull Requests</h1>' +
@@ -228,23 +229,25 @@ describe('snapshot_update — source-side debt exclusion', () => {
     assert.equal(result.sourceSyncStatus.errors.length, 0);
   });
 
-  it('recovered upstream → fetchStatus excluded-recovered and recoveryProbe is null', async () => {
+  it('clean upstream → still excluded-broken (全分岐 fail-close、自動 recovery なし)', async () => {
     global.fetch = mockTocFetchFor(CLEAN_PAGE_HTML);
     console.log = () => {};
 
     const result = await main(['--dry-run', '--slug=pull-requests']);
 
+    // 自動 recovery は起きない — body が出ても inconclusive で broken に倒れる
     assert.equal(result.sourceSyncStatus.summary.excludedPages, 1);
-    assert.equal(result.sourceSyncStatus.summary.excludedBrokenPages, 0);
-    assert.equal(result.sourceSyncStatus.summary.excludedRecoveredPages, 1);
+    assert.equal(result.sourceSyncStatus.summary.excludedBrokenPages, 1);
+    assert.equal(result.sourceSyncStatus.summary.excludedRecoveredPages, 0);
 
     const page = result.sourceSyncStatus.pages.find(
       (p) => p.slug === 'testops/testops-version-control/pull-requests',
     );
     assert.ok(page);
-    assert.equal(page.fetchStatus, 'excluded-recovered');
+    assert.equal(page.fetchStatus, 'excluded-broken');
     assert.equal(page.debtCategory, 'source-side-debt');
-    assert.equal(page.recoveryProbe, null);
+    assert.equal(page.recoveryProbe.reason, 'body-appeared-inconclusive');
+    assert.equal(page.recoveryProbe.expectedMatch, false);
   });
 
   it('does not overwrite snapshot file even in non-dry-run mode', async () => {
@@ -310,15 +313,18 @@ describe('snapshot_update — source-side debt exclusion', () => {
     assert.equal(page.recoveryProbe.expectedMatch, true);
   });
 
-  it('clean EN → excluded-recovered (probe returns null)', async () => {
+  it('clean EN → excluded-broken + body-appeared-inconclusive (全分岐 fail-close)', async () => {
+    // clean EN でも自動 recovery しない。body が出現しただけでは
+    // usable かは不明なので broken に倒す (false recovery 防止)。
     global.fetch = mockTocFetchFor(CLEAN_PAGE_HTML);
     console.log = () => {};
 
     const result = await main(['--dry-run', '--slug=pull-requests']);
 
     const page = result.sourceSyncStatus.pages[0];
-    assert.equal(page.fetchStatus, 'excluded-recovered');
-    assert.equal(page.recoveryProbe, null);
+    assert.equal(page.fetchStatus, 'excluded-broken');
+    assert.equal(page.recoveryProbe.reason, 'body-appeared-inconclusive');
+    assert.equal(page.recoveryProbe.expectedMatch, false);
   });
 
   // --- Finding 2: expectedMatch + actual/expected が probe output に載る ---
@@ -446,7 +452,9 @@ describe('probeRecoveryEnOnly — fail-close branches', () => {
     assert.equal(result.expectedMatch, true);
   });
 
-  it('extractor-empty + body>0 → recovered (null)', () => {
+  it('extractor-empty + body>0 → excluded-broken + body-appeared-inconclusive (fail-close)', () => {
+    // body が出現しても usable かは不明。false recovery を避けるため
+    // broken に倒す。expectedMatch=false で壊れ方の変化を通知。
     const entry = {
       ...baseEntry,
       expectedIssueType: 'snapshot-incomplete',
@@ -456,6 +464,8 @@ describe('probeRecoveryEnOnly — fail-close branches', () => {
 
     const result = probeRecoveryEnOnly(cleanHtml, entry);
 
-    assert.equal(result, null, 'body が復活したら recovered');
+    assert.ok(result, 'body が出ても自動 recovery しない');
+    assert.equal(result.reason, 'body-appeared-inconclusive');
+    assert.equal(result.expectedMatch, false);
   });
 });

--- a/scripts/__tests__/snapshot_update.test.mjs
+++ b/scripts/__tests__/snapshot_update.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 
 let main;
 let extractMainContent;
+let probeRecoveryEnOnly;
 
 const originalFetch = global.fetch;
 const originalLog = console.log;
@@ -18,7 +19,7 @@ function createResponse({ ok = true, status = 200, text = '' } = {}) {
 }
 
 before(async () => {
-  ({ main, extractMainContent } = await import('../snapshot_update.mjs'));
+  ({ main, extractMainContent, _probeRecoveryEnOnly: probeRecoveryEnOnly } = await import('../snapshot_update.mjs'));
 });
 
 afterEach(() => {
@@ -334,5 +335,119 @@ describe('snapshot_update — source-side debt exclusion', () => {
     assert.equal(probe.expectedIssueType, 'snapshot-incomplete');
     assert.equal(probe.expectedReason, 'extractor-empty');
     assert.equal(probe.expectedMatch, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// probeRecoveryEnOnly — fail-close 分岐のユニットテスト
+//
+// extract-error と unsupported-recovery-probe の 2 分岐を直接テストし、
+// 将来のリファクタで false recovery が再発しないよう regression pin する。
+// ---------------------------------------------------------------------------
+
+describe('probeRecoveryEnOnly — fail-close branches', () => {
+  const baseEntry = {
+    reason: 'broken-upstream-source',
+    note: 'test',
+    addedAt: '2026-04-09',
+    linkedIssue: 255,
+  };
+
+  it('extractError → excluded-broken + reason=extract-error + expectedMatch=false', () => {
+    // extractSegmentsFromHtml が throw する HTML を渡す。
+    // 不正な HTML でも extractMainContent は通るが、segmenter が落ちる
+    // ケースを模擬するため、空文字列を渡す (extractor は空入力で throw)。
+    // ただし probeRecoveryEnOnly は rawEnHtml (mc-main-content の innerHTML)
+    // を受け取るので、segmenter が throw する合成 payload を使う。
+    //
+    // extractSegmentsFromHtml は valid HTML なら throw しないので、
+    // 意図的に throw させるのは難しい。代わりに extractor-empty の
+    // entry で body=0 のページを渡し、expected path を確認する。
+    //
+    // ここでは unsupported reason のテストに焦点を当てる。
+    // extract-error は別途確認。
+  });
+
+  it('unsupported expectedReason は excluded-broken + unsupported-recovery-probe + expectedMatch=false', () => {
+    const entry = {
+      ...baseEntry,
+      expectedIssueType: 'snapshot-incomplete',
+      expectedReason: 'shallow-snapshot',
+    };
+    // clean EN — 正常な本文があるページ
+    const cleanHtml =
+      '<h1>Title</h1>' +
+      '<p>First paragraph with real content.</p>' +
+      '<h2>Section</h2>' +
+      '<p>Second paragraph.</p>' +
+      '<p>Third paragraph.</p>';
+
+    const result = probeRecoveryEnOnly(cleanHtml, entry);
+
+    // shallow-snapshot は unsupported なので recovered に流れず broken に倒れる
+    assert.ok(result, 'unsupported reason must not return null (recovered)');
+    assert.equal(result.reason, 'unsupported-recovery-probe');
+    assert.equal(result.expectedMatch, false);
+    assert.equal(result.expectedIssueType, 'snapshot-incomplete');
+    assert.equal(result.expectedReason, 'shallow-snapshot');
+  });
+
+  it('unsupported expectedReason: escaped-details-residue も fail-close', () => {
+    const entry = {
+      ...baseEntry,
+      expectedIssueType: 'source-unusable',
+      expectedReason: 'escaped-details-residue',
+    };
+    const cleanHtml = '<h1>Page</h1><p>Normal content.</p>';
+
+    const result = probeRecoveryEnOnly(cleanHtml, entry);
+
+    assert.ok(result);
+    assert.equal(result.reason, 'unsupported-recovery-probe');
+    assert.equal(result.expectedMatch, false);
+  });
+
+  it('未知の将来 reason も fail-close に倒れる', () => {
+    const entry = {
+      ...baseEntry,
+      expectedIssueType: 'snapshot-incomplete',
+      expectedReason: 'future-unknown-reason',
+    };
+    const cleanHtml = '<h1>Page</h1><p>Content.</p>';
+
+    const result = probeRecoveryEnOnly(cleanHtml, entry);
+
+    assert.ok(result);
+    assert.equal(result.reason, 'unsupported-recovery-probe');
+    assert.equal(result.expectedMatch, false);
+  });
+
+  it('extractor-empty + body=0 → broken (expectedMatch=true)', () => {
+    const entry = {
+      ...baseEntry,
+      expectedIssueType: 'snapshot-incomplete',
+      expectedReason: 'extractor-empty',
+    };
+    // body segment が 0 になる HTML (heading のみ)
+    const emptyBodyHtml = '<h1>Title Only</h1>';
+
+    const result = probeRecoveryEnOnly(emptyBodyHtml, entry);
+
+    assert.ok(result);
+    assert.equal(result.reason, 'extractor-empty');
+    assert.equal(result.expectedMatch, true);
+  });
+
+  it('extractor-empty + body>0 → recovered (null)', () => {
+    const entry = {
+      ...baseEntry,
+      expectedIssueType: 'snapshot-incomplete',
+      expectedReason: 'extractor-empty',
+    };
+    const cleanHtml = '<h1>Title</h1><p>Has body content.</p>';
+
+    const result = probeRecoveryEnOnly(cleanHtml, entry);
+
+    assert.equal(result, null, 'body が復活したら recovered');
   });
 });

--- a/scripts/__tests__/snapshot_update.test.mjs
+++ b/scripts/__tests__/snapshot_update.test.mjs
@@ -339,9 +339,164 @@ describe('snapshot_update — source-side debt exclusion', () => {
 });
 
 // ---------------------------------------------------------------------------
-// recovery probe — detectSourceUsability 再利用の統合テスト
-//
-// probeRecoveryEnOnly は廃止。recovery probe は detectSourceUsability を
-// 再利用するため、detector が対応する全 reason を registry 追加だけで扱える。
-// 個別 reason の判定ロジックは source_parity_source_usability.test.mjs で pin。
+// excluded-fetch-error — fetch 失敗を source-sync 劣化として可視化
 // ---------------------------------------------------------------------------
+
+describe('snapshot_update — excluded-fetch-error', () => {
+  function mockTocWithFetchError() {
+    const tocMainJs = "define({numchunks:1,prefix:'Mock_Chunk',tree:{n:[{i:0,c:0}]}});";
+    const tocChunkJs =
+      "define({'/content/testops/testops-version-control/pull-requests/index.htm':{i:[0],t:['Pull Requests'],b:['']}});";
+
+    return async (url) => {
+      const href = String(url);
+      if (href.includes('Main.js')) return createResponse({ text: tocMainJs });
+      if (href.includes('Mock_Chunk0.js')) return createResponse({ text: tocChunkJs });
+      // excluded slug の fetch が HTTP error を返す
+      return createResponse({ ok: false, status: 500 });
+    };
+  }
+
+  function mockTocWithFetchThrow() {
+    const tocMainJs = "define({numchunks:1,prefix:'Mock_Chunk',tree:{n:[{i:0,c:0}]}});";
+    const tocChunkJs =
+      "define({'/content/testops/testops-version-control/pull-requests/index.htm':{i:[0],t:['Pull Requests'],b:['']}});";
+
+    return async (url) => {
+      const href = String(url);
+      if (href.includes('Main.js')) return createResponse({ text: tocMainJs });
+      if (href.includes('Mock_Chunk0.js')) return createResponse({ text: tocChunkJs });
+      throw new Error('simulated network failure');
+    };
+  }
+
+  it('excluded slug + HTTP error → excluded-fetch-error', async () => {
+    global.fetch = mockTocWithFetchError();
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    const page = result.sourceSyncStatus.pages.find(
+      (p) => p.slug === 'testops/testops-version-control/pull-requests',
+    );
+    assert.ok(page);
+    assert.equal(page.fetchStatus, 'excluded-fetch-error');
+    assert.equal(page.debtCategory, 'source-side-debt');
+    assert.equal(page.recoveryProbe, null);
+    assert.ok(page.errorDetail);
+  });
+
+  it('excluded slug + fetch throw → excluded-fetch-error', async () => {
+    global.fetch = mockTocWithFetchThrow();
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    const page = result.sourceSyncStatus.pages.find(
+      (p) => p.slug === 'testops/testops-version-control/pull-requests',
+    );
+    assert.ok(page);
+    assert.equal(page.fetchStatus, 'excluded-fetch-error');
+    assert.equal(page.debtCategory, 'source-side-debt');
+    assert.equal(page.errorDetail, 'simulated network failure');
+  });
+
+  it('debt-only run + excluded-fetch-error → freshnessState broken', async () => {
+    global.fetch = mockTocWithFetchError();
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    // fetch error は freshness 劣化 — fresh ではなく broken になる
+    assert.equal(result.sourceSyncStatus.freshnessState, 'broken');
+    assert.equal(result.errors, 1);
+  });
+
+  it('errors[] に excluded-fetch-error の slug が載る', async () => {
+    global.fetch = mockTocWithFetchError();
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    const errorEntry = result.sourceSyncStatus.errors.find(
+      (e) => e.slug === 'testops/testops-version-control/pull-requests',
+    );
+    assert.ok(errorEntry, 'excluded-fetch-error must appear in top-level errors');
+    assert.ok(errorEntry.detail);
+  });
+
+  it('excluded-fetch-error は excludedPages counter に含まれない', async () => {
+    global.fetch = mockTocWithFetchError();
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    // fetch 失敗は errorPages に計上、excludedPages には含まない
+    assert.equal(result.sourceSyncStatus.summary.excludedPages, 0);
+    assert.equal(result.sourceSyncStatus.summary.errorPages, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recovery probe — JA 非依存の synthetic segments テスト
+// ---------------------------------------------------------------------------
+
+describe('snapshot_update — recovery probe JA independence', () => {
+  const BROKEN_PAGE_HTML =
+    '<html><body><div role="main" id="mc-main-content">' +
+    '<h1>Pull Requests</h1>' +
+    '<div class="codeSnippet"><div class="codeSnippetBody"><pre><code>' +
+    'Pull requests notify reviewers on changes introduced to a test.' +
+    '</code></pre></div></div>' +
+    '</div></body></html>';
+
+  const CLEAN_PAGE_HTML =
+    '<html><body><div role="main" id="mc-main-content">' +
+    '<h1>Pull Requests</h1>' +
+    '<p>Pull requests notify reviewers on changes introduced to a test.</p>' +
+    '<h2>Creating a Pull Request</h2>' +
+    '<p>A pull request represents the difference between branches.</p>' +
+    '<h2>Reviewing a Pull Request</h2>' +
+    '<p>Reviewers are notified via email.</p>' +
+    '<h2>Resubmitting a Pull Request</h2>' +
+    '<p>If the reviewer sent back the PR you can respond.</p>' +
+    '</div></body></html>';
+
+  function mockTocFetchFor(pageHtml) {
+    const tocMainJs = "define({numchunks:1,prefix:'Mock_Chunk',tree:{n:[{i:0,c:0}]}});";
+    const tocChunkJs =
+      "define({'/content/testops/testops-version-control/pull-requests/index.htm':{i:[0],t:['Pull Requests'],b:['']}});";
+
+    return async (url) => {
+      const href = String(url);
+      if (href.includes('Main.js')) return createResponse({ text: tocMainJs });
+      if (href.includes('Mock_Chunk0.js')) return createResponse({ text: tocChunkJs });
+      return createResponse({ text: pageHtml });
+    };
+  }
+
+  it('broken EN → excluded-broken regardless of JA content (synthetic JA)', async () => {
+    // probe は synthetic JA segments を使うため、実 JA ファイルの内容に
+    // 依存しない。broken EN は常に excluded-broken になる。
+    global.fetch = mockTocFetchFor(BROKEN_PAGE_HTML);
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    const page = result.sourceSyncStatus.pages[0];
+    assert.equal(page.fetchStatus, 'excluded-broken');
+    assert.equal(page.recoveryProbe.reason, 'extractor-empty');
+    assert.equal(page.recoveryProbe.expectedMatch, true);
+  });
+
+  it('clean EN → excluded-recovered (detector が null を返す)', async () => {
+    global.fetch = mockTocFetchFor(CLEAN_PAGE_HTML);
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    const page = result.sourceSyncStatus.pages[0];
+    assert.equal(page.fetchStatus, 'excluded-recovered');
+    assert.equal(page.recoveryProbe, null);
+  });
+});

--- a/scripts/__tests__/snapshot_update.test.mjs
+++ b/scripts/__tests__/snapshot_update.test.mjs
@@ -4,7 +4,6 @@ import assert from 'node:assert/strict';
 
 let main;
 let extractMainContent;
-let probeRecoveryEnOnly;
 
 const originalFetch = global.fetch;
 const originalLog = console.log;
@@ -19,7 +18,7 @@ function createResponse({ ok = true, status = 200, text = '' } = {}) {
 }
 
 before(async () => {
-  ({ main, extractMainContent, _probeRecoveryEnOnly: probeRecoveryEnOnly } = await import('../snapshot_update.mjs'));
+  ({ main, extractMainContent } = await import('../snapshot_update.mjs'));
 });
 
 afterEach(() => {
@@ -168,8 +167,7 @@ describe('snapshot_update — source-side debt exclusion', () => {
 
   // clean upstream simulation: broken 状態から upstream が直り、
   // 正しく <h2> / <p> / <ol> に分解された clean HTML が返る想定。
-  // ただし EN-only probe は全分岐 fail-close なので excluded-broken
-  // (body-appeared-inconclusive) に倒れる。excluded-recovered は自動では起きない。
+  // detectSourceUsability が null を返すため excluded-recovered になる。
   const CLEAN_PAGE_HTML =
     '<html><body><div role="main" id="mc-main-content">' +
     '<h1>Pull Requests</h1>' +
@@ -229,25 +227,24 @@ describe('snapshot_update — source-side debt exclusion', () => {
     assert.equal(result.sourceSyncStatus.errors.length, 0);
   });
 
-  it('clean upstream → still excluded-broken (全分岐 fail-close、自動 recovery なし)', async () => {
+  it('clean upstream → excluded-recovered (detectSourceUsability が null を返す)', async () => {
     global.fetch = mockTocFetchFor(CLEAN_PAGE_HTML);
     console.log = () => {};
 
     const result = await main(['--dry-run', '--slug=pull-requests']);
 
-    // 自動 recovery は起きない — body が出ても inconclusive で broken に倒れる
+    // upstream が復旧 — detectSourceUsability が issue なしと判定
     assert.equal(result.sourceSyncStatus.summary.excludedPages, 1);
-    assert.equal(result.sourceSyncStatus.summary.excludedBrokenPages, 1);
-    assert.equal(result.sourceSyncStatus.summary.excludedRecoveredPages, 0);
+    assert.equal(result.sourceSyncStatus.summary.excludedBrokenPages, 0);
+    assert.equal(result.sourceSyncStatus.summary.excludedRecoveredPages, 1);
 
     const page = result.sourceSyncStatus.pages.find(
       (p) => p.slug === 'testops/testops-version-control/pull-requests',
     );
     assert.ok(page);
-    assert.equal(page.fetchStatus, 'excluded-broken');
+    assert.equal(page.fetchStatus, 'excluded-recovered');
     assert.equal(page.debtCategory, 'source-side-debt');
-    assert.equal(page.recoveryProbe.reason, 'body-appeared-inconclusive');
-    assert.equal(page.recoveryProbe.expectedMatch, false);
+    assert.equal(page.recoveryProbe, null);
   });
 
   it('does not overwrite snapshot file even in non-dry-run mode', async () => {
@@ -313,18 +310,15 @@ describe('snapshot_update — source-side debt exclusion', () => {
     assert.equal(page.recoveryProbe.expectedMatch, true);
   });
 
-  it('clean EN → excluded-broken + body-appeared-inconclusive (全分岐 fail-close)', async () => {
-    // clean EN でも自動 recovery しない。body が出現しただけでは
-    // usable かは不明なので broken に倒す (false recovery 防止)。
+  it('clean EN → excluded-recovered (detectSourceUsability returns null)', async () => {
     global.fetch = mockTocFetchFor(CLEAN_PAGE_HTML);
     console.log = () => {};
 
     const result = await main(['--dry-run', '--slug=pull-requests']);
 
     const page = result.sourceSyncStatus.pages[0];
-    assert.equal(page.fetchStatus, 'excluded-broken');
-    assert.equal(page.recoveryProbe.reason, 'body-appeared-inconclusive');
-    assert.equal(page.recoveryProbe.expectedMatch, false);
+    assert.equal(page.fetchStatus, 'excluded-recovered');
+    assert.equal(page.recoveryProbe, null);
   });
 
   // --- Finding 2: expectedMatch + actual/expected が probe output に載る ---
@@ -345,127 +339,9 @@ describe('snapshot_update — source-side debt exclusion', () => {
 });
 
 // ---------------------------------------------------------------------------
-// probeRecoveryEnOnly — fail-close 分岐のユニットテスト
+// recovery probe — detectSourceUsability 再利用の統合テスト
 //
-// extract-error と unsupported-recovery-probe の 2 分岐を直接テストし、
-// 将来のリファクタで false recovery が再発しないよう regression pin する。
+// probeRecoveryEnOnly は廃止。recovery probe は detectSourceUsability を
+// 再利用するため、detector が対応する全 reason を registry 追加だけで扱える。
+// 個別 reason の判定ロジックは source_parity_source_usability.test.mjs で pin。
 // ---------------------------------------------------------------------------
-
-describe('probeRecoveryEnOnly — fail-close branches', () => {
-  const baseEntry = {
-    reason: 'broken-upstream-source',
-    note: 'test',
-    addedAt: '2026-04-09',
-    linkedIssue: 255,
-  };
-
-  it('extractError → excluded-broken + reason=extract-error + expectedMatch=false', () => {
-    const entry = {
-      ...baseEntry,
-      expectedIssueType: 'snapshot-incomplete',
-      expectedReason: 'extractor-empty',
-    };
-    const throwingExtractor = () => {
-      throw new Error('simulated extractor failure');
-    };
-
-    const result = probeRecoveryEnOnly(
-      '<h1>Title</h1><p>Body</p>',
-      entry,
-      { extractFn: throwingExtractor },
-    );
-
-    assert.ok(result, 'extractError must not return null (recovered)');
-    assert.equal(result.reason, 'extract-error');
-    assert.equal(result.expectedMatch, false);
-    assert.equal(result.expectedIssueType, 'snapshot-incomplete');
-    assert.equal(result.expectedReason, 'extractor-empty');
-  });
-
-  it('unsupported expectedReason は excluded-broken + unsupported-recovery-probe + expectedMatch=false', () => {
-    const entry = {
-      ...baseEntry,
-      expectedIssueType: 'snapshot-incomplete',
-      expectedReason: 'shallow-snapshot',
-    };
-    // clean EN — 正常な本文があるページ
-    const cleanHtml =
-      '<h1>Title</h1>' +
-      '<p>First paragraph with real content.</p>' +
-      '<h2>Section</h2>' +
-      '<p>Second paragraph.</p>' +
-      '<p>Third paragraph.</p>';
-
-    const result = probeRecoveryEnOnly(cleanHtml, entry);
-
-    // shallow-snapshot は unsupported なので recovered に流れず broken に倒れる
-    assert.ok(result, 'unsupported reason must not return null (recovered)');
-    assert.equal(result.reason, 'unsupported-recovery-probe');
-    assert.equal(result.expectedMatch, false);
-    assert.equal(result.expectedIssueType, 'snapshot-incomplete');
-    assert.equal(result.expectedReason, 'shallow-snapshot');
-  });
-
-  it('unsupported expectedReason: escaped-details-residue も fail-close', () => {
-    const entry = {
-      ...baseEntry,
-      expectedIssueType: 'source-unusable',
-      expectedReason: 'escaped-details-residue',
-    };
-    const cleanHtml = '<h1>Page</h1><p>Normal content.</p>';
-
-    const result = probeRecoveryEnOnly(cleanHtml, entry);
-
-    assert.ok(result);
-    assert.equal(result.reason, 'unsupported-recovery-probe');
-    assert.equal(result.expectedMatch, false);
-  });
-
-  it('未知の将来 reason も fail-close に倒れる', () => {
-    const entry = {
-      ...baseEntry,
-      expectedIssueType: 'snapshot-incomplete',
-      expectedReason: 'future-unknown-reason',
-    };
-    const cleanHtml = '<h1>Page</h1><p>Content.</p>';
-
-    const result = probeRecoveryEnOnly(cleanHtml, entry);
-
-    assert.ok(result);
-    assert.equal(result.reason, 'unsupported-recovery-probe');
-    assert.equal(result.expectedMatch, false);
-  });
-
-  it('extractor-empty + body=0 → broken (expectedMatch=true)', () => {
-    const entry = {
-      ...baseEntry,
-      expectedIssueType: 'snapshot-incomplete',
-      expectedReason: 'extractor-empty',
-    };
-    // body segment が 0 になる HTML (heading のみ)
-    const emptyBodyHtml = '<h1>Title Only</h1>';
-
-    const result = probeRecoveryEnOnly(emptyBodyHtml, entry);
-
-    assert.ok(result);
-    assert.equal(result.reason, 'extractor-empty');
-    assert.equal(result.expectedMatch, true);
-  });
-
-  it('extractor-empty + body>0 → excluded-broken + body-appeared-inconclusive (fail-close)', () => {
-    // body が出現しても usable かは不明。false recovery を避けるため
-    // broken に倒す。expectedMatch=false で壊れ方の変化を通知。
-    const entry = {
-      ...baseEntry,
-      expectedIssueType: 'snapshot-incomplete',
-      expectedReason: 'extractor-empty',
-    };
-    const cleanHtml = '<h1>Title</h1><p>Has body content.</p>';
-
-    const result = probeRecoveryEnOnly(cleanHtml, entry);
-
-    assert.ok(result, 'body が出ても自動 recovery しない');
-    assert.equal(result.reason, 'body-appeared-inconclusive');
-    assert.equal(result.expectedMatch, false);
-  });
-});

--- a/scripts/__tests__/snapshot_update.test.mjs
+++ b/scripts/__tests__/snapshot_update.test.mjs
@@ -363,6 +363,25 @@ describe('snapshot_update — source-side debt exclusion', () => {
     });
   });
 
+  it('cross-reason drift to shallow-snapshot stays excluded-broken', () => {
+    const result = runRecoveryProbe({
+      rawEnHtml: '<h1>Title</h1><p>A</p>',
+      exclusionEntry: {
+        expectedIssueType: 'snapshot-incomplete',
+        expectedReason: 'extractor-empty',
+      },
+    });
+
+    assert.equal(result.fetchStatus, 'excluded-broken');
+    assert.deepEqual(result.recoveryProbe, {
+      issueType: 'snapshot-incomplete',
+      reason: 'shallow-snapshot',
+      expectedIssueType: 'snapshot-incomplete',
+      expectedReason: 'extractor-empty',
+      expectedMatch: false,
+    });
+  });
+
   // --- Finding 2: expectedMatch + actual/expected が probe output に載る ---
 
   it('excluded-broken probe に expectedIssueType / expectedReason / expectedMatch が載る', async () => {

--- a/scripts/__tests__/snapshot_update.test.mjs
+++ b/scripts/__tests__/snapshot_update.test.mjs
@@ -220,6 +220,8 @@ describe('snapshot_update — source-side debt exclusion', () => {
     assert.ok(page.recoveryProbe);
     assert.equal(page.recoveryProbe.issueType, 'snapshot-incomplete');
     assert.equal(page.recoveryProbe.reason, 'extractor-empty');
+    // registry の expected と一致するので true
+    assert.equal(page.recoveryProbe.expectedMatch, true);
 
     // excluded は top-level errors に積まない
     assert.equal(result.sourceSyncStatus.errors.length, 0);

--- a/scripts/__tests__/snapshot_update.test.mjs
+++ b/scripts/__tests__/snapshot_update.test.mjs
@@ -354,18 +354,26 @@ describe('probeRecoveryEnOnly — fail-close branches', () => {
   };
 
   it('extractError → excluded-broken + reason=extract-error + expectedMatch=false', () => {
-    // extractSegmentsFromHtml が throw する HTML を渡す。
-    // 不正な HTML でも extractMainContent は通るが、segmenter が落ちる
-    // ケースを模擬するため、空文字列を渡す (extractor は空入力で throw)。
-    // ただし probeRecoveryEnOnly は rawEnHtml (mc-main-content の innerHTML)
-    // を受け取るので、segmenter が throw する合成 payload を使う。
-    //
-    // extractSegmentsFromHtml は valid HTML なら throw しないので、
-    // 意図的に throw させるのは難しい。代わりに extractor-empty の
-    // entry で body=0 のページを渡し、expected path を確認する。
-    //
-    // ここでは unsupported reason のテストに焦点を当てる。
-    // extract-error は別途確認。
+    const entry = {
+      ...baseEntry,
+      expectedIssueType: 'snapshot-incomplete',
+      expectedReason: 'extractor-empty',
+    };
+    const throwingExtractor = () => {
+      throw new Error('simulated extractor failure');
+    };
+
+    const result = probeRecoveryEnOnly(
+      '<h1>Title</h1><p>Body</p>',
+      entry,
+      { extractFn: throwingExtractor },
+    );
+
+    assert.ok(result, 'extractError must not return null (recovered)');
+    assert.equal(result.reason, 'extract-error');
+    assert.equal(result.expectedMatch, false);
+    assert.equal(result.expectedIssueType, 'snapshot-incomplete');
+    assert.equal(result.expectedReason, 'extractor-empty');
   });
 
   it('unsupported expectedReason は excluded-broken + unsupported-recovery-probe + expectedMatch=false', () => {

--- a/scripts/__tests__/snapshot_update.test.mjs
+++ b/scripts/__tests__/snapshot_update.test.mjs
@@ -292,4 +292,47 @@ describe('snapshot_update — source-side debt exclusion', () => {
     // excluded-only のみの scope でも sidebar さえ verified なら fresh
     assert.equal(result.sourceSyncStatus.freshnessState, 'fresh');
   });
+
+  // --- Finding 1: EN-only probe は JA 入力に依存しない ---
+
+  it('recovery probe は JA の有無で結果が変わらない (EN-only)', async () => {
+    // JA body は collectTargets 経由で読まれるが probe には渡らない。
+    // broken EN に対して excluded-broken が返ることだけを確認する。
+    global.fetch = mockTocFetchFor(BROKEN_PAGE_HTML);
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    const page = result.sourceSyncStatus.pages[0];
+    assert.equal(page.fetchStatus, 'excluded-broken');
+    assert.equal(page.recoveryProbe.reason, 'extractor-empty');
+    assert.equal(page.recoveryProbe.expectedMatch, true);
+  });
+
+  it('clean EN → excluded-recovered (probe returns null)', async () => {
+    global.fetch = mockTocFetchFor(CLEAN_PAGE_HTML);
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    const page = result.sourceSyncStatus.pages[0];
+    assert.equal(page.fetchStatus, 'excluded-recovered');
+    assert.equal(page.recoveryProbe, null);
+  });
+
+  // --- Finding 2: expectedMatch + actual/expected が probe output に載る ---
+
+  it('excluded-broken probe に expectedIssueType / expectedReason / expectedMatch が載る', async () => {
+    global.fetch = mockTocFetchFor(BROKEN_PAGE_HTML);
+    console.log = () => {};
+
+    const result = await main(['--dry-run', '--slug=pull-requests']);
+
+    const probe = result.sourceSyncStatus.pages[0].recoveryProbe;
+    assert.equal(probe.issueType, 'snapshot-incomplete');
+    assert.equal(probe.reason, 'extractor-empty');
+    assert.equal(probe.expectedIssueType, 'snapshot-incomplete');
+    assert.equal(probe.expectedReason, 'extractor-empty');
+    assert.equal(probe.expectedMatch, true);
+  });
 });

--- a/scripts/__tests__/source_parity_representative_summary.test.mjs
+++ b/scripts/__tests__/source_parity_representative_summary.test.mjs
@@ -1,11 +1,18 @@
 /**
  * Issue #247 post-merge — representative full-run summary contract test。
  *
- * 代表 8 ページに対して `checkSourceParity({ slug, baselinePath, outputPath })`
+ * 代表 7 ページに対して `checkSourceParity({ slug, baselinePath, outputPath })`
  * を in-process で順次呼び、temp status file から summary counter を
  * pin する。Phase D/E/F/G の post-resolution state を固定する fixture。
  *
- * 8 ページ全て RESOLVED_PAGES で baseline 0 件 clean green 完了:
+ * Issue #255: `testops/testops-version-control/pull-requests` は
+ * representative から外された。理由は upstream EN HTML が broken
+ * (body 全体が <code> ブロックに collapsed) で、parity comparator の
+ * 前提を満たさないため。このページは "source-side debt" として
+ * `source_sync_exclusions.mjs` registry で管理され、契約は
+ * `source_parity_source_side_debt.test.mjs` に分離されている。
+ *
+ * 7 ページ全て RESOLVED_PAGES で baseline 0 件 clean green 完了:
  *
  *   | slug                                               | 解消手段                                         |
  *   | -------------------------------------------------- | ------------------------------------------------ |
@@ -16,7 +23,6 @@
  *   | results/test-results/network-logs                  | Phase D.2: Filtering / test level の JA rewrite  |
  *   | advanced-editing/validations/email-validation      | Phase D.3: preface / Codeless Option / token 差別化 |
  *   | salesforce-testing/salesforce-testing-overview     | Phase G: shallow EN に合わせて JA trim           |
- *   | testops/testops-version-control/pull-requests      | Phase G: broken EN snapshot を手動で正しい HTML 化 |
  *
  * pin する契約:
  *   1. 全 slug で `reportableActiveFiles === 0`
@@ -80,8 +86,11 @@ const COMMON_ZERO_COUNTERS = Object.freeze({
 });
 
 // ---------------------------------------------------------------------------
-// RESOLVED_PAGES — Issue #247 End-to-End 完全解消後、全 8 代表ページが
+// RESOLVED_PAGES — Issue #247 End-to-End 完全解消後、代表 7 ページが
 // baseline entry 0 で clean green に到達。
+//
+// Issue #255 で `pull-requests` は representative から外され、
+// `source_parity_source_side_debt.test.mjs` に分離された。
 //
 // 解消プロセス:
 // - `custom-action-step-mobile` / `test-runs`: Phase E の JA 修正で解消
@@ -99,9 +108,6 @@ const COMMON_ZERO_COUNTERS = Object.freeze({
 //   body 例の `messages[0].subject` / `DOMParser` token 差別化)
 // - `salesforce-testing-overview`: EN 本文が `<h1>` + 1 paragraph のみで
 //   source が shallow なため、JA も同構造に trim
-// - `pull-requests`: EN source が `<code>` ブロックで全文 wrap されていた
-//   ため、正しい HTML snapshot を手動で書き起こし (Reviewing a Pull Request
-//   section の nested list を flatten して JA と構造一致)
 // ---------------------------------------------------------------------------
 const RESOLVED_PAGES = Object.freeze([
   'advanced-editing/custom-action-step-mobile',
@@ -111,7 +117,6 @@ const RESOLVED_PAGES = Object.freeze([
   'results/test-results/network-logs',
   'advanced-editing/validations/email-validation',
   'salesforce-testing/salesforce-testing-overview',
-  'testops/testops-version-control/pull-requests',
 ]);
 
 // Issue #247 End-to-End 完全解消後、RESIDUAL_PAGES は空。

--- a/scripts/__tests__/source_parity_source_side_debt.test.mjs
+++ b/scripts/__tests__/source_parity_source_side_debt.test.mjs
@@ -239,7 +239,7 @@ describe('source-side debt pipeline integration', () => {
     const md = renderSummaryMarkdown(emptySnapshot, emptyParity, report, [], sourceSync);
 
     // 日本語 debt セクション
-    assert.match(md, /## ソース側 debt/);
+    assert.match(md, /## ソース原文の既知問題/);
     assert.match(md, /除外ページ: 1/);
     assert.match(md, /未復旧: 1/);
     // slug が listing に現れる

--- a/scripts/__tests__/source_parity_source_side_debt.test.mjs
+++ b/scripts/__tests__/source_parity_source_side_debt.test.mjs
@@ -214,8 +214,8 @@ describe('source-side debt pipeline integration', () => {
         reason: 'extractor-empty',
       },
     ]);
-    // fresh なので sourceSyncHealth issue は open しない
-    assert.equal(report.sourceSyncHealth.shouldOpenIssue, false);
+    // P1 修正: fresh でも debt があれば managed issue に可視化する
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, true);
   });
 
   it('summary markdown emits the 日本語 debt section with the slug', () => {

--- a/scripts/__tests__/source_parity_source_side_debt.test.mjs
+++ b/scripts/__tests__/source_parity_source_side_debt.test.mjs
@@ -162,7 +162,7 @@ describe('source-side debt pipeline integration', () => {
         slug: debtSlug,
         fetchStatus: 'excluded-broken',
         debtCategory: 'source-side-debt',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
       },
     ];
     return buildSourceSyncStatus({
@@ -210,8 +210,11 @@ describe('source-side debt pipeline integration', () => {
     assert.deepEqual(report.sourceSyncHealth.sourceSideDebt.brokenDetails, [
       {
         slug: debtSlug,
-        issueType: 'snapshot-incomplete',
-        reason: 'extractor-empty',
+        actualIssueType: 'snapshot-incomplete',
+        actualReason: 'extractor-empty',
+        expectedIssueType: 'snapshot-incomplete',
+        expectedReason: 'extractor-empty',
+        expectedMatch: true,
       },
     ]);
     // P1 修正: fresh でも debt があれば managed issue に可視化する
@@ -256,7 +259,7 @@ describe('source-side debt pipeline integration', () => {
           slug: debtSlug,
           fetchStatus: 'excluded-broken',
           debtCategory: 'source-side-debt',
-          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
         },
       ],
       sidebarResult: baseSidebarResult,
@@ -274,7 +277,7 @@ describe('source-side debt pipeline integration', () => {
         slug: debtSlug,
         fetchStatus: 'excluded-broken',
         debtCategory: 'source-side-debt',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
       },
     ];
     assert.equal(computeFreshnessState(pages, true), 'partial');

--- a/scripts/__tests__/source_parity_source_side_debt.test.mjs
+++ b/scripts/__tests__/source_parity_source_side_debt.test.mjs
@@ -1,0 +1,282 @@
+/**
+ * Issue #255 Phase 1 + Phase 5 — source-side debt contract test。
+ *
+ * `source_sync_exclusions.mjs` に登録された broken upstream source page の
+ * 運用契約を pin する。representative test から分離することで、
+ * "解消済み代表" の契約と "既知 debt" の契約を混ぜない。
+ *
+ * pin する契約:
+ *
+ *   1. registry に最低 1 entry (`pull-requests`) が seeding されている
+ *   2. 各 debt slug には対応する JA file が存在する
+ *      (registry entry が孤立すると Issue #247 の completion state を崩す)
+ *   3. 各 debt slug の hand-authored EN snapshot file が存在する
+ *      (Q1=A の決定: 凍結参照として残す)
+ *   4. 各 debt slug の metadata は "upstream recovery を検知できる shape"
+ *      を備えている (expectedIssueType / expectedReason / addedAt /
+ *      linkedIssue が実際の detectSourceUsability 出力と合致可能)
+ *   5. end-to-end: exclusion registry → buildSourceSyncStatus →
+ *      buildActionableReport → renderSummaryMarkdown の流れで、
+ *      debt slug が日本語 summary section と JSON counter に現れる
+ *
+ * Issue #255 Phase 3b の snapshot_update 側挙動 (excluded-broken /
+ * excluded-recovered) は `snapshot_update.test.mjs` 側で pin している。
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { ROOT_DIR, DOCS_DIR } from '../lib/project.mjs';
+import {
+  SOURCE_SYNC_EXCLUSIONS,
+  listSourceSideDebtSlugs,
+  getExclusion,
+} from '../lib/source_sync_exclusions.mjs';
+import {
+  buildSourceSyncStatus,
+  computeFreshnessState,
+} from '../lib/source_sync_health.mjs';
+import {
+  buildActionableReport,
+  renderSummaryMarkdown,
+} from '../lib/detection_reports.mjs';
+
+const SNAPSHOTS_CONTENT_DIR = path.join(ROOT_DIR, 'snapshots', 'en', 'content');
+
+describe('source-side debt registry seeding', () => {
+  it('contains at least one debt slug (pull-requests as initial seed)', () => {
+    const slugs = listSourceSideDebtSlugs();
+    assert.ok(
+      slugs.length >= 1,
+      `expected at least one source-side debt entry, got ${slugs.length}`,
+    );
+    assert.ok(
+      slugs.includes('testops/testops-version-control/pull-requests'),
+      `pull-requests must be seeded as the first known debt entry. ` +
+        `Actual slugs: ${JSON.stringify(slugs)}`,
+    );
+  });
+
+  it('only contains upstream-broken entries (no debug / placeholder slugs)', () => {
+    for (const [slug, entry] of Object.entries(SOURCE_SYNC_EXCLUSIONS)) {
+      assert.equal(
+        entry.reason,
+        'broken-upstream-source',
+        `registry[${slug}] must declare reason="broken-upstream-source" ` +
+          `(auto-exclusion is forbidden — only hand-confirmed upstream debt)`,
+      );
+    }
+  });
+});
+
+describe('source-side debt registry / repository integrity', () => {
+  const debtSlugs = listSourceSideDebtSlugs();
+
+  for (const slug of debtSlugs) {
+    describe(`debt slug: ${slug}`, () => {
+      it('has a matching JA file in src/content/docs/', () => {
+        const jaPath = path.join(DOCS_DIR, `${slug}.md`);
+        assert.ok(
+          existsSync(jaPath),
+          `debt slug ${slug} must have a JA file at ${jaPath} — ` +
+            `orphan registry entries corrupt the Issue #247 completion state`,
+        );
+      });
+
+      it('has a frozen hand-authored EN snapshot (Issue #255 Q1=A decision)', () => {
+        const snapshotPath = path.join(SNAPSHOTS_CONTENT_DIR, `${slug}.html`);
+        assert.ok(
+          existsSync(snapshotPath),
+          `debt slug ${slug} must keep its hand-authored snapshot at ${snapshotPath}. ` +
+            `Issue #255 決定: snapshot_update は write をスキップし、この file を凍結参照として温存する。`,
+        );
+      });
+
+      it('metadata carries a probe-compatible shape for recovery detection', () => {
+        const entry = getExclusion(slug);
+        assert.ok(entry, `registry entry must exist`);
+
+        // expectedIssueType / expectedReason は
+        // detectSourceUsability().usabilitySignals.reason と
+        // detectSourceUsability().type の実値に合致させる。
+        // これにより upstream が recovered したとき registry を再訪する
+        // 意思決定の材料になる。
+        const validIssueTypes = new Set(['snapshot-incomplete', 'source-unusable']);
+        const validReasons = new Set([
+          'extractor-empty',
+          'shallow-snapshot',
+          'escaped-details-residue',
+          'fetch-failed',
+        ]);
+        assert.ok(
+          validIssueTypes.has(entry.expectedIssueType),
+          `${slug}: expectedIssueType must be a known detectSourceUsability type. ` +
+            `Got: ${entry.expectedIssueType}`,
+        );
+        assert.ok(
+          validReasons.has(entry.expectedReason),
+          `${slug}: expectedReason must be a known detectSourceUsability reason. ` +
+            `Got: ${entry.expectedReason}`,
+        );
+        assert.match(
+          entry.addedAt,
+          /^\d{4}-\d{2}-\d{2}$/,
+          `${slug}: addedAt must be ISO date (YYYY-MM-DD)`,
+        );
+        assert.equal(
+          typeof entry.linkedIssue,
+          'number',
+          `${slug}: linkedIssue must be a number (GitHub issue number)`,
+        );
+      });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Phase 5 — end-to-end pipeline integration
+//
+// registry に登録された debt slug が、pipeline 全体 (source-sync-status →
+// actionable-report → summary markdown) を一貫して流れることを pin する。
+// それぞれの unit は個別テストで pin されているが、統合経路で機械が
+// 誤配線すると silent に drift する可能性があるため end-to-end で assertion。
+// ---------------------------------------------------------------------------
+
+describe('source-side debt pipeline integration', () => {
+  const debtSlug = 'testops/testops-version-control/pull-requests';
+  const normalSlug = 'overview/testim-overview';
+  const baseSidebarResult = {
+    ok: true,
+    sectionCount: 20,
+    pageCount: 200,
+    sidebarSlugs: ['a', 'b', 'c'],
+  };
+  const fullScope = { type: 'full', isComplete: true, filters: { slug: null, section: null } };
+
+  function buildMixedRun() {
+    // 1 debt slug (excluded-broken) + 1 normal slug (ok) — realistic shape
+    const pages = [
+      { slug: normalSlug, fetchStatus: 'ok' },
+      {
+        slug: debtSlug,
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+      },
+    ];
+    return buildSourceSyncStatus({
+      pages,
+      sidebarResult: baseSidebarResult,
+      runScope: fullScope,
+    });
+  }
+
+  it('source-sync-status exposes debt page without polluting fetch counters', () => {
+    const status = buildMixedRun();
+    // debt slug は fetchedPages に数えない
+    assert.equal(status.summary.fetchedPages, 1);
+    assert.equal(status.summary.errorPages, 0);
+    assert.equal(status.summary.excludedPages, 1);
+    assert.equal(status.summary.excludedBrokenPages, 1);
+    // freshness は fresh のまま (debt だけでは壊れない)
+    assert.equal(status.freshnessState, 'fresh');
+  });
+
+  it('actionable report exposes sourceSideDebt summary field', () => {
+    const sourceSync = buildMixedRun();
+    const emptySnapshot = {
+      checkedAt: '2026-04-09T00:00:00Z',
+      summary: { totalSnapshots: 100, changed: 0, added: 0, removed: 0, unchanged: 100 },
+      changes: [],
+      sidebar: { changed: false, addedPages: [], removedPages: [] },
+    };
+    const emptyParity = {
+      summary: {
+        checkedAt: '2026-04-09T00:00:00Z',
+        actionableFiles: 0,
+        signalFiles: 0,
+        errorFiles: 0,
+      },
+      files: [],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+
+    // source-sync-health family に sourceSideDebt が露出している
+    assert.ok(report.sourceSyncHealth.sourceSideDebt);
+    assert.equal(report.sourceSyncHealth.sourceSideDebt.excludedPages, 1);
+    assert.equal(report.sourceSyncHealth.sourceSideDebt.excludedBrokenPages, 1);
+    assert.deepEqual(report.sourceSyncHealth.sourceSideDebt.brokenSlugs, [debtSlug]);
+    assert.deepEqual(report.sourceSyncHealth.sourceSideDebt.brokenDetails, [
+      {
+        slug: debtSlug,
+        issueType: 'snapshot-incomplete',
+        reason: 'extractor-empty',
+      },
+    ]);
+    // fresh なので sourceSyncHealth issue は open しない
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, false);
+  });
+
+  it('summary markdown emits the 日本語 debt section with the slug', () => {
+    const sourceSync = buildMixedRun();
+    const emptySnapshot = {
+      checkedAt: '2026-04-09T00:00:00Z',
+      summary: { totalSnapshots: 100, changed: 0, added: 0, removed: 0, unchanged: 100 },
+      changes: [],
+      sidebar: { changed: false, addedPages: [], removedPages: [] },
+    };
+    const emptyParity = {
+      summary: {
+        checkedAt: '2026-04-09T00:00:00Z',
+        actionableFiles: 0,
+        signalFiles: 0,
+        errorFiles: 0,
+      },
+      files: [],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], { sourceSync });
+    const md = renderSummaryMarkdown(emptySnapshot, emptyParity, report, [], sourceSync);
+
+    // 日本語 debt セクション
+    assert.match(md, /## ソース側 debt/);
+    assert.match(md, /除外ページ: 1/);
+    assert.match(md, /未復旧: 1/);
+    // slug が listing に現れる
+    assert.match(md, new RegExp(debtSlug.replace(/\//g, '\\/')));
+    // probe 結果
+    assert.match(md, /snapshot-incomplete/);
+    assert.match(md, /extractor-empty/);
+  });
+
+  it('debt-only run (no real fetch targets) keeps freshness fresh', () => {
+    const debtOnly = buildSourceSyncStatus({
+      pages: [
+        {
+          slug: debtSlug,
+          fetchStatus: 'excluded-broken',
+          debtCategory: 'source-side-debt',
+          recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        },
+      ],
+      sidebarResult: baseSidebarResult,
+      runScope: fullScope,
+    });
+    assert.equal(debtOnly.freshnessState, 'fresh');
+  });
+
+  it('computeFreshnessState ignores debt pages when mixed with errors', () => {
+    // debt + 1 error: partial (error pulls it down, debt is ignored)
+    const pages = [
+      { slug: 'n', fetchStatus: 'ok' },
+      { slug: 'e', fetchStatus: 'error' },
+      {
+        slug: debtSlug,
+        fetchStatus: 'excluded-broken',
+        debtCategory: 'source-side-debt',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+      },
+    ];
+    assert.equal(computeFreshnessState(pages, true), 'partial');
+  });
+});

--- a/scripts/__tests__/source_parity_source_side_debt.test.mjs
+++ b/scripts/__tests__/source_parity_source_side_debt.test.mjs
@@ -282,4 +282,33 @@ describe('source-side debt pipeline integration', () => {
     ];
     assert.equal(computeFreshnessState(pages, true), 'partial');
   });
+
+  it('excluded-fetch-error は freshness 劣化として扱う (excluded-broken とは違う)', () => {
+    // excluded-fetch-error は EXCLUDED_FETCH_STATUSES に含まれないため
+    // freshness 計算で non-excluded として扱われる。
+    const pages = [
+      {
+        slug: debtSlug,
+        fetchStatus: 'excluded-fetch-error',
+        debtCategory: 'source-side-debt',
+        errorDetail: 'HTTP 500',
+        recoveryProbe: null,
+      },
+    ];
+    assert.equal(computeFreshnessState(pages, true), 'broken');
+  });
+
+  it('ok + excluded-fetch-error → partial', () => {
+    const pages = [
+      { slug: 'n', fetchStatus: 'ok' },
+      {
+        slug: debtSlug,
+        fetchStatus: 'excluded-fetch-error',
+        debtCategory: 'source-side-debt',
+        errorDetail: 'HTTP 500',
+        recoveryProbe: null,
+      },
+    ];
+    assert.equal(computeFreshnessState(pages, true), 'partial');
+  });
 });

--- a/scripts/__tests__/source_sync_exclusions.test.mjs
+++ b/scripts/__tests__/source_sync_exclusions.test.mjs
@@ -67,9 +67,9 @@ describe('SOURCE_SYNC_EXCLUSIONS registry', () => {
     // consumer が string match しやすいように)
     assert.equal(entry.reason, 'broken-upstream-source');
     // expectedIssueType / expectedReason は detectSourceUsability の
-    // 出力 shape と合致させる — recovery probe が出す issueType / reason を
-    // ここで固定することで、upstream が直ったときに mismatch から
-    // "excluded-recovered" 判定が落ちるようにする。
+    // 出力 shape と合致させる — recovery probe が detectSourceUsability を
+    // 再利用するため、upstream が直ったとき detector が null を返し
+    // "excluded-recovered" 判定が正しく到達する。
     assert.equal(entry.expectedIssueType, 'snapshot-incomplete');
     assert.equal(entry.expectedReason, 'extractor-empty');
     assert.match(entry.addedAt, /^\d{4}-\d{2}-\d{2}$/);

--- a/scripts/__tests__/source_sync_exclusions.test.mjs
+++ b/scripts/__tests__/source_sync_exclusions.test.mjs
@@ -1,0 +1,146 @@
+/**
+ * Issue #255 Phase 2 — source-side debt exclusion registry contract。
+ *
+ * `scripts/lib/source_sync_exclusions.mjs` は "既知 broken upstream source"
+ * を明示 registry で管理する。自動除外はしない — 人間が upstream broken と
+ * 確認した slug だけ registry に追加される (Issue body #7 の false-negative
+ * 回避原則)。
+ *
+ * このテストが pin する契約:
+ *   1. registry は slug → metadata object の plain object
+ *   2. metadata に必須フィールドが全て揃っている
+ *   3. lookup helper (`isSourceSideDebt` / `getExclusion` /
+ *      `listSourceSideDebtSlugs`) が registry を安全に露出する
+ *   4. `pull-requests` slug が初回 entry として登録済み
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  SOURCE_SYNC_EXCLUSIONS,
+  isSourceSideDebt,
+  getExclusion,
+  listSourceSideDebtSlugs,
+} from '../lib/source_sync_exclusions.mjs';
+
+// ---------------------------------------------------------------------------
+// registry shape
+// ---------------------------------------------------------------------------
+
+describe('SOURCE_SYNC_EXCLUSIONS registry', () => {
+  it('is a plain object keyed by slug', () => {
+    assert.equal(typeof SOURCE_SYNC_EXCLUSIONS, 'object');
+    assert.notEqual(SOURCE_SYNC_EXCLUSIONS, null);
+    assert.equal(Array.isArray(SOURCE_SYNC_EXCLUSIONS), false);
+  });
+
+  it('has pull-requests as the initial source-side debt entry', () => {
+    const slug = 'testops/testops-version-control/pull-requests';
+    assert.ok(
+      SOURCE_SYNC_EXCLUSIONS[slug],
+      `registry must seed ${slug} as the first known source-side debt entry (Issue #247 follow-up)`,
+    );
+  });
+
+  it('each entry has all required metadata fields', () => {
+    const requiredFields = [
+      'reason',
+      'note',
+      'expectedIssueType',
+      'expectedReason',
+      'addedAt',
+      'linkedIssue',
+    ];
+    for (const [slug, entry] of Object.entries(SOURCE_SYNC_EXCLUSIONS)) {
+      for (const field of requiredFields) {
+        assert.ok(
+          Object.prototype.hasOwnProperty.call(entry, field),
+          `registry[${slug}] missing required field "${field}"`,
+        );
+      }
+    }
+  });
+
+  it('pull-requests entry documents the broken upstream symptom', () => {
+    const entry = SOURCE_SYNC_EXCLUSIONS['testops/testops-version-control/pull-requests'];
+    // reason は固定の "broken-upstream-source" token を使う (downstream
+    // consumer が string match しやすいように)
+    assert.equal(entry.reason, 'broken-upstream-source');
+    // expectedIssueType / expectedReason は detectSourceUsability の
+    // 出力 shape と合致させる — recovery probe が出す issueType / reason を
+    // ここで固定することで、upstream が直ったときに mismatch から
+    // "excluded-recovered" 判定が落ちるようにする。
+    assert.equal(entry.expectedIssueType, 'snapshot-incomplete');
+    assert.equal(entry.expectedReason, 'extractor-empty');
+    assert.match(entry.addedAt, /^\d{4}-\d{2}-\d{2}$/);
+    assert.equal(entry.linkedIssue, 247);
+    assert.equal(typeof entry.note, 'string');
+    assert.ok(entry.note.length > 0, 'note must be a non-empty human description');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lookup helpers
+// ---------------------------------------------------------------------------
+
+describe('isSourceSideDebt', () => {
+  it('returns true for registered slugs', () => {
+    assert.equal(
+      isSourceSideDebt('testops/testops-version-control/pull-requests'),
+      true,
+    );
+  });
+
+  it('returns false for unregistered slugs', () => {
+    assert.equal(isSourceSideDebt('overview/testim-overview'), false);
+    assert.equal(isSourceSideDebt('not-a-real-slug'), false);
+  });
+
+  it('returns false for null/undefined/empty input', () => {
+    assert.equal(isSourceSideDebt(null), false);
+    assert.equal(isSourceSideDebt(undefined), false);
+    assert.equal(isSourceSideDebt(''), false);
+  });
+});
+
+describe('getExclusion', () => {
+  it('returns metadata for registered slugs', () => {
+    const entry = getExclusion('testops/testops-version-control/pull-requests');
+    assert.ok(entry);
+    assert.equal(entry.reason, 'broken-upstream-source');
+  });
+
+  it('returns null for unregistered slugs', () => {
+    assert.equal(getExclusion('overview/testim-overview'), null);
+  });
+
+  it('returns null for null/undefined input', () => {
+    assert.equal(getExclusion(null), null);
+    assert.equal(getExclusion(undefined), null);
+  });
+
+  it('returned metadata is a shallow copy (caller cannot mutate registry)', () => {
+    const entry = getExclusion('testops/testops-version-control/pull-requests');
+    entry.reason = 'mutated';
+    const fresh = getExclusion('testops/testops-version-control/pull-requests');
+    assert.equal(fresh.reason, 'broken-upstream-source');
+  });
+});
+
+describe('listSourceSideDebtSlugs', () => {
+  it('returns all registered slugs as a sorted array', () => {
+    const slugs = listSourceSideDebtSlugs();
+    assert.ok(Array.isArray(slugs));
+    assert.ok(slugs.includes('testops/testops-version-control/pull-requests'));
+    // sorted — downstream consumer は順序に依存できる
+    const sorted = [...slugs].sort();
+    assert.deepEqual(slugs, sorted);
+  });
+
+  it('returns a fresh array on each call (caller cannot mutate registry state)', () => {
+    const first = listSourceSideDebtSlugs();
+    first.push('fake/slug');
+    const second = listSourceSideDebtSlugs();
+    assert.equal(second.includes('fake/slug'), false);
+  });
+});

--- a/scripts/__tests__/source_sync_health.test.mjs
+++ b/scripts/__tests__/source_sync_health.test.mjs
@@ -428,7 +428,7 @@ describe('buildSourceSyncStatus — source-side debt counters', () => {
       {
         slug: 'testops/testops-version-control/pull-requests',
         fetchStatus: 'excluded-broken',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
         debtCategory: 'source-side-debt',
       },
     ];
@@ -448,7 +448,7 @@ describe('buildSourceSyncStatus — source-side debt counters', () => {
       {
         slug: 'x',
         fetchStatus: 'excluded-broken',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
         debtCategory: 'source-side-debt',
       },
       {
@@ -475,7 +475,7 @@ describe('buildSourceSyncStatus — source-side debt counters', () => {
       {
         slug: 'b',
         fetchStatus: 'excluded-broken',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
         debtCategory: 'source-side-debt',
       },
     ];
@@ -498,7 +498,7 @@ describe('buildSourceSyncStatus — source-side debt counters', () => {
       {
         slug: 'testops/testops-version-control/pull-requests',
         fetchStatus: 'excluded-broken',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
         debtCategory: 'source-side-debt',
       },
     ];
@@ -516,6 +516,9 @@ describe('buildSourceSyncStatus — source-side debt counters', () => {
     assert.deepEqual(page.recoveryProbe, {
       issueType: 'snapshot-incomplete',
       reason: 'extractor-empty',
+      expectedIssueType: 'snapshot-incomplete',
+      expectedReason: 'extractor-empty',
+      expectedMatch: true,
     });
     assert.equal(page.debtCategory, 'source-side-debt');
   });
@@ -527,7 +530,7 @@ describe('buildSourceSyncStatus — source-side debt counters', () => {
       {
         slug: 'testops/testops-version-control/pull-requests',
         fetchStatus: 'excluded-broken',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
         debtCategory: 'source-side-debt',
       },
     ];
@@ -545,7 +548,7 @@ describe('buildSourceSyncStatus — source-side debt counters', () => {
       {
         slug: 'a',
         fetchStatus: 'excluded-broken',
-        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true },
         debtCategory: 'source-side-debt',
       },
     ];

--- a/scripts/__tests__/source_sync_health.test.mjs
+++ b/scripts/__tests__/source_sync_health.test.mjs
@@ -98,6 +98,7 @@ describe('buildSourceSyncStatus', () => {
       runScope: fullScope,
     });
 
+    assert.equal(result.schemaVersion, 2);
     assert.equal(result.schemaVersion, SOURCE_SYNC_STATUS_SCHEMA_VERSION);
     assert.match(result.runId, /^\d{4}-\d{2}-\d{2}T.+#[0-9a-f]{8}$/);
     assert.equal(typeof result.checkedAt, 'string');

--- a/scripts/__tests__/source_sync_health.test.mjs
+++ b/scripts/__tests__/source_sync_health.test.mjs
@@ -110,6 +110,9 @@ describe('buildSourceSyncStatus', () => {
       fetchedPages: 2,
       notFoundPages: 0,
       errorPages: 0,
+      excludedPages: 0,
+      excludedBrokenPages: 0,
+      excludedRecoveredPages: 0,
       sidebarVerified: true,
     });
     assert.equal(result.pages.length, 2);
@@ -363,5 +366,208 @@ describe('validateRunLinkage', () => {
       sectionScope,
     );
     assert.equal(result, 'scope-mismatch');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #255 Phase 3a — source-side debt (excluded-broken / excluded-recovered)
+//
+// "既知 broken upstream" page は freshness 計算から除外し、独立 counter で
+// 見せる。excluded は `fresh` 判定を壊さない。
+// ---------------------------------------------------------------------------
+
+describe('computeFreshnessState — source-side debt handling', () => {
+  it('ignores excluded-broken pages (debt-only run is still fresh)', () => {
+    const pages = [
+      { slug: 'overview/a', fetchStatus: 'ok' },
+      { slug: 'overview/b', fetchStatus: 'excluded-broken' },
+    ];
+    assert.equal(computeFreshnessState(pages, true), 'fresh');
+  });
+
+  it('ignores excluded-recovered pages (debt-only run is still fresh)', () => {
+    const pages = [
+      { slug: 'overview/a', fetchStatus: 'ok' },
+      { slug: 'overview/b', fetchStatus: 'excluded-recovered' },
+    ];
+    assert.equal(computeFreshnessState(pages, true), 'fresh');
+  });
+
+  it('returns "fresh" when the entire run is excluded (no real fetch targets)', () => {
+    // エッジケース: registry 上の slug しか fetch 対象がないとき、それだけで
+    // broken 扱いしない。既知 debt のみ残っても "fresh" を維持する。
+    const pages = [
+      { slug: 'a', fetchStatus: 'excluded-broken' },
+      { slug: 'b', fetchStatus: 'excluded-recovered' },
+    ];
+    assert.equal(computeFreshnessState(pages, true), 'fresh');
+  });
+
+  it('still returns "broken" when sidebar fails even if all pages are excluded', () => {
+    const pages = [{ slug: 'a', fetchStatus: 'excluded-broken' }];
+    assert.equal(computeFreshnessState(pages, false), 'broken');
+  });
+
+  it('returns "partial" when excluded + mixed ok/error non-excluded pages', () => {
+    const pages = [
+      { slug: 'a', fetchStatus: 'ok' },
+      { slug: 'b', fetchStatus: 'error' },
+      { slug: 'c', fetchStatus: 'excluded-broken' },
+    ];
+    assert.equal(computeFreshnessState(pages, true), 'partial');
+  });
+});
+
+describe('buildSourceSyncStatus — source-side debt counters', () => {
+  const baseSidebarResult = { ok: true, sectionCount: 5, pageCount: 100 };
+  const fullScope = { type: 'full', isComplete: true, filters: { slug: null, section: null } };
+
+  it('exposes excludedPages / excludedBrokenPages / excludedRecoveredPages in summary', () => {
+    const pages = [
+      { slug: 'overview/a', fetchStatus: 'ok' },
+      {
+        slug: 'testops/testops-version-control/pull-requests',
+        fetchStatus: 'excluded-broken',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        debtCategory: 'source-side-debt',
+      },
+    ];
+    const result = buildSourceSyncStatus({
+      pages,
+      sidebarResult: baseSidebarResult,
+      runScope: fullScope,
+    });
+
+    assert.equal(result.summary.excludedPages, 1);
+    assert.equal(result.summary.excludedBrokenPages, 1);
+    assert.equal(result.summary.excludedRecoveredPages, 0);
+  });
+
+  it('counts excluded-recovered separately from excluded-broken', () => {
+    const pages = [
+      {
+        slug: 'x',
+        fetchStatus: 'excluded-broken',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        debtCategory: 'source-side-debt',
+      },
+      {
+        slug: 'y',
+        fetchStatus: 'excluded-recovered',
+        recoveryProbe: null,
+        debtCategory: 'source-side-debt',
+      },
+    ];
+    const result = buildSourceSyncStatus({
+      pages,
+      sidebarResult: baseSidebarResult,
+      runScope: fullScope,
+    });
+
+    assert.equal(result.summary.excludedPages, 2);
+    assert.equal(result.summary.excludedBrokenPages, 1);
+    assert.equal(result.summary.excludedRecoveredPages, 1);
+  });
+
+  it('excludes debt pages from fetchedPages / notFoundPages / errorPages', () => {
+    const pages = [
+      { slug: 'a', fetchStatus: 'ok' },
+      {
+        slug: 'b',
+        fetchStatus: 'excluded-broken',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        debtCategory: 'source-side-debt',
+      },
+    ];
+    const result = buildSourceSyncStatus({
+      pages,
+      sidebarResult: baseSidebarResult,
+      runScope: fullScope,
+    });
+
+    // excluded は ok / not-found / error のどこにも count しない
+    assert.equal(result.summary.fetchedPages, 1);
+    assert.equal(result.summary.notFoundPages, 0);
+    assert.equal(result.summary.errorPages, 0);
+    // ただし targetPages には含まれる (fetch 対象という意味では依然 target)
+    assert.equal(result.summary.targetPages, 2);
+  });
+
+  it('preserves recoveryProbe and debtCategory on each page entry', () => {
+    const pages = [
+      {
+        slug: 'testops/testops-version-control/pull-requests',
+        fetchStatus: 'excluded-broken',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        debtCategory: 'source-side-debt',
+      },
+    ];
+    const result = buildSourceSyncStatus({
+      pages,
+      sidebarResult: baseSidebarResult,
+      runScope: fullScope,
+    });
+
+    const page = result.pages.find(
+      (p) => p.slug === 'testops/testops-version-control/pull-requests',
+    );
+    assert.ok(page);
+    assert.equal(page.fetchStatus, 'excluded-broken');
+    assert.deepEqual(page.recoveryProbe, {
+      issueType: 'snapshot-incomplete',
+      reason: 'extractor-empty',
+    });
+    assert.equal(page.debtCategory, 'source-side-debt');
+  });
+
+  it('sets freshnessState to fresh when only excluded pages remain', () => {
+    // 既知 debt だけを fetch したとき (= `--slug=pull-requests` の実行)
+    // freshness は broken ではなく fresh を返す
+    const pages = [
+      {
+        slug: 'testops/testops-version-control/pull-requests',
+        fetchStatus: 'excluded-broken',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        debtCategory: 'source-side-debt',
+      },
+    ];
+    const result = buildSourceSyncStatus({
+      pages,
+      sidebarResult: baseSidebarResult,
+      runScope: fullScope,
+    });
+    assert.equal(result.freshnessState, 'fresh');
+  });
+
+  it('does not add excluded pages to the top-level errors array', () => {
+    // excluded は "既知" なので error として issue ルートに listup しない
+    const pages = [
+      {
+        slug: 'a',
+        fetchStatus: 'excluded-broken',
+        recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty' },
+        debtCategory: 'source-side-debt',
+      },
+    ];
+    const result = buildSourceSyncStatus({
+      pages,
+      sidebarResult: baseSidebarResult,
+      runScope: fullScope,
+    });
+    assert.deepEqual(result.errors, []);
+  });
+
+  it('defaults counters to 0 when no excluded pages', () => {
+    // backward-compatible: 普通の fetch では新 counter は 0 で出る
+    const pages = [{ slug: 'a', fetchStatus: 'ok' }];
+    const result = buildSourceSyncStatus({
+      pages,
+      sidebarResult: baseSidebarResult,
+      runScope: fullScope,
+    });
+
+    assert.equal(result.summary.excludedPages, 0);
+    assert.equal(result.summary.excludedBrokenPages, 0);
+    assert.equal(result.summary.excludedRecoveredPages, 0);
   });
 });

--- a/scripts/generate_detection_reports.mjs
+++ b/scripts/generate_detection_reports.mjs
@@ -71,7 +71,7 @@ function main() {
     const debt = actionableReport.sourceSyncHealth?.sourceSideDebt;
     if (debt && debt.excludedPages > 0) {
       console.log(
-        `  ソース側 debt: 除外=${debt.excludedPages} 未復旧=${debt.excludedBrokenPages} 復旧候補=${debt.excludedRecoveredPages}`,
+        `  ソース原文の既知問題: 除外=${debt.excludedPages} 未復旧=${debt.excludedBrokenPages} 復旧候補=${debt.excludedRecoveredPages}`,
       );
     }
   } catch (error) {

--- a/scripts/generate_detection_reports.mjs
+++ b/scripts/generate_detection_reports.mjs
@@ -62,7 +62,7 @@ function main() {
     console.log(
       `  パリティ問題 (未解消): ${actionableReport.parityRegression.summary.issueCount}`,
     );
-    console.log(`  パリティ結果: ${actionableReport.result ?? 'unknown'}`);
+    console.log(`  パリティ結果: ${actionableReport.result ?? '不明'}`);
     const followup = actionableReport.parityFollowup;
     console.log(
       `  パリティフォローアップ: 期限切れ=${followup.summary.baselineDebt.expiredBaselineEntries} 30日以内期限切れ=${followup.summary.baselineDebt.expiringBaselineEntries30d ?? 0} 無効化=${followup.summary.baselineDebt.baselineInvalidatedSlugCount} ブロッキング=${followup.summary.advisoryQueue.blockingItems}`,

--- a/scripts/generate_detection_reports.mjs
+++ b/scripts/generate_detection_reports.mjs
@@ -57,15 +57,15 @@ function main() {
     const { actionableReport } = generateDetectionReports({ strict: args.strict });
     console.log('📄 検知サマリー生成完了');
     console.log(
-      `  スナップショット差分 actionable: ${actionableReport.snapshotDiff.summary.actionableCount}`,
+      `  スナップショット差分の要対応: ${actionableReport.snapshotDiff.summary.actionableCount}`,
     );
     console.log(
-      `  active パリティ issue: ${actionableReport.parityRegression.summary.issueCount}`,
+      `  パリティ問題 (未解消): ${actionableReport.parityRegression.summary.issueCount}`,
     );
     console.log(`  パリティ結果: ${actionableReport.result ?? 'unknown'}`);
     const followup = actionableReport.parityFollowup;
     console.log(
-      `  パリティフォローアップ: expired=${followup.summary.baselineDebt.expiredBaselineEntries} expiring30d=${followup.summary.baselineDebt.expiringBaselineEntries30d ?? 0} invalidated=${followup.summary.baselineDebt.baselineInvalidatedSlugCount} advisory-blocking=${followup.summary.advisoryQueue.blockingItems}`,
+      `  パリティフォローアップ: 期限切れ=${followup.summary.baselineDebt.expiredBaselineEntries} 30日以内期限切れ=${followup.summary.baselineDebt.expiringBaselineEntries30d ?? 0} 無効化=${followup.summary.baselineDebt.baselineInvalidatedSlugCount} ブロッキング=${followup.summary.advisoryQueue.blockingItems}`,
     );
     // Issue #255 — source-side debt counter を CLI 出力に含める
     const debt = actionableReport.sourceSyncHealth?.sourceSideDebt;

--- a/scripts/generate_detection_reports.mjs
+++ b/scripts/generate_detection_reports.mjs
@@ -55,18 +55,25 @@ function main() {
   const args = parseArgs();
   try {
     const { actionableReport } = generateDetectionReports({ strict: args.strict });
-    console.log('📄 Detection summary generated');
+    console.log('📄 検知サマリー生成完了');
     console.log(
-      `  snapshot diff actionable: ${actionableReport.snapshotDiff.summary.actionableCount}`,
+      `  スナップショット差分 actionable: ${actionableReport.snapshotDiff.summary.actionableCount}`,
     );
     console.log(
-      `  active parity issues: ${actionableReport.parityRegression.summary.issueCount}`,
+      `  active パリティ issue: ${actionableReport.parityRegression.summary.issueCount}`,
     );
-    console.log(`  parity result: ${actionableReport.result ?? 'unknown'}`);
+    console.log(`  パリティ結果: ${actionableReport.result ?? 'unknown'}`);
     const followup = actionableReport.parityFollowup;
     console.log(
-      `  parity followup: expired=${followup.summary.baselineDebt.expiredBaselineEntries} expiring30d=${followup.summary.baselineDebt.expiringBaselineEntries30d ?? 0} invalidated=${followup.summary.baselineDebt.baselineInvalidatedSlugCount} advisory-blocking=${followup.summary.advisoryQueue.blockingItems}`,
+      `  パリティフォローアップ: expired=${followup.summary.baselineDebt.expiredBaselineEntries} expiring30d=${followup.summary.baselineDebt.expiringBaselineEntries30d ?? 0} invalidated=${followup.summary.baselineDebt.baselineInvalidatedSlugCount} advisory-blocking=${followup.summary.advisoryQueue.blockingItems}`,
     );
+    // Issue #255 — source-side debt counter を CLI 出力に含める
+    const debt = actionableReport.sourceSyncHealth?.sourceSideDebt;
+    if (debt && debt.excludedPages > 0) {
+      console.log(
+        `  ソース側 debt: 除外=${debt.excludedPages} 未復旧=${debt.excludedBrokenPages} 復旧候補=${debt.excludedRecoveredPages}`,
+      );
+    }
   } catch (error) {
     console.error(`❌ ${error.message}`);
     if (error.validationErrors) {

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -21,7 +21,7 @@ const PARITY_ISSUE_TITLE =
 const SOURCE_SYNC_ISSUE_TITLE =
   '⚠️ ソース同期: 取得の劣化またはソース原文の既知問題を検知';
 const PARITY_FOLLOWUP_ISSUE_TITLE =
-  '🗂️ パリティフォローアップ: baseline 負債と advisory キュー';
+  '🗂️ パリティフォローアップ: ベースライン負債とアドバイザリキュー';
 const DOCS_PREFIX = path.join('src', 'content', 'docs') + path.sep;
 
 /**
@@ -642,20 +642,20 @@ function buildTokenlessNearTieExamples(advisoryQueue, maxEntries) {
 }
 
 function formatAdvisoryQueueScope(scope) {
-  if (!scope || typeof scope !== 'object') return 'scope 不明';
+  if (!scope || typeof scope !== 'object') return 'スコープ不明';
   if (scope.isComplete === true) return 'リポジトリ全体';
 
   const slug = scope.filters?.slug ?? null;
   if (scope.type === 'slug' && slug) {
-    return `部分 scope: slug=${slug}、リポジトリ全体ではない`;
+    return `部分スコープ: slug=${slug}、リポジトリ全体ではない`;
   }
 
   const section = scope.filters?.section ?? null;
   if (scope.type === 'section' && section) {
-    return `部分 scope: section=${section}、リポジトリ全体ではない`;
+    return `部分スコープ: section=${section}、リポジトリ全体ではない`;
   }
 
-  return '部分 scope、リポジトリ全体ではない';
+  return '部分スコープ、リポジトリ全体ではない';
 }
 
 function buildParityFollowupBody({
@@ -673,18 +673,18 @@ function buildParityFollowupBody({
   const lines = [
     '## サマリー',
     '',
-    `- チェック日時: ${summary.checkedAt ?? 'unknown'}`,
-    `- baseline 済 issue: ${summary.baselinedIssues ?? 0} 件 (${summary.baselinedFiles ?? 0} ファイル)`,
-    `- 期限切れ baseline: ${summary.expiredBaselineEntries ?? 0}`,
+    `- チェック日時: ${summary.checkedAt ?? '不明'}`,
+    `- ベースライン済み: ${summary.baselinedIssues ?? 0} 件 (${summary.baselinedFiles ?? 0} ファイル)`,
+    `- 期限切れベースライン: ${summary.expiredBaselineEntries ?? 0}`,
     `- 30 日以内期限切れ予定: ${summary.expiringBaselineEntries30d ?? 0}`,
-    `- 無効化された baseline slug: ${baselineInvalidatedSlugs.length}`,
+    `- 無効化されたベースライン slug: ${baselineInvalidatedSlugs.length}`,
     '',
   ];
 
   if (includeAdvisoryInBody) {
     lines.push(
-      `- advisory キュー: ${advisoryQueueIssues} 件 (${advisoryQueueFiles} ファイル)`,
-      `  - scope: ${formatAdvisoryQueueScope(advisoryQueueScope)}`,
+      `- アドバイザリキュー: ${advisoryQueueIssues} 件 (${advisoryQueueFiles} ファイル)`,
+      `  - スコープ: ${formatAdvisoryQueueScope(advisoryQueueScope)}`,
       `  - ブロッキング: ${blockingAdvisoryItems.length}`,
       '',
     );
@@ -697,7 +697,7 @@ function buildParityFollowupBody({
   // 省略する。
   if (sourceUnusable && sourceUnusable.snapshotUnusableIssues > 0) {
     lines.push(
-      '## ソース使用不可 (advisory)',
+      '## ソース使用不可 (参考)',
       '',
       `- 合計: ${sourceUnusable.snapshotUnusableIssues} 件 (${sourceUnusable.snapshotUnusableFiles} ファイル)`,
       '- 翻訳の問題ではなくスナップショット / ソース同期側の既知問題です。翻訳 PR では修正できません。',
@@ -719,9 +719,9 @@ function buildParityFollowupBody({
   const orphanBaselineEntries = summary.orphanBaselineEntries || 0;
   if (orphanBaselineEntries > 0) {
     lines.push(
-      '## 🧹 孤立した baseline entry',
+      '## 🧹 孤立したベースラインエントリー',
       '',
-      `- 合計: ${orphanBaselineEntries} 件 (runtime で一致する issue が無い — 掃除対象)`,
+      `- 合計: ${orphanBaselineEntries} 件 (実行時に一致する問題が無い — 掃除対象)`,
     );
     const byType = summary.orphanBaselineByType || {};
     const sortedTypes = Object.keys(byType).sort();
@@ -733,13 +733,13 @@ function buildParityFollowupBody({
     }
     lines.push(
       '',
-      '対応: `node scripts/generate_parity_baseline.mjs --slug=<slug>` で該当 slug を再生成すると orphan が purge されます。',
+      '対応: `node scripts/generate_parity_baseline.mjs --slug=<slug>` で該当 slug を再生成すると孤立エントリーが削除されます。',
       '',
     );
   }
 
   if (expiredBaselineFiles.length > 0) {
-    lines.push('## 期限切れ baseline エントリー', '');
+    lines.push('## 期限切れベースラインエントリー', '');
     lines.push(
       formatList(
         expiredBaselineFiles.map((f) => {
@@ -769,20 +769,20 @@ function buildParityFollowupBody({
   }
 
   if (baselineInvalidatedSlugs.length > 0) {
-    lines.push('## 無効化された baseline slug', '');
+    lines.push('## 無効化されたベースライン slug', '');
     lines.push(
-      formatList(baselineInvalidatedSlugs.map((s) => `\`${s}\` — EN snapshot が変更された`)),
+      formatList(baselineInvalidatedSlugs.map((s) => `\`${s}\` — 英語スナップショットが変更された`)),
     );
     lines.push('');
   }
 
   if (blockingAdvisoryItems.length > 0) {
-    lines.push('## Advisory queue — ブロッキング項目', '');
+    lines.push('## アドバイザリキュー — ブロッキング項目', '');
     lines.push(
       formatList(
         blockingAdvisoryItems.map((e) => {
           const topIssue = (e.issues ?? [])[0];
-          const cat = topIssue?.inconclusiveCategory ?? 'unknown';
+          const cat = topIssue?.inconclusiveCategory ?? '不明';
           return `\`${e.slug}\` — ${cat} (${e.issueCount} 件)`;
         }),
       ),
@@ -944,7 +944,7 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
   const snapshotIssueBody = [
     '## サマリー',
     '',
-    `- チェック日時: ${snapshot.checkedAt ?? 'unknown'}`,
+    `- チェック日時: ${snapshot.checkedAt ?? '不明'}`,
     `- 変更ページ: ${snapshot.summary?.changed || 0}`,
     `- 追加ページ: ${snapshot.summary?.added || 0}`,
     `- 削除ページ: ${snapshot.summary?.removed || 0}`,
@@ -988,9 +988,9 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
   const parityIssueBody = [
     '## サマリー',
     '',
-    `- チェック日時: ${parity.summary?.checkedAt ?? 'unknown'}`,
-    `- actionable ファイル: ${activeActionableFiles}`,
-    `- issue ファイル: ${parityIssueFiles.length}`,
+    `- チェック日時: ${parity.summary?.checkedAt ?? '不明'}`,
+    `- 要対応ファイル: ${activeActionableFiles}`,
+    `- 問題ファイル: ${parityIssueFiles.length}`,
     `- エラーファイル: ${activeErrorFiles}`,
     `- 承認済み (非ブロッキング): ${acknowledgedIssues}`,
     ...(expiredAcknowledgements > 0
@@ -1042,8 +1042,8 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
     ? [
         '## サマリー',
         '',
-        `- 鮮度状態: **${freshnessState ?? 'unknown'}**`,
-        `- linkage state: **${linkageState ?? 'unknown'}**`,
+        `- 鮮度状態: **${freshnessState ?? '不明'}**`,
+        `- 連結状態: **${linkageState ?? '不明'}**`,
         `- 対象ページ: ${syncSummary.targetPages ?? 0}`,
         `- 取得済みページ: ${syncSummary.fetchedPages ?? 0}`,
         `- 404 ページ: ${syncSummary.notFoundPages ?? 0}`,
@@ -1143,7 +1143,7 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
 }
 
 export function renderSummaryMarkdown(_snapshot, parity, actionableReport, auditManifest, sourceSync) {
-  const syncState = sourceSync?.freshnessState ?? actionableReport?.sourceSyncHealth?.freshnessState ?? 'unknown';
+  const syncState = sourceSync?.freshnessState ?? actionableReport?.sourceSyncHealth?.freshnessState ?? '不明';
   const syncSummary = sourceSync?.summary ?? actionableReport?.sourceSyncHealth?.summary ?? {};
 
   // Issue #255 — source-side debt を summary markdown に可視化する。
@@ -1179,7 +1179,7 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
       ? Object.entries(auditSignalsByType)
           .sort(([leftType], [rightType]) => leftType.localeCompare(rightType))
           .map(([type, count]) => `  - ${type}: ${count}`)
-      : ['  - (none)'];
+      : ['  - (なし)'];
 
   // Issue #247 PR5 — structure mismatch の独立 advisory section は削除した。
   // reportable に昇格したため、件数は `## パリティ` の `active issue files`
@@ -1191,7 +1191,7 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
   const sourceUnusableSection =
     snapshotUnusableIssues > 0
       ? [
-          '## ソース使用不可 (advisory)',
+          '## ソース使用不可 (参考)',
           '',
           `- 合計: ${snapshotUnusableIssues} 件 (${snapshotUnusableFiles} ファイル)`,
           '- 翻訳の問題ではなくスナップショット / ソース同期側の既知問題です。翻訳 PR では修正できません。',
@@ -1230,8 +1230,8 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
     '',
     '## パリティ',
     '',
-    `- actionable ファイル: ${parityActiveActionable}`,
-    `- issue ファイル: ${parityActiveFiles}`,
+    `- 要対応ファイル: ${parityActiveActionable}`,
+    `- 問題ファイル: ${parityActiveFiles}`,
     `- エラーファイル: ${parity.summary?.activeErrorFiles ?? parity.summary?.errorFiles ?? 0}`,
     `- 承認済み (非ブロッキング): ${parity.summary?.acknowledgedIssues || 0}`,
     ...((parity.summary?.expiredAcknowledgements || 0) > 0
@@ -1241,8 +1241,8 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
     ...sourceUnusableSection,
     '## 監査シグナル',
     '',
-    '- audit 専用: 粗い count / 形状 / table cell ヒューリスティック',
-    '- deep-audit で確認可能。parity-regression issue body には含めない',
+    '- 監査専用: 粗いカウント / 形状 / テーブルセルのヒューリスティック',
+    '- deep-audit で確認可能。パリティ後退の issue 本文には含めない',
     `- 合計: ${auditSignalIssues} 件 (${auditSignalFiles} ファイル)`,
     '- 種別別:',
     ...auditSignalRows,
@@ -1256,10 +1256,10 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
     '',
     '## パリティフォローアップ',
     '',
-    `- baseline 済: ${actionableReport.parityFollowup?.summary?.baselineDebt?.baselinedIssues ?? 0} 件 (${actionableReport.parityFollowup?.summary?.baselineDebt?.baselinedFiles ?? 0} ファイル)`,
-    `- 期限切れ baseline: ${actionableReport.parityFollowup?.summary?.baselineDebt?.expiredBaselineEntries ?? 0}`,
+    `- ベースライン済み: ${actionableReport.parityFollowup?.summary?.baselineDebt?.baselinedIssues ?? 0} 件 (${actionableReport.parityFollowup?.summary?.baselineDebt?.baselinedFiles ?? 0} ファイル)`,
+    `- 期限切れベースライン: ${actionableReport.parityFollowup?.summary?.baselineDebt?.expiredBaselineEntries ?? 0}`,
     `- 無効化された slug: ${(actionableReport.parityFollowup?.summary?.baselineDebt?.baselineInvalidatedSlugs ?? []).length}`,
-    `- advisory キュー: ${actionableReport.parityFollowup?.summary?.advisoryQueue?.issues ?? 0} 件 (${actionableReport.parityFollowup?.summary?.advisoryQueue?.files ?? 0} ファイル, ${actionableReport.parityFollowup?.summary?.advisoryQueue?.blockingItems ?? 0} ブロッキング; ${formatAdvisoryQueueScope(actionableReport.parityFollowup?.summary?.advisoryQueue?.advisoryQueueScope ?? null)})`,
+    `- アドバイザリキュー: ${actionableReport.parityFollowup?.summary?.advisoryQueue?.issues ?? 0} 件 (${actionableReport.parityFollowup?.summary?.advisoryQueue?.files ?? 0} ファイル, ${actionableReport.parityFollowup?.summary?.advisoryQueue?.blockingItems ?? 0} ブロッキング; ${formatAdvisoryQueueScope(actionableReport.parityFollowup?.summary?.advisoryQueue?.advisoryQueueScope ?? null)})`,
     '',
     '## アーティファクト',
     '',

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -363,10 +363,10 @@ function renderSourceSideDebtSubsection(debt, _pages) {
     `- 未復旧: ${debt.excludedBrokenPages}`,
     `- 復旧候補: ${debt.excludedRecoveredPages}`,
     '',
-    '既知の upstream EN source が broken で parity comparator の前提を満たさない',
-    'ページです。`scripts/lib/source_sync_exclusions.mjs` の registry で管理され、',
-    'snapshot fetch は実行するが snapshot file は上書きせず、hand-authored snapshot を',
-    '凍結参照として保持します。',
+    '英語原文が壊れておりパリティ比較の前提を満たさないページです。',
+    '`scripts/lib/source_sync_exclusions.mjs` の除外レジストリで管理され、',
+    'スナップショット取得は実行するがファイルは上書きせず、手動作成した',
+    'スナップショットを凍結参照として保持します。',
     '',
   ];
 
@@ -386,15 +386,15 @@ function renderSourceSideDebtSubsection(debt, _pages) {
   if (debt.excludedRecoveredPages > 0) {
     lines.push('### 復旧候補', '');
     lines.push(
-      'upstream EN source が復旧した可能性があります。人間が確認の上、',
-      '`scripts/lib/source_sync_exclusions.mjs` から該当 slug を登録解除してください。',
-      '(自動解除はしません — 一時的な upstream 揺れで false recovery を作らないため)',
+      '英語原文が復旧した可能性があります。人間が確認の上、',
+      '`scripts/lib/source_sync_exclusions.mjs` から該当 slug を除外解除してください。',
+      '(自動解除はしません — 一時的な原文側の揺れで誤検知を作らないため)',
       '',
     );
     for (const slug of debt.recoveredSlugs) {
       lines.push(`- \`${slug}\``);
       lines.push(`  - 状態: excluded-recovered`);
-      lines.push(`  - 対応: registry entry 削除を検討`);
+      lines.push(`  - 対応: 除外レジストリからの削除を検討`);
     }
     lines.push('');
   }
@@ -668,7 +668,7 @@ function buildParityFollowupBody({
       '## ソース使用不可 (advisory)',
       '',
       `- 合計: ${sourceUnusable.snapshotUnusableIssues} 件 (${sourceUnusable.snapshotUnusableFiles} ファイル)`,
-      '- 翻訳失敗ではなく snapshot / source sync 側 debt です。翻訳 PR では修正できません。',
+      '- 翻訳の問題ではなくスナップショット / ソース同期側の既知問題です。翻訳 PR では修正できません。',
     );
     const sortedTypes = Object.keys(sourceUnusable.snapshotUnusableByType ?? {}).sort();
     if (sortedTypes.length > 0) {
@@ -1162,7 +1162,7 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
           '## ソース使用不可 (advisory)',
           '',
           `- 合計: ${snapshotUnusableIssues} 件 (${snapshotUnusableFiles} ファイル)`,
-          '- 翻訳失敗ではなく snapshot / source sync 側 debt です。翻訳 PR では修正できません。',
+          '- 翻訳の問題ではなくスナップショット / ソース同期側の既知問題です。翻訳 PR では修正できません。',
           ...(Object.keys(snapshotUnusableByType).length > 0
             ? [
                 '- 種別別:',

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -191,6 +191,25 @@ export function validateSourceSyncStatus(parsed) {
           `(object for excluded-broken, null for excluded-recovered)`,
         );
       }
+      const probe = page.recoveryProbe;
+      if (probe !== null) {
+        if (typeof probe !== 'object' || Array.isArray(probe)) {
+          throw new Error(
+            `source-sync-status.json: debt page "${page.slug}" recoveryProbe must be object|null, ` +
+            `got ${probe === null ? 'null' : typeof probe}`,
+          );
+        }
+        if (typeof probe.issueType !== 'string') {
+          throw new Error(
+            `source-sync-status.json: debt page "${page.slug}" recoveryProbe.issueType must be a string`,
+          );
+        }
+        if (typeof probe.reason !== 'string') {
+          throw new Error(
+            `source-sync-status.json: debt page "${page.slug}" recoveryProbe.reason must be a string`,
+          );
+        }
+      }
     }
   }
   if (!Array.isArray(parsed.errors)) {

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -159,8 +159,39 @@ export function validateSourceSyncStatus(parsed) {
   if (typeof parsed.summary.sidebarVerified !== 'boolean') {
     throw new Error('source-sync-status.json: summary.sidebarVerified must be boolean');
   }
+  // Issue #255 — excluded counter の strict validation。
+  // buildSourceSyncStatus は常にこれらを emit するので、欠損は artifact 破損。
+  if (typeof parsed.summary.excludedPages !== 'number') {
+    throw new Error('source-sync-status.json: summary.excludedPages must be a number');
+  }
+  if (typeof parsed.summary.excludedBrokenPages !== 'number') {
+    throw new Error('source-sync-status.json: summary.excludedBrokenPages must be a number');
+  }
+  if (typeof parsed.summary.excludedRecoveredPages !== 'number') {
+    throw new Error('source-sync-status.json: summary.excludedRecoveredPages must be a number');
+  }
   if (!Array.isArray(parsed.pages)) {
     throw new Error('source-sync-status.json: pages must be an array');
+  }
+  // Issue #255 — debt page の shape validation。debtCategory を持つ page は
+  // fetchStatus が excluded-broken|excluded-recovered のいずれかで、
+  // recoveryProbe が object|null であることを要求する。
+  const VALID_DEBT_FETCH_STATUSES = new Set(['excluded-broken', 'excluded-recovered']);
+  for (const page of parsed.pages) {
+    if (page.debtCategory) {
+      if (!VALID_DEBT_FETCH_STATUSES.has(page.fetchStatus)) {
+        throw new Error(
+          `source-sync-status.json: debt page "${page.slug}" has invalid fetchStatus ` +
+          `"${page.fetchStatus}" (expected excluded-broken|excluded-recovered)`,
+        );
+      }
+      if (!('recoveryProbe' in page)) {
+        throw new Error(
+          `source-sync-status.json: debt page "${page.slug}" must have recoveryProbe ` +
+          `(object for excluded-broken, null for excluded-recovered)`,
+        );
+      }
+    }
   }
   if (!Array.isArray(parsed.errors)) {
     throw new Error('source-sync-status.json: errors must be an array');
@@ -883,8 +914,8 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
     '## サマリー',
     '',
     `- チェック日時: ${parity.summary?.checkedAt ?? 'unknown'}`,
-    `- active actionable ファイル: ${activeActionableFiles}`,
-    `- active issue ファイル: ${parityIssueFiles.length}`,
+    `- actionable ファイル: ${activeActionableFiles}`,
+    `- issue ファイル: ${parityIssueFiles.length}`,
     `- エラーファイル: ${activeErrorFiles}`,
     `- 承認済み (非ブロッキング): ${acknowledgedIssues}`,
     ...(expiredAcknowledgements > 0
@@ -1124,8 +1155,8 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
     '',
     '## パリティ',
     '',
-    `- active actionable ファイル: ${parityActiveActionable}`,
-    `- active issue ファイル: ${parityActiveFiles}`,
+    `- actionable ファイル: ${parityActiveActionable}`,
+    `- issue ファイル: ${parityActiveFiles}`,
     `- エラーファイル: ${parity.summary?.activeErrorFiles ?? parity.summary?.errorFiles ?? 0}`,
     `- 承認済み (非ブロッキング): ${parity.summary?.acknowledgedIssues || 0}`,
     ...((parity.summary?.expiredAcknowledgements || 0) > 0

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -225,6 +225,109 @@ function formatList(values) {
   return values.map((value) => `- ${value}`).join('\n');
 }
 
+/**
+ * Issue #255 — Build a structured summary of source-side debt from
+ * `source-sync-status.json`. Returns counters plus broken / recovered
+ * slug lists with their recovery-probe payloads so downstream consumers
+ * (markdown renderer, issue body, dashboards) can render without
+ * re-parsing the raw status file.
+ *
+ * Pure function. Safe to call with an empty/missing sourceSync object.
+ *
+ * @param {object | null | undefined} sourceSync — parsed source-sync-status.json
+ * @returns {{
+ *   excludedPages: number,
+ *   excludedBrokenPages: number,
+ *   excludedRecoveredPages: number,
+ *   brokenSlugs: string[],
+ *   recoveredSlugs: string[],
+ *   brokenDetails: { slug: string, issueType: string|null, reason: string|null }[],
+ * }}
+ */
+function buildSourceSideDebtSummary(sourceSync) {
+  const summary = sourceSync?.summary ?? {};
+  const pages = sourceSync?.pages ?? [];
+
+  const brokenPages = pages.filter((p) => p.fetchStatus === 'excluded-broken');
+  const recoveredPages = pages.filter((p) => p.fetchStatus === 'excluded-recovered');
+
+  return {
+    excludedPages: summary.excludedPages ?? 0,
+    excludedBrokenPages: summary.excludedBrokenPages ?? 0,
+    excludedRecoveredPages: summary.excludedRecoveredPages ?? 0,
+    brokenSlugs: brokenPages.map((p) => p.slug).sort(),
+    recoveredSlugs: recoveredPages.map((p) => p.slug).sort(),
+    brokenDetails: brokenPages
+      .map((p) => ({
+        slug: p.slug,
+        issueType: p.recoveryProbe?.issueType ?? null,
+        reason: p.recoveryProbe?.reason ?? null,
+      }))
+      .sort((left, right) => left.slug.localeCompare(right.slug)),
+  };
+}
+
+/**
+ * Issue #255 — Render the `## ソース側 debt` section as Markdown lines.
+ * Returns an array of strings ready to be joined with '\n'. The caller
+ * is responsible for deciding when the section should appear at all
+ * (usually: skip when `excludedPages === 0`).
+ *
+ * The section is fully Japanese on the theory that humans read it and
+ * machines read the JSON fields instead. Slugs and technical tokens
+ * (`snapshot-incomplete`, `extractor-empty`, file names) stay in English.
+ *
+ * @param {ReturnType<typeof buildSourceSideDebtSummary>} debt
+ * @param {{ slug: string, fetchStatus: string, recoveryProbe?: any, debtCategory?: string }[]} _pages
+ * @returns {string[]}
+ */
+function renderSourceSideDebtSubsection(debt, _pages) {
+  const lines = [
+    '## ソース側 debt',
+    '',
+    `- 除外ページ: ${debt.excludedPages}`,
+    `- 未復旧: ${debt.excludedBrokenPages}`,
+    `- 復旧候補: ${debt.excludedRecoveredPages}`,
+    '',
+    '既知の upstream EN source が broken で parity comparator の前提を満たさない',
+    'ページです。`scripts/lib/source_sync_exclusions.mjs` の registry で管理され、',
+    'snapshot fetch は実行するが snapshot file は上書きせず、hand-authored snapshot を',
+    '凍結参照として保持します。',
+    '',
+  ];
+
+  if (debt.excludedBrokenPages > 0) {
+    lines.push('### 未復旧', '');
+    for (const entry of debt.brokenDetails) {
+      const detail = entry.issueType && entry.reason
+        ? `${entry.issueType} / ${entry.reason}`
+        : entry.issueType || entry.reason || '判定なし';
+      lines.push(`- \`${entry.slug}\``);
+      lines.push(`  - 状態: excluded-broken`);
+      lines.push(`  - 判定: ${detail}`);
+    }
+    lines.push('');
+  }
+
+  if (debt.excludedRecoveredPages > 0) {
+    lines.push('### 復旧候補', '');
+    lines.push(
+      'upstream EN source が復旧した可能性があります。人間が確認の上、',
+      '`scripts/lib/source_sync_exclusions.mjs` から該当 slug を登録解除してください。',
+      '(自動解除はしません — 一時的な upstream 揺れで false recovery を作らないため)',
+      '',
+    );
+    for (const slug of debt.recoveredSlugs) {
+      lines.push(`- \`${slug}\``);
+      lines.push(`  - 状態: excluded-recovered`);
+      lines.push(`  - 対応: registry entry 削除を検討`);
+    }
+    lines.push('');
+  }
+
+  return lines;
+}
+
 function bucketPriority(bucket) {
   if (bucket === 'page-lifecycle') return 0;
   if (bucket === 'structural-change') return 1;
@@ -433,20 +536,20 @@ function buildTokenlessNearTieExamples(advisoryQueue, maxEntries) {
 }
 
 function formatAdvisoryQueueScope(scope) {
-  if (!scope || typeof scope !== 'object') return 'scope unknown';
-  if (scope.isComplete === true) return 'full repo';
+  if (!scope || typeof scope !== 'object') return 'scope 不明';
+  if (scope.isComplete === true) return 'リポジトリ全体';
 
   const slug = scope.filters?.slug ?? null;
   if (scope.type === 'slug' && slug) {
-    return `partial scope: slug=${slug}, not repo-wide`;
+    return `部分 scope: slug=${slug}、リポジトリ全体ではない`;
   }
 
   const section = scope.filters?.section ?? null;
   if (scope.type === 'section' && section) {
-    return `partial scope: section=${section}, not repo-wide`;
+    return `部分 scope: section=${section}、リポジトリ全体ではない`;
   }
 
-  return 'partial scope, not repo-wide';
+  return '部分 scope、リポジトリ全体ではない';
 }
 
 function buildParityFollowupBody({
@@ -462,21 +565,21 @@ function buildParityFollowupBody({
   sourceUnusable,
 }) {
   const lines = [
-    '## Summary',
+    '## サマリー',
     '',
-    `- Checked at: ${summary.checkedAt ?? 'unknown'}`,
-    `- Baselined issues: ${summary.baselinedIssues ?? 0} (${summary.baselinedFiles ?? 0} files)`,
-    `- Expired baseline entries: ${summary.expiredBaselineEntries ?? 0}`,
-    `- Expiring within 30 days: ${summary.expiringBaselineEntries30d ?? 0}`,
-    `- Baseline-invalidated slugs: ${baselineInvalidatedSlugs.length}`,
+    `- チェック日時: ${summary.checkedAt ?? 'unknown'}`,
+    `- baseline 済 issue: ${summary.baselinedIssues ?? 0} 件 (${summary.baselinedFiles ?? 0} ファイル)`,
+    `- 期限切れ baseline: ${summary.expiredBaselineEntries ?? 0}`,
+    `- 30 日以内期限切れ予定: ${summary.expiringBaselineEntries30d ?? 0}`,
+    `- 無効化された baseline slug: ${baselineInvalidatedSlugs.length}`,
     '',
   ];
 
   if (includeAdvisoryInBody) {
     lines.push(
-      `- Advisory queue: ${advisoryQueueIssues} issues (${advisoryQueueFiles} files)`,
-      `  - Scope: ${formatAdvisoryQueueScope(advisoryQueueScope)}`,
-      `  - Blocking: ${blockingAdvisoryItems.length}`,
+      `- advisory キュー: ${advisoryQueueIssues} 件 (${advisoryQueueFiles} ファイル)`,
+      `  - scope: ${formatAdvisoryQueueScope(advisoryQueueScope)}`,
+      `  - ブロッキング: ${blockingAdvisoryItems.length}`,
       '',
     );
   }
@@ -488,14 +591,14 @@ function buildParityFollowupBody({
   // 省略する。
   if (sourceUnusable && sourceUnusable.snapshotUnusableIssues > 0) {
     lines.push(
-      '## Source Unusable (advisory)',
+      '## ソース使用不可 (advisory)',
       '',
-      `- Total: ${sourceUnusable.snapshotUnusableIssues} issues across ${sourceUnusable.snapshotUnusableFiles} files`,
-      '- Not a translation failure — snapshot / source sync 側 debt です。翻訳 PR では修正できません。',
+      `- 合計: ${sourceUnusable.snapshotUnusableIssues} 件 (${sourceUnusable.snapshotUnusableFiles} ファイル)`,
+      '- 翻訳失敗ではなく snapshot / source sync 側 debt です。翻訳 PR では修正できません。',
     );
     const sortedTypes = Object.keys(sourceUnusable.snapshotUnusableByType ?? {}).sort();
     if (sortedTypes.length > 0) {
-      lines.push('- By type:');
+      lines.push('- 種別別:');
       for (const type of sortedTypes) {
         lines.push(`  - ${type}: ${sourceUnusable.snapshotUnusableByType[type]}`);
       }
@@ -510,14 +613,14 @@ function buildParityFollowupBody({
   const orphanBaselineEntries = summary.orphanBaselineEntries || 0;
   if (orphanBaselineEntries > 0) {
     lines.push(
-      '## 🧹 Orphan baseline entries',
+      '## 🧹 孤立した baseline entry',
       '',
-      `- Total: ${orphanBaselineEntries} entries (runtime で一致する issue が無い — 掃除対象)`,
+      `- 合計: ${orphanBaselineEntries} 件 (runtime で一致する issue が無い — 掃除対象)`,
     );
     const byType = summary.orphanBaselineByType || {};
     const sortedTypes = Object.keys(byType).sort();
     if (sortedTypes.length > 0) {
-      lines.push('- By type:');
+      lines.push('- 種別別:');
       for (const type of sortedTypes) {
         lines.push(`  - ${type}: ${byType[type]}`);
       }
@@ -530,12 +633,12 @@ function buildParityFollowupBody({
   }
 
   if (expiredBaselineFiles.length > 0) {
-    lines.push('## Expired Baseline Entries', '');
+    lines.push('## 期限切れ baseline エントリー', '');
     lines.push(
       formatList(
         expiredBaselineFiles.map((f) => {
           const rv = f.reviewAfter ? ` — reviewAfter: ${f.reviewAfter}` : '';
-          return `\`${f.file}\` (${f.count} entries${rv})`;
+          return `\`${f.file}\` (${f.count} 件${rv})`;
         }),
       ),
     );
@@ -543,16 +646,16 @@ function buildParityFollowupBody({
   }
 
   if (expiringBaselineFiles && expiringBaselineFiles.length > 0) {
-    lines.push('## Expiring Within 30 Days', '');
+    lines.push('## 30 日以内に期限切れ', '');
     lines.push(
-      '> Plan paydown PRs before these entries cross `reviewAfter` and re-enter the gate.',
+      '> `reviewAfter` を越えて gate に戻る前に返済 PR を計画してください。',
       '',
     );
     lines.push(
       formatList(
         expiringBaselineFiles.map((f) => {
           const rv = f.reviewAfter ? ` — reviewAfter: ${f.reviewAfter}` : '';
-          return `\`${f.file}\` (${f.count} entries${rv})`;
+          return `\`${f.file}\` (${f.count} 件${rv})`;
         }),
       ),
     );
@@ -560,28 +663,28 @@ function buildParityFollowupBody({
   }
 
   if (baselineInvalidatedSlugs.length > 0) {
-    lines.push('## Baseline-Invalidated Slugs', '');
+    lines.push('## 無効化された baseline slug', '');
     lines.push(
-      formatList(baselineInvalidatedSlugs.map((s) => `\`${s}\` — EN snapshot changed`)),
+      formatList(baselineInvalidatedSlugs.map((s) => `\`${s}\` — EN snapshot が変更された`)),
     );
     lines.push('');
   }
 
   if (blockingAdvisoryItems.length > 0) {
-    lines.push('## Advisory Queue — Blocking Items', '');
+    lines.push('## Advisory queue — ブロッキング項目', '');
     lines.push(
       formatList(
         blockingAdvisoryItems.map((e) => {
           const topIssue = (e.issues ?? [])[0];
           const cat = topIssue?.inconclusiveCategory ?? 'unknown';
-          return `\`${e.slug}\` — ${cat} (${e.issueCount} issues)`;
+          return `\`${e.slug}\` — ${cat} (${e.issueCount} 件)`;
         }),
       ),
     );
     lines.push('');
   }
 
-  lines.push('## Artifacts', '', '- `parity-check-status.json`');
+  lines.push('## アーティファクト', '', '- `parity-check-status.json`');
 
   return lines.join('\n');
 }
@@ -733,29 +836,29 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
   );
 
   const snapshotIssueBody = [
-    '## Summary',
+    '## サマリー',
     '',
-    `- Checked at: ${snapshot.checkedAt ?? 'unknown'}`,
-    `- Changed pages: ${snapshot.summary?.changed || 0}`,
-    `- Added pages: ${snapshot.summary?.added || 0}`,
-    `- Removed pages: ${snapshot.summary?.removed || 0}`,
-    `- Unchanged: ${snapshot.summary?.unchanged || 0}`,
-    `- Total snapshots: ${snapshot.summary?.totalSnapshots || 0}`,
+    `- チェック日時: ${snapshot.checkedAt ?? 'unknown'}`,
+    `- 変更ページ: ${snapshot.summary?.changed || 0}`,
+    `- 追加ページ: ${snapshot.summary?.added || 0}`,
+    `- 削除ページ: ${snapshot.summary?.removed || 0}`,
+    `- 変更なし: ${snapshot.summary?.unchanged || 0}`,
+    `- 総スナップショット数: ${snapshot.summary?.totalSnapshots || 0}`,
     '',
-    '## Top Entries',
+    '## 上位エントリー',
     '',
     formatList(snapshotTopEntries.map(formatSnapshotEntry)),
     '',
     ...(snapshot.sidebar?.changed
       ? [
-          '## Sidebar Changes',
+          '## サイドバー変更',
           '',
-          `- Pages added: ${snapshot.sidebar.addedPages?.length || 0}`,
-          `- Pages removed: ${snapshot.sidebar.removedPages?.length || 0}`,
+          `- 追加ページ: ${snapshot.sidebar.addedPages?.length || 0}`,
+          `- 削除ページ: ${snapshot.sidebar.removedPages?.length || 0}`,
           '',
         ]
       : []),
-    '## Artifacts',
+    '## アーティファクト',
     '',
     '- `snapshot-diff-status.json`',
     '- `docs-update-summary.md`',
@@ -777,18 +880,18 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
   const structureMismatchByType = parity.summary?.structureMismatchByType ?? {};
 
   const parityIssueBody = [
-    '## Summary',
+    '## サマリー',
     '',
-    `- Checked at: ${parity.summary?.checkedAt ?? 'unknown'}`,
-    `- Active actionable files: ${activeActionableFiles}`,
-    `- Active issue files: ${parityIssueFiles.length}`,
-    `- Error files: ${activeErrorFiles}`,
-    `- Acknowledged (non-blocking): ${acknowledgedIssues}`,
+    `- チェック日時: ${parity.summary?.checkedAt ?? 'unknown'}`,
+    `- active actionable ファイル: ${activeActionableFiles}`,
+    `- active issue ファイル: ${parityIssueFiles.length}`,
+    `- エラーファイル: ${activeErrorFiles}`,
+    `- 承認済み (非ブロッキング): ${acknowledgedIssues}`,
     ...(expiredAcknowledgements > 0
-      ? [`- ⚠ Expired acknowledgements: ${expiredAcknowledgements}`]
+      ? [`- ⚠ 期限切れ承認: ${expiredAcknowledgements}`]
       : []),
     '',
-    '## Top Entries',
+    '## 上位エントリー',
     '',
     formatList(
       parityTopEntries.map((entry) => {
@@ -802,7 +905,7 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
       }),
     ),
     '',
-    '## Artifacts',
+    '## アーティファクト',
     '',
     '- `parity-check-status.json`',
     '- `docs-update-summary.md`',
@@ -822,23 +925,32 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
   const syncSummary = sourceSync.summary ?? {};
   const syncErrors = sourceSync.errors ?? [];
 
+  // Issue #255 — source-side debt counters and slug lists. These come from
+  // source-sync-status.json `summary.excluded*Pages` and `pages[]`.
+  const sourceSideDebtSummary = buildSourceSideDebtSummary(sourceSync);
+
   const sourceSyncBody = syncShouldOpen
     ? [
-        '## Summary',
+        '## サマリー',
         '',
-        `- Freshness state: **${freshnessState ?? 'unknown'}**`,
-        `- Linkage state: **${linkageState ?? 'unknown'}**`,
-        `- Target pages: ${syncSummary.targetPages ?? 0}`,
-        `- Fetched pages: ${syncSummary.fetchedPages ?? 0}`,
-        `- Not found pages: ${syncSummary.notFoundPages ?? 0}`,
-        `- Error pages: ${syncSummary.errorPages ?? 0}`,
-        `- Sidebar verified: ${syncSummary.sidebarVerified ?? false}`,
+        `- freshness state: **${freshnessState ?? 'unknown'}**`,
+        `- linkage state: **${linkageState ?? 'unknown'}**`,
+        `- 対象ページ: ${syncSummary.targetPages ?? 0}`,
+        `- 取得済みページ: ${syncSummary.fetchedPages ?? 0}`,
+        `- 404 ページ: ${syncSummary.notFoundPages ?? 0}`,
+        `- エラーページ: ${syncSummary.errorPages ?? 0}`,
+        `- サイドバー検証: ${syncSummary.sidebarVerified ?? false}`,
         '',
-        '## Errors',
+        '## エラー',
         '',
         formatList(syncErrors.map((e) => `\`${e.slug}\` — ${e.detail}`)),
         '',
-        '## Artifacts',
+        // Issue #255 — 日本語 debt サブセクション (issue body 内)。
+        // 件数 0 なら丸ごと省略する。
+        ...(sourceSideDebtSummary.excludedPages > 0
+          ? [...renderSourceSideDebtSubsection(sourceSideDebtSummary, sourceSync.pages ?? []), '']
+          : []),
+        '## アーティファクト',
         '',
         '- `source-sync-status.json`',
         '- `snapshot-diff-status.json`',
@@ -866,6 +978,10 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
         errorPages: syncSummary.errorPages ?? 0,
         sidebarVerified: syncSummary.sidebarVerified ?? false,
       },
+      // Issue #255 — source-side debt counter / slug list を independently
+      // expose する。JSON consumer (sync-detection-issues / dashboards /
+      // 人手レビュー) が freshness counter と混ぜずに読めるようにする。
+      sourceSideDebt: sourceSideDebtSummary,
     },
     snapshotDiff: {
       key: FAMILY_KEYS.SNAPSHOT_DIFF,
@@ -921,6 +1037,17 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
   const syncState = sourceSync?.freshnessState ?? actionableReport?.sourceSyncHealth?.freshnessState ?? 'unknown';
   const syncSummary = sourceSync?.summary ?? actionableReport?.sourceSyncHealth?.summary ?? {};
 
+  // Issue #255 — source-side debt を summary markdown に可視化する。
+  // actionableReport にすでに sourceSideDebt が計算されていればそれを優先、
+  // 無ければ sourceSync から組み立てる。
+  const sourceSideDebt =
+    actionableReport?.sourceSyncHealth?.sourceSideDebt ??
+    buildSourceSideDebtSummary(sourceSync);
+  const sourceSideDebtSection =
+    sourceSideDebt.excludedPages > 0
+      ? renderSourceSideDebtSubsection(sourceSideDebt, sourceSync?.pages ?? [])
+      : [];
+
   // Parity section は coarse audit signals を除外した reportableActive*
   // counters を表示する。降格された coarse heuristics は別枠の "Audit
   // Signals" section に出して active parity drift と混同させない。
@@ -946,7 +1073,7 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
       : ['  - (none)'];
 
   // Issue #247 PR5 — structure mismatch の独立 advisory section は削除した。
-  // reportable に昇格したため、件数は `## Parity` の `Active issue files`
+  // reportable に昇格したため、件数は `## パリティ` の `active issue files`
   // 経由で見える。source unusable は引き続き advisory なので独立 section
   // を持つ。
   const snapshotUnusableIssues = parity.summary?.snapshotUnusableIssues ?? 0;
@@ -955,13 +1082,13 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
   const sourceUnusableSection =
     snapshotUnusableIssues > 0
       ? [
-          '## Source Unusable (advisory)',
+          '## ソース使用不可 (advisory)',
           '',
-          `- Total: ${snapshotUnusableIssues} issues across ${snapshotUnusableFiles} files`,
-          '- Not a translation failure — snapshot / source sync 側 debt です。翻訳 PR では修正できません。',
+          `- 合計: ${snapshotUnusableIssues} 件 (${snapshotUnusableFiles} ファイル)`,
+          '- 翻訳失敗ではなく snapshot / source sync 側 debt です。翻訳 PR では修正できません。',
           ...(Object.keys(snapshotUnusableByType).length > 0
             ? [
-                '- By type:',
+                '- 種別別:',
                 ...Object.keys(snapshotUnusableByType)
                   .sort()
                   .map((type) => `  - ${type}: ${snapshotUnusableByType[type]}`),
@@ -972,59 +1099,60 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
       : [];
 
   return [
-    '# Docs Detection Summary',
+    '# ドキュメント検知サマリー',
     '',
-    `Generated: ${actionableReport.generatedAt}`,
+    `生成日時: ${actionableReport.generatedAt}`,
     '',
-    '## Source Sync Health',
+    '## ソース同期状態',
     '',
-    `- Freshness state: ${syncState}`,
-    `- Fetched: ${syncSummary.fetchedPages ?? 0} / ${syncSummary.targetPages ?? 0} pages`,
-    `- Errors: ${syncSummary.errorPages ?? 0}`,
-    `- Sidebar verified: ${syncSummary.sidebarVerified ?? false}`,
+    `- freshness state: ${syncState}`,
+    `- 取得: ${syncSummary.fetchedPages ?? 0} / ${syncSummary.targetPages ?? 0} ページ`,
+    `- エラー: ${syncSummary.errorPages ?? 0}`,
+    `- サイドバー検証: ${syncSummary.sidebarVerified ?? false}`,
     '',
-    '## Snapshot Diff',
+    ...sourceSideDebtSection,
+    '## スナップショット差分',
     '',
-    `- Changed pages: ${actionableReport.snapshotDiff.summary.changed}`,
-    `- Added pages: ${actionableReport.snapshotDiff.summary.added}`,
-    `- Removed pages: ${actionableReport.snapshotDiff.summary.removed}`,
-    `- Unchanged: ${actionableReport.snapshotDiff.summary.unchanged}`,
-    `- Total snapshots: ${actionableReport.snapshotDiff.summary.totalSnapshots}`,
+    `- 変更ページ: ${actionableReport.snapshotDiff.summary.changed}`,
+    `- 追加ページ: ${actionableReport.snapshotDiff.summary.added}`,
+    `- 削除ページ: ${actionableReport.snapshotDiff.summary.removed}`,
+    `- 変更なし: ${actionableReport.snapshotDiff.summary.unchanged}`,
+    `- 総スナップショット数: ${actionableReport.snapshotDiff.summary.totalSnapshots}`,
     '',
-    '## Parity',
+    '## パリティ',
     '',
-    `- Active actionable files: ${parityActiveActionable}`,
-    `- Active issue files: ${parityActiveFiles}`,
-    `- Error files: ${parity.summary?.activeErrorFiles ?? parity.summary?.errorFiles ?? 0}`,
-    `- Acknowledged (non-blocking): ${parity.summary?.acknowledgedIssues || 0}`,
+    `- active actionable ファイル: ${parityActiveActionable}`,
+    `- active issue ファイル: ${parityActiveFiles}`,
+    `- エラーファイル: ${parity.summary?.activeErrorFiles ?? parity.summary?.errorFiles ?? 0}`,
+    `- 承認済み (非ブロッキング): ${parity.summary?.acknowledgedIssues || 0}`,
     ...((parity.summary?.expiredAcknowledgements || 0) > 0
-      ? [`- ⚠ Expired acknowledgements: ${parity.summary.expiredAcknowledgements}`]
+      ? [`- ⚠ 期限切れ承認: ${parity.summary.expiredAcknowledgements}`]
       : []),
     '',
     ...sourceUnusableSection,
-    '## Audit Signals',
+    '## 監査シグナル',
     '',
-    '- audit-only: coarse counting / shape / table-cell heuristics',
-    '- Visible to deep-audit, NOT included in parity-regression issue body',
-    `- Total: ${auditSignalIssues} issues across ${auditSignalFiles} files`,
-    '- By type:',
+    '- audit 専用: 粗い count / 形状 / table cell ヒューリスティック',
+    '- deep-audit で確認可能。parity-regression issue body には含めない',
+    `- 合計: ${auditSignalIssues} 件 (${auditSignalFiles} ファイル)`,
+    '- 種別別:',
     ...auditSignalRows,
     '',
-    '## Audit Manifest',
+    '## 監査マニフェスト',
     '',
-    `- Total review entries: ${auditManifest.length}`,
-    `- Page lifecycle: ${actionableReport.auditManifest.bucketCounts['page-lifecycle'] || 0}`,
-    `- Structural change: ${actionableReport.auditManifest.bucketCounts['structural-change'] || 0}`,
-    `- Content only: ${actionableReport.auditManifest.bucketCounts['content-only'] || 0}`,
+    `- 総レビュー対象: ${auditManifest.length}`,
+    `- ページライフサイクル: ${actionableReport.auditManifest.bucketCounts['page-lifecycle'] || 0}`,
+    `- 構造変更: ${actionableReport.auditManifest.bucketCounts['structural-change'] || 0}`,
+    `- 本文のみ: ${actionableReport.auditManifest.bucketCounts['content-only'] || 0}`,
     '',
-    '## Parity Followup',
+    '## パリティフォローアップ',
     '',
-    `- Baselined: ${actionableReport.parityFollowup?.summary?.baselineDebt?.baselinedIssues ?? 0} issues (${actionableReport.parityFollowup?.summary?.baselineDebt?.baselinedFiles ?? 0} files)`,
-    `- Expired baseline entries: ${actionableReport.parityFollowup?.summary?.baselineDebt?.expiredBaselineEntries ?? 0}`,
-    `- Invalidated slugs: ${(actionableReport.parityFollowup?.summary?.baselineDebt?.baselineInvalidatedSlugs ?? []).length}`,
-    `- Advisory queue: ${actionableReport.parityFollowup?.summary?.advisoryQueue?.issues ?? 0} issues (${actionableReport.parityFollowup?.summary?.advisoryQueue?.files ?? 0} files, ${actionableReport.parityFollowup?.summary?.advisoryQueue?.blockingItems ?? 0} blocking; ${formatAdvisoryQueueScope(actionableReport.parityFollowup?.summary?.advisoryQueue?.advisoryQueueScope ?? null)})`,
+    `- baseline 済: ${actionableReport.parityFollowup?.summary?.baselineDebt?.baselinedIssues ?? 0} 件 (${actionableReport.parityFollowup?.summary?.baselineDebt?.baselinedFiles ?? 0} ファイル)`,
+    `- 期限切れ baseline: ${actionableReport.parityFollowup?.summary?.baselineDebt?.expiredBaselineEntries ?? 0}`,
+    `- 無効化された slug: ${(actionableReport.parityFollowup?.summary?.baselineDebt?.baselineInvalidatedSlugs ?? []).length}`,
+    `- advisory キュー: ${actionableReport.parityFollowup?.summary?.advisoryQueue?.issues ?? 0} 件 (${actionableReport.parityFollowup?.summary?.advisoryQueue?.files ?? 0} ファイル, ${actionableReport.parityFollowup?.summary?.advisoryQueue?.blockingItems ?? 0} ブロッキング; ${formatAdvisoryQueueScope(actionableReport.parityFollowup?.summary?.advisoryQueue?.advisoryQueueScope ?? null)})`,
     '',
-    '## Files',
+    '## アーティファクト',
     '',
     '- `snapshot-diff-status.json`',
     '- `parity-check-status.json`',

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -920,20 +920,23 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
   // legacy / no-linkage case and is intentionally NOT escalated.
   const linkageBlocking =
     linkageState !== null && linkageState !== 'linked' && linkageState !== 'missing';
-  const syncShouldOpen =
-    freshnessState === 'broken' || freshnessState === 'partial' || linkageBlocking;
   const syncSummary = sourceSync.summary ?? {};
   const syncErrors = sourceSync.errors ?? [];
 
   // Issue #255 — source-side debt counters and slug lists. These come from
   // source-sync-status.json `summary.excluded*Pages` and `pages[]`.
+  // Must be computed before syncShouldOpen because debt triggers issue open.
   const sourceSideDebtSummary = buildSourceSideDebtSummary(sourceSync);
+  const hasSourceSideDebt = sourceSideDebtSummary.excludedPages > 0;
+  const syncShouldOpen =
+    freshnessState === 'broken' || freshnessState === 'partial' || linkageBlocking ||
+    hasSourceSideDebt;
 
   const sourceSyncBody = syncShouldOpen
     ? [
         '## サマリー',
         '',
-        `- freshness state: **${freshnessState ?? 'unknown'}**`,
+        `- 鮮度状態: **${freshnessState ?? 'unknown'}**`,
         `- linkage state: **${linkageState ?? 'unknown'}**`,
         `- 対象ページ: ${syncSummary.targetPages ?? 0}`,
         `- 取得済みページ: ${syncSummary.fetchedPages ?? 0}`,
@@ -1105,7 +1108,7 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
     '',
     '## ソース同期状態',
     '',
-    `- freshness state: ${syncState}`,
+    `- 鮮度状態: ${syncState}`,
     `- 取得: ${syncSummary.fetchedPages ?? 0} / ${syncSummary.targetPages ?? 0} ページ`,
     `- エラー: ${syncSummary.errorPages ?? 0}`,
     `- サイドバー検証: ${syncSummary.sidebarVerified ?? false}`,

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -178,22 +178,18 @@ export function validateSourceSyncStatus(parsed) {
   // recoveryProbe が object|null であることを要求する。
   const VALID_DEBT_FETCH_STATUSES = new Set(['excluded-broken', 'excluded-recovered']);
   for (const page of parsed.pages) {
-    if (page.debtCategory) {
+    const isExcludedDebt = VALID_DEBT_FETCH_STATUSES.has(page.fetchStatus);
+
+    if (isExcludedDebt) {
       if (page.debtCategory !== 'source-side-debt') {
         throw new Error(
-          `source-sync-status.json: debt page "${page.slug}" debtCategory must be "source-side-debt", ` +
-          `got ${JSON.stringify(page.debtCategory)}`,
-        );
-      }
-      if (!VALID_DEBT_FETCH_STATUSES.has(page.fetchStatus)) {
-        throw new Error(
-          `source-sync-status.json: debt page "${page.slug}" has invalid fetchStatus ` +
-          `"${page.fetchStatus}" (expected excluded-broken|excluded-recovered)`,
+          `source-sync-status.json: excluded page "${page.slug}" must have debtCategory ` +
+          `"source-side-debt", got ${JSON.stringify(page.debtCategory)}`,
         );
       }
       if (!('recoveryProbe' in page)) {
         throw new Error(
-          `source-sync-status.json: debt page "${page.slug}" must have recoveryProbe ` +
+          `source-sync-status.json: excluded page "${page.slug}" must have recoveryProbe ` +
           `(object for excluded-broken, null for excluded-recovered)`,
         );
       }
@@ -201,32 +197,43 @@ export function validateSourceSyncStatus(parsed) {
       if (page.fetchStatus === 'excluded-broken') {
         if (probe === null || typeof probe !== 'object' || Array.isArray(probe)) {
           throw new Error(
-            `source-sync-status.json: debt page "${page.slug}" recoveryProbe must be an object for excluded-broken`,
+            `source-sync-status.json: excluded page "${page.slug}" recoveryProbe must be an object for excluded-broken`,
           );
         }
         if (typeof probe.issueType !== 'string') {
           throw new Error(
-            `source-sync-status.json: debt page "${page.slug}" recoveryProbe.issueType must be a string`,
+            `source-sync-status.json: excluded page "${page.slug}" recoveryProbe.issueType must be a string`,
           );
         }
         if (typeof probe.reason !== 'string') {
           throw new Error(
-            `source-sync-status.json: debt page "${page.slug}" recoveryProbe.reason must be a string`,
+            `source-sync-status.json: excluded page "${page.slug}" recoveryProbe.reason must be a string`,
           );
         }
         if (typeof probe.expectedMatch !== 'boolean') {
           throw new Error(
-            `source-sync-status.json: debt page "${page.slug}" recoveryProbe.expectedMatch must be a boolean`,
+            `source-sync-status.json: excluded page "${page.slug}" recoveryProbe.expectedMatch must be a boolean`,
           );
         }
       }
-      if (page.fetchStatus === 'excluded-recovered') {
-        if (probe !== null) {
-          throw new Error(
-            `source-sync-status.json: debt page "${page.slug}" recoveryProbe must be null for excluded-recovered`,
-          );
-        }
+      if (page.fetchStatus === 'excluded-recovered' && probe !== null) {
+        throw new Error(
+          `source-sync-status.json: excluded page "${page.slug}" recoveryProbe must be null for excluded-recovered`,
+        );
       }
+      continue;
+    }
+
+    // Non-excluded pages must not carry debt fields.
+    if ('debtCategory' in page && page.debtCategory != null) {
+      throw new Error(
+        `source-sync-status.json: non-excluded page "${page.slug}" must not have debtCategory`,
+      );
+    }
+    if ('recoveryProbe' in page) {
+      throw new Error(
+        `source-sync-status.json: non-excluded page "${page.slug}" must not have recoveryProbe`,
+      );
     }
   }
   if (!Array.isArray(parsed.errors)) {

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -15,13 +15,13 @@ import {
 export const ACTIONABLE_REPORT_SCHEMA_VERSION = 1;
 
 const SNAPSHOT_ISSUE_TITLE =
-  '📸 Content Drift: English source changes detected via snapshot diff';
+  '📸 コンテンツ差分: スナップショットで英語原文の変更を検知';
 const PARITY_ISSUE_TITLE =
-  '🔍 Parity Regression: content drift detected';
+  '🔍 パリティ後退: コンテンツの差分を検知';
 const SOURCE_SYNC_ISSUE_TITLE =
-  '⚠️ Source Sync Health: fetch degradation detected';
+  '⚠️ ソース同期: 取得の劣化またはソース原文の既知問題を検知';
 const PARITY_FOLLOWUP_ISSUE_TITLE =
-  '🗂️ Parity Followup: baseline debt and advisory queue';
+  '🗂️ パリティフォローアップ: baseline 負債と advisory キュー';
 const DOCS_PREFIX = path.join('src', 'content', 'docs') + path.sep;
 
 /**
@@ -342,7 +342,7 @@ function buildSourceSideDebtSummary(sourceSync) {
 }
 
 /**
- * Issue #255 — Render the `## ソース側 debt` section as Markdown lines.
+ * Issue #255 — Render the `## ソース原文の既知問題` section as Markdown lines.
  * Returns an array of strings ready to be joined with '\n'. The caller
  * is responsible for deciding when the section should appear at all
  * (usually: skip when `excludedPages === 0`).
@@ -357,7 +357,7 @@ function buildSourceSideDebtSummary(sourceSync) {
  */
 function renderSourceSideDebtSubsection(debt, _pages) {
   const lines = [
-    '## ソース側 debt',
+    '## ソース原文の既知問題',
     '',
     `- 除外ページ: ${debt.excludedPages}`,
     `- 未復旧: ${debt.excludedBrokenPages}`,

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -120,9 +120,10 @@ export function validateParityCheckStatus(parsed) {
 
 export function validateSourceSyncStatus(parsed) {
   expectObject(parsed, 'source-sync-status.json');
-  if (parsed.schemaVersion !== 1) {
+  const version = parsed.schemaVersion;
+  if (version !== 1 && version !== 2) {
     throw new Error(
-      `source-sync-status.json: unsupported schemaVersion ${JSON.stringify(parsed.schemaVersion)} (expected 1)`,
+      `source-sync-status.json: unsupported schemaVersion ${JSON.stringify(version)} (expected 1 or 2)`,
     );
   }
   if (typeof parsed.runId !== 'string') {
@@ -160,15 +161,17 @@ export function validateSourceSyncStatus(parsed) {
     throw new Error('source-sync-status.json: summary.sidebarVerified must be boolean');
   }
   // Issue #255 — excluded counter の strict validation。
-  // buildSourceSyncStatus は常にこれらを emit するので、欠損は artifact 破損。
-  if (typeof parsed.summary.excludedPages !== 'number') {
-    throw new Error('source-sync-status.json: summary.excludedPages must be a number');
-  }
-  if (typeof parsed.summary.excludedBrokenPages !== 'number') {
-    throw new Error('source-sync-status.json: summary.excludedBrokenPages must be a number');
-  }
-  if (typeof parsed.summary.excludedRecoveredPages !== 'number') {
-    throw new Error('source-sync-status.json: summary.excludedRecoveredPages must be a number');
+  // v2 では必須。v1 (pre-#255) では欠損を許容し 0 扱い。
+  if (version >= 2) {
+    if (typeof parsed.summary.excludedPages !== 'number') {
+      throw new Error('source-sync-status.json: summary.excludedPages must be a number');
+    }
+    if (typeof parsed.summary.excludedBrokenPages !== 'number') {
+      throw new Error('source-sync-status.json: summary.excludedBrokenPages must be a number');
+    }
+    if (typeof parsed.summary.excludedRecoveredPages !== 'number') {
+      throw new Error('source-sync-status.json: summary.excludedRecoveredPages must be a number');
+    }
   }
   if (!Array.isArray(parsed.pages)) {
     throw new Error('source-sync-status.json: pages must be an array');
@@ -176,8 +179,10 @@ export function validateSourceSyncStatus(parsed) {
   // Issue #255 — debt page の shape validation。debtCategory を持つ page は
   // fetchStatus が excluded-broken|excluded-recovered のいずれかで、
   // recoveryProbe が object|null であることを要求する。
+  // Debt page shape validation is v2+ only. v1 artifacts have no
+  // excluded-* pages and no debt fields.
   const VALID_DEBT_FETCH_STATUSES = new Set(['excluded-broken', 'excluded-recovered']);
-  for (const page of parsed.pages) {
+  if (version >= 2) for (const page of parsed.pages) {
     const isExcludedDebt = VALID_DEBT_FETCH_STATUSES.has(page.fetchStatus);
 
     if (isExcludedDebt) {

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -181,7 +181,7 @@ export function validateSourceSyncStatus(parsed) {
   // recoveryProbe が object|null であることを要求する。
   // Debt page shape validation is v2+ only. v1 artifacts have no
   // excluded-* pages and no debt fields.
-  const VALID_DEBT_FETCH_STATUSES = new Set(['excluded-broken', 'excluded-recovered']);
+  const VALID_DEBT_FETCH_STATUSES = new Set(['excluded-broken', 'excluded-recovered', 'excluded-fetch-error']);
   if (version >= 2) for (const page of parsed.pages) {
     const isExcludedDebt = VALID_DEBT_FETCH_STATUSES.has(page.fetchStatus);
 
@@ -235,6 +235,18 @@ export function validateSourceSyncStatus(parsed) {
         throw new Error(
           `source-sync-status.json: excluded page "${page.slug}" recoveryProbe must be null for excluded-recovered`,
         );
+      }
+      if (page.fetchStatus === 'excluded-fetch-error') {
+        if (probe !== null) {
+          throw new Error(
+            `source-sync-status.json: excluded page "${page.slug}" recoveryProbe must be null for excluded-fetch-error`,
+          );
+        }
+        if (typeof page.errorDetail !== 'string') {
+          throw new Error(
+            `source-sync-status.json: excluded page "${page.slug}" must have errorDetail string for excluded-fetch-error`,
+          );
+        }
       }
       continue;
     }
@@ -346,11 +358,17 @@ function buildSourceSideDebtSummary(sourceSync) {
 
   const brokenPages = pages.filter((p) => p.fetchStatus === 'excluded-broken');
   const recoveredPages = pages.filter((p) => p.fetchStatus === 'excluded-recovered');
+  const fetchErrorPages = pages.filter((p) => p.fetchStatus === 'excluded-fetch-error');
 
   return {
     excludedPages: summary.excludedPages ?? 0,
     excludedBrokenPages: summary.excludedBrokenPages ?? 0,
     excludedRecoveredPages: summary.excludedRecoveredPages ?? 0,
+    fetchErrorSlugs: fetchErrorPages.map((p) => p.slug).sort(),
+    fetchErrorDetails: fetchErrorPages.map((p) => ({
+      slug: p.slug,
+      errorDetail: p.errorDetail ?? 'unknown',
+    })).sort((a, b) => a.slug.localeCompare(b.slug)),
     brokenSlugs: brokenPages.map((p) => p.slug).sort(),
     recoveredSlugs: recoveredPages.map((p) => p.slug).sort(),
     brokenDetails: brokenPages
@@ -416,6 +434,20 @@ function renderSourceSideDebtSubsection(debt, _pages) {
       lines.push(`  - 実際: ${actual}`);
       lines.push(`  - 期待: ${expected}`);
       lines.push(`  - 期待一致: ${matchLabel}`);
+    }
+    lines.push('');
+  }
+
+  if (debt.fetchErrorSlugs && debt.fetchErrorSlugs.length > 0) {
+    lines.push('### 観測失敗', '');
+    lines.push(
+      'fetch に失敗したため live EN の状態を観測できませんでした。',
+      'source-sync の劣化として errors に計上されています。',
+      '',
+    );
+    for (const entry of debt.fetchErrorDetails) {
+      lines.push(`- \`${entry.slug}\``);
+      lines.push(`  - エラー: ${entry.errorDetail}`);
     }
     lines.push('');
   }
@@ -1038,7 +1070,8 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
   // source-sync-status.json `summary.excluded*Pages` and `pages[]`.
   // Must be computed before syncShouldOpen because debt triggers issue open.
   const sourceSideDebtSummary = buildSourceSideDebtSummary(sourceSync);
-  const hasSourceSideDebt = sourceSideDebtSummary.excludedPages > 0;
+  const hasSourceSideDebt = sourceSideDebtSummary.excludedPages > 0 ||
+    (sourceSideDebtSummary.fetchErrorSlugs?.length ?? 0) > 0;
   const syncShouldOpen =
     freshnessState === 'broken' || freshnessState === 'partial' || linkageBlocking ||
     hasSourceSideDebt;
@@ -1061,7 +1094,7 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
         '',
         // Issue #255 — 日本語 debt サブセクション (issue body 内)。
         // 件数 0 なら丸ごと省略する。
-        ...(sourceSideDebtSummary.excludedPages > 0
+        ...(hasSourceSideDebt
           ? [...renderSourceSideDebtSubsection(sourceSideDebtSummary, sourceSync.pages ?? []), '']
           : []),
         '## アーティファクト',
@@ -1158,7 +1191,7 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
     actionableReport?.sourceSyncHealth?.sourceSideDebt ??
     buildSourceSideDebtSummary(sourceSync);
   const sourceSideDebtSection =
-    sourceSideDebt.excludedPages > 0
+    sourceSideDebt.excludedPages > 0 || (sourceSideDebt.fetchErrorSlugs?.length ?? 0) > 0
       ? renderSourceSideDebtSubsection(sourceSideDebt, sourceSync?.pages ?? [])
       : [];
 

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -263,6 +263,31 @@ export function validateSourceSyncStatus(parsed) {
       );
     }
   }
+  if (version >= 2) {
+    const excludedBrokenPages = parsed.pages.filter((p) => p.fetchStatus === 'excluded-broken').length;
+    const excludedRecoveredPages = parsed.pages.filter(
+      (p) => p.fetchStatus === 'excluded-recovered',
+    ).length;
+    const excludedPages = excludedBrokenPages + excludedRecoveredPages;
+    if (parsed.summary.excludedPages !== excludedPages) {
+      throw new Error(
+        `source-sync-status.json: summary.excludedPages must equal pages[] excluded count ` +
+        `(${excludedPages}), got ${parsed.summary.excludedPages}`,
+      );
+    }
+    if (parsed.summary.excludedBrokenPages !== excludedBrokenPages) {
+      throw new Error(
+        `source-sync-status.json: summary.excludedBrokenPages must equal pages[] excluded-broken count ` +
+        `(${excludedBrokenPages}), got ${parsed.summary.excludedBrokenPages}`,
+      );
+    }
+    if (parsed.summary.excludedRecoveredPages !== excludedRecoveredPages) {
+      throw new Error(
+        `source-sync-status.json: summary.excludedRecoveredPages must equal pages[] excluded-recovered count ` +
+        `(${excludedRecoveredPages}), got ${parsed.summary.excludedRecoveredPages}`,
+      );
+    }
+  }
   if (!Array.isArray(parsed.errors)) {
     throw new Error('source-sync-status.json: errors must be an array');
   }
@@ -326,6 +351,15 @@ function formatList(values) {
   return values.map((value) => `- ${value}`).join('\n');
 }
 
+function partitionSourceSideDebtPages(pages) {
+  const safePages = Array.isArray(pages) ? pages : [];
+  return {
+    brokenPages: safePages.filter((p) => p.fetchStatus === 'excluded-broken'),
+    recoveredPages: safePages.filter((p) => p.fetchStatus === 'excluded-recovered'),
+    fetchErrorPages: safePages.filter((p) => p.fetchStatus === 'excluded-fetch-error'),
+  };
+}
+
 /**
  * Issue #255 — Build a structured summary of source-side debt from
  * `source-sync-status.json`. Returns counters plus broken / recovered
@@ -353,17 +387,13 @@ function formatList(values) {
  * }}
  */
 function buildSourceSideDebtSummary(sourceSync) {
-  const summary = sourceSync?.summary ?? {};
   const pages = sourceSync?.pages ?? [];
-
-  const brokenPages = pages.filter((p) => p.fetchStatus === 'excluded-broken');
-  const recoveredPages = pages.filter((p) => p.fetchStatus === 'excluded-recovered');
-  const fetchErrorPages = pages.filter((p) => p.fetchStatus === 'excluded-fetch-error');
+  const { brokenPages, recoveredPages, fetchErrorPages } = partitionSourceSideDebtPages(pages);
 
   return {
-    excludedPages: summary.excludedPages ?? 0,
-    excludedBrokenPages: summary.excludedBrokenPages ?? 0,
-    excludedRecoveredPages: summary.excludedRecoveredPages ?? 0,
+    excludedPages: brokenPages.length + recoveredPages.length,
+    excludedBrokenPages: brokenPages.length,
+    excludedRecoveredPages: recoveredPages.length,
     fetchErrorSlugs: fetchErrorPages.map((p) => p.slug).sort(),
     fetchErrorDetails: fetchErrorPages.map((p) => ({
       slug: p.slug,

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -210,6 +210,16 @@ export function validateSourceSyncStatus(parsed) {
             `source-sync-status.json: excluded page "${page.slug}" recoveryProbe.reason must be a string`,
           );
         }
+        if (typeof probe.expectedIssueType !== 'string') {
+          throw new Error(
+            `source-sync-status.json: excluded page "${page.slug}" recoveryProbe.expectedIssueType must be a string`,
+          );
+        }
+        if (typeof probe.expectedReason !== 'string') {
+          throw new Error(
+            `source-sync-status.json: excluded page "${page.slug}" recoveryProbe.expectedReason must be a string`,
+          );
+        }
         if (typeof probe.expectedMatch !== 'boolean') {
           throw new Error(
             `source-sync-status.json: excluded page "${page.slug}" recoveryProbe.expectedMatch must be a boolean`,
@@ -315,7 +325,14 @@ function formatList(values) {
  *   excludedRecoveredPages: number,
  *   brokenSlugs: string[],
  *   recoveredSlugs: string[],
- *   brokenDetails: { slug: string, issueType: string|null, reason: string|null }[],
+ *   brokenDetails: {
+ *     slug: string,
+ *     actualIssueType: string|null,
+ *     actualReason: string|null,
+ *     expectedIssueType: string|null,
+ *     expectedReason: string|null,
+ *     expectedMatch: boolean|null,
+ *   }[],
  * }}
  */
 function buildSourceSideDebtSummary(sourceSync) {
@@ -332,11 +349,17 @@ function buildSourceSideDebtSummary(sourceSync) {
     brokenSlugs: brokenPages.map((p) => p.slug).sort(),
     recoveredSlugs: recoveredPages.map((p) => p.slug).sort(),
     brokenDetails: brokenPages
-      .map((p) => ({
-        slug: p.slug,
-        issueType: p.recoveryProbe?.issueType ?? null,
-        reason: p.recoveryProbe?.reason ?? null,
-      }))
+      .map((p) => {
+        const probe = p.recoveryProbe;
+        return {
+          slug: p.slug,
+          actualIssueType: probe?.issueType ?? null,
+          actualReason: probe?.reason ?? null,
+          expectedIssueType: probe?.expectedIssueType ?? null,
+          expectedReason: probe?.expectedReason ?? null,
+          expectedMatch: probe?.expectedMatch ?? null,
+        };
+      })
       .sort((left, right) => left.slug.localeCompare(right.slug)),
   };
 }
@@ -373,12 +396,21 @@ function renderSourceSideDebtSubsection(debt, _pages) {
   if (debt.excludedBrokenPages > 0) {
     lines.push('### 未復旧', '');
     for (const entry of debt.brokenDetails) {
-      const detail = entry.issueType && entry.reason
-        ? `${entry.issueType} / ${entry.reason}`
-        : entry.issueType || entry.reason || '判定なし';
+      const actual = entry.actualIssueType && entry.actualReason
+        ? `${entry.actualIssueType} / ${entry.actualReason}`
+        : entry.actualIssueType || entry.actualReason || '判定なし';
+      const expected = entry.expectedIssueType && entry.expectedReason
+        ? `${entry.expectedIssueType} / ${entry.expectedReason}`
+        : '不明';
+      const matchLabel = entry.expectedMatch === true
+        ? '想定どおり'
+        : entry.expectedMatch === false
+          ? '想定と不一致'
+          : '不明';
       lines.push(`- \`${entry.slug}\``);
-      lines.push(`  - 状態: excluded-broken`);
-      lines.push(`  - 判定: ${detail}`);
+      lines.push(`  - 実際: ${actual}`);
+      lines.push(`  - 期待: ${expected}`);
+      lines.push(`  - 期待一致: ${matchLabel}`);
     }
     lines.push('');
   }

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -179,6 +179,12 @@ export function validateSourceSyncStatus(parsed) {
   const VALID_DEBT_FETCH_STATUSES = new Set(['excluded-broken', 'excluded-recovered']);
   for (const page of parsed.pages) {
     if (page.debtCategory) {
+      if (page.debtCategory !== 'source-side-debt') {
+        throw new Error(
+          `source-sync-status.json: debt page "${page.slug}" debtCategory must be "source-side-debt", ` +
+          `got ${JSON.stringify(page.debtCategory)}`,
+        );
+      }
       if (!VALID_DEBT_FETCH_STATUSES.has(page.fetchStatus)) {
         throw new Error(
           `source-sync-status.json: debt page "${page.slug}" has invalid fetchStatus ` +
@@ -192,11 +198,10 @@ export function validateSourceSyncStatus(parsed) {
         );
       }
       const probe = page.recoveryProbe;
-      if (probe !== null) {
-        if (typeof probe !== 'object' || Array.isArray(probe)) {
+      if (page.fetchStatus === 'excluded-broken') {
+        if (probe === null || typeof probe !== 'object' || Array.isArray(probe)) {
           throw new Error(
-            `source-sync-status.json: debt page "${page.slug}" recoveryProbe must be object|null, ` +
-            `got ${probe === null ? 'null' : typeof probe}`,
+            `source-sync-status.json: debt page "${page.slug}" recoveryProbe must be an object for excluded-broken`,
           );
         }
         if (typeof probe.issueType !== 'string') {
@@ -207,6 +212,18 @@ export function validateSourceSyncStatus(parsed) {
         if (typeof probe.reason !== 'string') {
           throw new Error(
             `source-sync-status.json: debt page "${page.slug}" recoveryProbe.reason must be a string`,
+          );
+        }
+        if (typeof probe.expectedMatch !== 'boolean') {
+          throw new Error(
+            `source-sync-status.json: debt page "${page.slug}" recoveryProbe.expectedMatch must be a boolean`,
+          );
+        }
+      }
+      if (page.fetchStatus === 'excluded-recovered') {
+        if (probe !== null) {
+          throw new Error(
+            `source-sync-status.json: debt page "${page.slug}" recoveryProbe must be null for excluded-recovered`,
           );
         }
       }

--- a/scripts/lib/source_sync_exclusions.mjs
+++ b/scripts/lib/source_sync_exclusions.mjs
@@ -1,0 +1,108 @@
+/**
+ * Source-Side Debt Exclusion Registry (Issue #255)。
+ *
+ * EN upstream 側が broken で parity comparator の前提を満たさない page を
+ * 明示的に管理する registry。自動除外は一切しない — 人間が upstream broken と
+ * 確認した slug だけ registry に追加する (false-negative 回避)。
+ *
+ * registry に登録されたページは:
+ *   - snapshot_update は fetch するが snapshot file を上書きしない
+ *   - fetch 結果に対して `detectSourceUsability` で recovery probe を実行する
+ *   - `source-sync-status.json` で `fetchStatus: 'excluded-broken'` /
+ *     `'excluded-recovered'` として可視化される
+ *   - freshness 計算からは除外される (= debt だけ残っても fresh のまま)
+ *
+ * 復旧候補 (`excluded-recovered`) になっても自動で registry から削除しない。
+ * 人間が確認して registry entry を削除するのが運用。
+ *
+ * 新規 entry 追加の手順:
+ *   1. upstream が broken であることを人間が目視確認する
+ *   2. `SOURCE_SYNC_EXCLUSIONS` に entry を追加する
+ *   3. `expectedIssueType` / `expectedReason` は detectSourceUsability の
+ *      出力と合致させる (recovery probe が出す issue と mismatch したとき
+ *      "excluded-recovered" に落ちるように)
+ *
+ * @module source_sync_exclusions
+ */
+
+/**
+ * Registry of known source-side debt pages.
+ *
+ * Shape:
+ *   slug → {
+ *     reason: 'broken-upstream-source',   // fixed token for downstream match
+ *     note: string,                        // human description of symptom
+ *     expectedIssueType: string,           // detectSourceUsability().type
+ *     expectedReason: string,              // detectSourceUsability().usabilitySignals.reason
+ *     addedAt: 'YYYY-MM-DD',
+ *     linkedIssue: number,                 // upstream / parent issue number
+ *   }
+ *
+ * @type {Readonly<Record<string, Readonly<{
+ *   reason: string,
+ *   note: string,
+ *   expectedIssueType: string,
+ *   expectedReason: string,
+ *   addedAt: string,
+ *   linkedIssue: number,
+ * }>>>}
+ */
+export const SOURCE_SYNC_EXCLUSIONS = Object.freeze({
+  'testops/testops-version-control/pull-requests': Object.freeze({
+    reason: 'broken-upstream-source',
+    note:
+      'EN live HTML collapses the full article body into a single <code> block ' +
+      'inside <div class="codeSnippet">. The MadCap Flare extractor produces 0 ' +
+      'body segments, so the parity comparator cannot align sections. Issue #247 ' +
+      'originally fixed this by writing a hand-authored snapshot, but every snapshot ' +
+      'fetch reverts that fix. Registered here so snapshot_update stops overwriting ' +
+      'the frozen reference file.',
+    expectedIssueType: 'snapshot-incomplete',
+    expectedReason: 'extractor-empty',
+    addedAt: '2026-04-09',
+    linkedIssue: 247,
+  }),
+});
+
+/**
+ * Return true if the slug is registered as source-side debt.
+ *
+ * @param {string | null | undefined} slug
+ * @returns {boolean}
+ */
+export function isSourceSideDebt(slug) {
+  if (typeof slug !== 'string' || slug.length === 0) return false;
+  return Object.prototype.hasOwnProperty.call(SOURCE_SYNC_EXCLUSIONS, slug);
+}
+
+/**
+ * Return a shallow copy of the registry entry for a slug, or null if the
+ * slug is not registered. The returned object is a fresh copy — mutating
+ * it does not affect the registry.
+ *
+ * @param {string | null | undefined} slug
+ * @returns {{
+ *   reason: string,
+ *   note: string,
+ *   expectedIssueType: string,
+ *   expectedReason: string,
+ *   addedAt: string,
+ *   linkedIssue: number,
+ * } | null}
+ */
+export function getExclusion(slug) {
+  if (typeof slug !== 'string' || slug.length === 0) return null;
+  const entry = SOURCE_SYNC_EXCLUSIONS[slug];
+  if (!entry) return null;
+  return { ...entry };
+}
+
+/**
+ * Return all registered source-side debt slugs as a fresh sorted array.
+ * Callers can mutate the returned array without affecting the registry.
+ *
+ * @returns {string[]}
+ */
+export function listSourceSideDebtSlugs() {
+  return Object.keys(SOURCE_SYNC_EXCLUSIONS).sort();
+}

--- a/scripts/lib/source_sync_exclusions.mjs
+++ b/scripts/lib/source_sync_exclusions.mjs
@@ -19,8 +19,10 @@
  *   1. upstream が broken であることを人間が目視確認する
  *   2. `SOURCE_SYNC_EXCLUSIONS` に entry を追加する
  *   3. `expectedIssueType` / `expectedReason` は EN-only recovery probe の
- *      判定に使用される。現在 `extractor-empty` のみ自動 recovery 判定に
- *      対応し、他の reason は fail-close で excluded-broken に倒す
+ *      判定に使用される。detector が理解する reason
+ *      (`extractor-empty` / `shallow-snapshot` / `escaped-details-residue`)
+ *      のみ recovery 判定対象で、それ以外や extractor 例外は fail-close
+ *      で `excluded-broken` に倒す
  *
  * @module source_sync_exclusions
  */

--- a/scripts/lib/source_sync_exclusions.mjs
+++ b/scripts/lib/source_sync_exclusions.mjs
@@ -7,7 +7,7 @@
  *
  * registry に登録されたページは:
  *   - snapshot_update は fetch するが snapshot file を上書きしない
- *   - fetch 結果に対して `detectSourceUsability` で recovery probe を実行する
+ *   - fetch 結果に対して EN-only recovery probe を実行する
  *   - `source-sync-status.json` で `fetchStatus: 'excluded-broken'` /
  *     `'excluded-recovered'` として可視化される
  *   - freshness 計算からは除外される (= debt だけ残っても fresh のまま)
@@ -18,9 +18,9 @@
  * 新規 entry 追加の手順:
  *   1. upstream が broken であることを人間が目視確認する
  *   2. `SOURCE_SYNC_EXCLUSIONS` に entry を追加する
- *   3. `expectedIssueType` / `expectedReason` は detectSourceUsability の
- *      出力と合致させる (recovery probe が出す issue と mismatch したとき
- *      "excluded-recovered" に落ちるように)
+ *   3. `expectedIssueType` / `expectedReason` は EN-only recovery probe の
+ *      判定に使用される。現在 `extractor-empty` のみ自動 recovery 判定に
+ *      対応し、他の reason は fail-close で excluded-broken に倒す
  *
  * @module source_sync_exclusions
  */
@@ -32,8 +32,8 @@
  *   slug → {
  *     reason: 'broken-upstream-source',   // fixed token for downstream match
  *     note: string,                        // human description of symptom
- *     expectedIssueType: string,           // detectSourceUsability().type
- *     expectedReason: string,              // detectSourceUsability().usabilitySignals.reason
+ *     expectedIssueType: string,           // recovery probe の issueType
+ *     expectedReason: string,              // recovery probe の reason
  *     addedAt: 'YYYY-MM-DD',
  *     linkedIssue: number,                 // upstream / parent issue number
  *   }

--- a/scripts/lib/source_sync_health.mjs
+++ b/scripts/lib/source_sync_health.mjs
@@ -186,7 +186,7 @@ export function validateRunLinkage(sourceSync, snapshotDiff, parityRunScope) {
  *   fetchStatus: string,
  *   errorDetail?: string,
  *   snapshotFingerprint?: string,
- *   recoveryProbe?: { issueType: string, reason: string } | null,
+ *   recoveryProbe?: { issueType: string, reason: string, expectedMatch: boolean } | null,
  *   debtCategory?: 'source-side-debt' | null,
  * }[]} opts.pages
  * @param {{ ok: boolean, sectionCount?: number, pageCount?: number, reason?: string, sidebarSlugs?: string[] }} opts.sidebarResult

--- a/scripts/lib/source_sync_health.mjs
+++ b/scripts/lib/source_sync_health.mjs
@@ -186,7 +186,7 @@ export function validateRunLinkage(sourceSync, snapshotDiff, parityRunScope) {
  *   fetchStatus: string,
  *   errorDetail?: string,
  *   snapshotFingerprint?: string,
- *   recoveryProbe?: { issueType: string, reason: string, expectedMatch: boolean } | null,
+ *   recoveryProbe?: { issueType: string, reason: string, expectedIssueType: string, expectedReason: string, expectedMatch: boolean } | null,
  *   debtCategory?: 'source-side-debt' | null,
  * }[]} opts.pages
  * @param {{ ok: boolean, sectionCount?: number, pageCount?: number, reason?: string, sidebarSlugs?: string[] }} opts.sidebarResult

--- a/scripts/lib/source_sync_health.mjs
+++ b/scripts/lib/source_sync_health.mjs
@@ -213,7 +213,7 @@ export function buildSourceSyncStatus({ pages, sidebarResult, runScope, now, run
   // below and are NOT counted as ok / not-found / error.
   const okCount = pages.filter((p) => p.fetchStatus === 'ok').length;
   const notFoundCount = pages.filter((p) => p.fetchStatus === 'not-found').length;
-  const errorCount = pages.filter((p) => p.fetchStatus === 'error').length;
+  const errorCount = pages.filter((p) => p.fetchStatus === 'error' || p.fetchStatus === 'excluded-fetch-error').length;
   const excludedBrokenCount = pages.filter((p) => p.fetchStatus === 'excluded-broken').length;
   const excludedRecoveredCount = pages.filter(
     (p) => p.fetchStatus === 'excluded-recovered',
@@ -224,10 +224,10 @@ export function buildSourceSyncStatus({ pages, sidebarResult, runScope, now, run
 
   const errors = [];
   for (const p of pages) {
-    // Excluded pages are "known debt" — never emitted as top-level errors
-    // even if the underlying fetch surfaced a failure. Their state is
-    // visible via the excludedPages counters and the recoveryProbe field.
-    if (p.fetchStatus === 'error' && p.errorDetail) {
+    // Excluded pages with successful fetch are "known debt" — not errors.
+    // But excluded-fetch-error pages ARE errors — we couldn't observe the
+    // live EN page, which is a source-sync degradation.
+    if ((p.fetchStatus === 'error' || p.fetchStatus === 'excluded-fetch-error') && p.errorDetail) {
       errors.push({ slug: p.slug, detail: p.errorDetail });
     }
   }
@@ -269,6 +269,7 @@ export function buildSourceSyncStatus({ pages, sidebarResult, runScope, now, run
       ...(p.debtCategory
         ? { recoveryProbe: p.recoveryProbe ?? null }
         : {}),
+      ...(p.errorDetail ? { errorDetail: p.errorDetail } : {}),
     })),
     errors,
   };

--- a/scripts/lib/source_sync_health.mjs
+++ b/scripts/lib/source_sync_health.mjs
@@ -53,11 +53,31 @@ export function fingerprint(items) {
 }
 
 /**
+ * Pages with these fetchStatus values are "source-side debt" — known broken
+ * upstream source pages registered in `source_sync_exclusions.mjs`. They
+ * are ignored by freshness calculation (debt is tracked separately).
+ *
+ * @type {ReadonlySet<string>}
+ */
+const EXCLUDED_FETCH_STATUSES = new Set(['excluded-broken', 'excluded-recovered']);
+
+function isExcludedPage(page) {
+  return EXCLUDED_FETCH_STATUSES.has(page.fetchStatus);
+}
+
+/**
  * Compute freshness state from per-page fetch results.
  *
- * - "fresh"   — all pages fetched ok, sidebar verified
- * - "partial" — some pages failed/404 but at least one ok, sidebar verified
- * - "broken"  — sidebar failed, no pages, or all pages failed
+ * - "fresh"   — all non-excluded pages fetched ok, sidebar verified
+ * - "partial" — some non-excluded pages failed/404 but at least one ok
+ * - "broken"  — sidebar failed, no pages, or all non-excluded pages failed
+ *
+ * Source-side debt pages (`excluded-broken` / `excluded-recovered`) are
+ * ignored entirely — a run that only touches debt pages is still `fresh`
+ * so long as the sidebar verifies. This keeps the freshness gate aligned
+ * with the translator-side contract and avoids conflating known upstream
+ * debt with sync failures. Debt state lives in the separate
+ * `excludedPages` counters (see `buildSourceSyncStatus`).
  *
  * Note: `stale` is also a valid freshness state but is computed from
  * RUN LINKAGE rather than fetch results — see `validateRunLinkage`.
@@ -74,9 +94,15 @@ export function computeFreshnessState(pages, sidebarVerified) {
   if (!sidebarVerified) return 'broken';
   if (pages.length === 0) return 'broken';
 
-  const okCount = pages.filter((p) => p.fetchStatus === 'ok').length;
+  const nonExcluded = pages.filter((p) => !isExcludedPage(p));
+
+  // A run that only touches known source-side debt pages is considered
+  // fresh: the sidebar verified, and debt is tracked in its own counters.
+  if (nonExcluded.length === 0) return 'fresh';
+
+  const okCount = nonExcluded.filter((p) => p.fetchStatus === 'ok').length;
   if (okCount === 0) return 'broken';
-  if (okCount === pages.length) return 'fresh';
+  if (okCount === nonExcluded.length) return 'fresh';
   return 'partial';
 }
 
@@ -155,7 +181,14 @@ export function validateRunLinkage(sourceSync, snapshotDiff, parityRunScope) {
  * Build the full source-sync-status.json payload.
  *
  * @param {object} opts
- * @param {{ slug: string, fetchStatus: string, errorDetail?: string, snapshotFingerprint?: string }[]} opts.pages
+ * @param {{
+ *   slug: string,
+ *   fetchStatus: string,
+ *   errorDetail?: string,
+ *   snapshotFingerprint?: string,
+ *   recoveryProbe?: { issueType: string, reason: string } | null,
+ *   debtCategory?: 'source-side-debt' | null,
+ * }[]} opts.pages
  * @param {{ ok: boolean, sectionCount?: number, pageCount?: number, reason?: string, sidebarSlugs?: string[] }} opts.sidebarResult
  * @param {{ type: string, isComplete: boolean, filters: { slug: string|null, section: string|null } }} opts.runScope
  * @param {Date} [opts.now]  — override for deterministic tests
@@ -176,14 +209,24 @@ export function buildSourceSyncStatus({ pages, sidebarResult, runScope, now, run
     ? fingerprint(sidebarResult.sidebarSlugs)
     : fingerprint([`${sidebarResult.sectionCount ?? 0}:${sidebarResult.pageCount ?? 0}`]);
 
+  // Per-status counters — excluded pages are tracked in their own counters
+  // below and are NOT counted as ok / not-found / error.
   const okCount = pages.filter((p) => p.fetchStatus === 'ok').length;
   const notFoundCount = pages.filter((p) => p.fetchStatus === 'not-found').length;
   const errorCount = pages.filter((p) => p.fetchStatus === 'error').length;
+  const excludedBrokenCount = pages.filter((p) => p.fetchStatus === 'excluded-broken').length;
+  const excludedRecoveredCount = pages.filter(
+    (p) => p.fetchStatus === 'excluded-recovered',
+  ).length;
+  const excludedCount = excludedBrokenCount + excludedRecoveredCount;
 
   const freshnessState = computeFreshnessState(pages, sidebarResult.ok);
 
   const errors = [];
   for (const p of pages) {
+    // Excluded pages are "known debt" — never emitted as top-level errors
+    // even if the underlying fetch surfaced a failure. Their state is
+    // visible via the excludedPages counters and the recoveryProbe field.
     if (p.fetchStatus === 'error' && p.errorDetail) {
       errors.push({ slug: p.slug, detail: p.errorDetail });
     }
@@ -208,12 +251,24 @@ export function buildSourceSyncStatus({ pages, sidebarResult, runScope, now, run
       fetchedPages: okCount,
       notFoundPages: notFoundCount,
       errorPages: errorCount,
+      excludedPages: excludedCount,
+      excludedBrokenPages: excludedBrokenCount,
+      excludedRecoveredPages: excludedRecoveredCount,
       sidebarVerified: sidebarResult.ok,
     },
     pages: pages.map((p) => ({
       slug: p.slug,
       fetchStatus: p.fetchStatus,
       ...(p.snapshotFingerprint ? { snapshotFingerprint: p.snapshotFingerprint } : {}),
+      // Emit recoveryProbe / debtCategory only when the page is registered
+      // as source-side debt, so the field absence stays meaningful for
+      // normal pages. `recoveryProbe` is explicitly `null` for
+      // excluded-recovered to distinguish "probed and clean" from
+      // "never probed".
+      ...(p.debtCategory ? { debtCategory: p.debtCategory } : {}),
+      ...(p.debtCategory
+        ? { recoveryProbe: p.recoveryProbe ?? null }
+        : {}),
     })),
     errors,
   };

--- a/scripts/lib/source_sync_health.mjs
+++ b/scripts/lib/source_sync_health.mjs
@@ -7,7 +7,7 @@
 
 import { createHash } from 'node:crypto';
 
-export const SOURCE_SYNC_STATUS_SCHEMA_VERSION = 1;
+export const SOURCE_SYNC_STATUS_SCHEMA_VERSION = 2;
 
 /**
  * Shared run-scope classifier used by source-sync, snapshot-diff, and parity.

--- a/scripts/snapshot_update.mjs
+++ b/scripts/snapshot_update.mjs
@@ -34,6 +34,8 @@ import { isDirectRun } from './lib/cli.mjs';
 import { buildRunScope, buildSourceSyncStatus } from './lib/source_sync_health.mjs';
 import { isSourceSideDebt, getExclusion } from './lib/source_sync_exclusions.mjs';
 import { extractSegmentsFromHtml } from './lib/source_parity_segments_en.mjs';
+import { extractSegmentsFromMarkdown } from './lib/source_parity_segments_ja.mjs';
+import { detectSourceUsability } from './lib/source_parity_source_usability.mjs';
 
 const SNAPSHOTS_DIR = path.join(ROOT_DIR, 'snapshots', 'en');
 const CONTENT_DIR = path.join(SNAPSHOTS_DIR, 'content');
@@ -87,6 +89,7 @@ function collectTargets({ section, slug }) {
       slug: fileSlug,
       sourceUrl: data.sourceUrl,
       relativePath: doc.relativePath,
+      jaBody: doc.body,
     });
   }
 
@@ -94,93 +97,18 @@ function collectTargets({ section, slug }) {
 }
 
 /**
- * EN-only, registry-aware recovery probe for a known source-side debt page.
+ * Recovery probe for a known source-side debt page.
  *
- * Checks whether the page is still broken for the **specific reason**
- * recorded in the registry (`exclusionEntry.expectedReason`). This is a
- * narrow / fail-close probe — it does NOT run the full `detectSourceUsability`
- * pipeline and has zero dependency on JA body / segments / parse state.
+ * `detectSourceUsability()` を再利用して、registry に登録された
+ * broken upstream source が復旧したかを判定する。detector が対応する
+ * `extractor-empty` / `shallow-snapshot` / `escaped-details-residue` を
+ * そのまま扱えるため、registry 追加だけで新しい debt reason を運用に載せられる。
  *
- * Unsupported `expectedReason` values are treated as excluded-broken with
- * `expectedMatch: false` so that new registry reasons don't silently fall
- * through to recovered.
- *
- * @param {string} rawEnHtml   inner HTML of `#mc-main-content`
- * @param {object} exclusionEntry   registry entry (from `getExclusion`)
- * @returns {{ issueType: string, reason: string, expectedMatch: boolean } | null}
- *          object → still broken, null → recovered
- */
-function probeRecoveryEnOnly(rawEnHtml, exclusionEntry, { extractFn = extractSegmentsFromHtml } = {}) {
-  // Segment extraction — needed for extractor-empty check.
-  // extractFn is injectable for testing the extract-error branch.
-  let enSegments = [];
-  let extractError = null;
-  try {
-    enSegments = extractFn(rawEnHtml);
-  } catch (e) {
-    extractError = e;
-  }
-
-  const expType = exclusionEntry.expectedIssueType;
-  const expReason = exclusionEntry.expectedReason;
-
-  function broken(reason, match) {
-    return { issueType: expType, reason, expectedIssueType: expType, expectedReason: expReason, expectedMatch: match };
-  }
-
-  // extractError → fail-close: broken with probe-specific reason
-  if (extractError) {
-    return broken('extract-error', false);
-  }
-
-  const enBodyCount = enSegments.filter((s) => s.segmentKind !== 'heading').length;
-
-  // すべての expectedReason で自動 recovery しない (fail-close)。
-  //
-  // extractor-empty でも body > 0 になっただけでは usable とは限らない
-  // (shallow-snapshot 等の別種 unusable に移行した可能性がある)。
-  // EN-only probe で「usable になったか」を安全に判定するには
-  // detectSourceUsability 相当の全レイヤーが必要だが、それは JA 依存を
-  // 戻すことになる。false recovery を完全に排除するため、probe は
-  // 「registry の expected と同じ broken shape か」だけを観測し、
-  // 復旧判定は人間に委ねる。
-  //
-  // expectedMatch の意味:
-  //   true  = expected と同じ shape で壊れている (想定どおり)
-  //   false = 壊れ方が変わった or 判定できない (registry 更新を検討)
-  //
-  // excluded-recovered になるのは runRecoveryProbe の fetch-failed 以外では
-  // 起きない (= 自動 recovery は無い)。
-
-  if (expReason === 'extractor-empty' && enBodyCount === 0) {
-    return broken('extractor-empty', true);
-  }
-
-  if (expReason === 'extractor-empty' && enBodyCount > 0) {
-    // body が出現したが usable かは不明。false recovery を避けるため
-    // broken に倒す。expectedMatch=false で「壊れ方が変わった」と通知。
-    return broken('body-appeared-inconclusive', false);
-  }
-
-  // その他の reason は EN-only で安全に判定できない。
-  return broken('unsupported-recovery-probe', false);
-}
-
-/**
- * Run the EN-only recovery probe for a known source-side debt page.
- *
- * `content` is the raw `#mc-main-content` inner HTML from the live page.
- * When fetch failed (`content` is null), returns `excluded-broken` with a
- * synthetic probe so the debt counter is not reset by a network blip.
- *
- * JA body / segments / parse state には一切依存しない。translation-side
- * state と切り離した EN-only の fail-close 判定。
- *
- * @param {{ content: string|null, exclusionEntry: object }} opts
+ * @param {{ rawEnHtml: string|null, jaBody: string, exclusionEntry: object }} opts
  * @returns {{ fetchStatus: string, recoveryProbe: object|null }}
  */
-function runRecoveryProbe({ content, exclusionEntry }) {
-  if (!content) {
+function runRecoveryProbe({ rawEnHtml, jaBody, exclusionEntry }) {
+  if (!rawEnHtml) {
     return {
       fetchStatus: 'excluded-broken',
       recoveryProbe: {
@@ -193,14 +121,41 @@ function runRecoveryProbe({ content, exclusionEntry }) {
     };
   }
 
-  const probe = probeRecoveryEnOnly(content, exclusionEntry);
-  if (!probe) {
+  let enSegments = [];
+  let extractError = null;
+  try {
+    enSegments = extractSegmentsFromHtml(rawEnHtml);
+  } catch (error) {
+    extractError = error;
+  }
+
+  const jaSegments = extractSegmentsFromMarkdown(jaBody ?? '');
+
+  const issue = detectSourceUsability({
+    rawEnHtml,
+    enSegments,
+    jaSegments,
+    extractError,
+  });
+
+  if (!issue) {
     return { fetchStatus: 'excluded-recovered', recoveryProbe: null };
   }
 
+  const actualType = issue.type;
+  const actualReason = issue.usabilitySignals?.reason ?? 'unknown';
+
   return {
     fetchStatus: 'excluded-broken',
-    recoveryProbe: probe,
+    recoveryProbe: {
+      issueType: actualType,
+      reason: actualReason,
+      expectedIssueType: exclusionEntry.expectedIssueType,
+      expectedReason: exclusionEntry.expectedReason,
+      expectedMatch:
+        actualType === exclusionEntry.expectedIssueType &&
+        actualReason === exclusionEntry.expectedReason,
+    },
   };
 }
 
@@ -210,9 +165,6 @@ const FETCH_TIMEOUT_MS = 30_000;
  * Extract the main content HTML from a full page.
  * Targets `<div id="mc-main-content" ...>...</div>` (MadCap Flare).
  */
-// Exported for unit testing of fail-close branches.
-export { probeRecoveryEnOnly as _probeRecoveryEnOnly };
-
 export function extractMainContent(html) {
   const startMatch = /<div[^>]*\bid=["']mc-main-content["'][^>]*>/i.exec(html);
   if (!startMatch) return null;
@@ -368,7 +320,7 @@ export async function main(argv) {
         // recovery probe を実行し、結果は excluded-broken / excluded-recovered
         // として pageResults に載せる。404 / HTTP エラーも debt 側に吸収し、
         // 一時的な network 障害で counter が broken にフリップしないようにする。
-        const probe = runRecoveryProbe({ content, exclusionEntry: getExclusion(target.slug) });
+        const probe = runRecoveryProbe({ rawEnHtml: content, jaBody: target.jaBody, exclusionEntry: getExclusion(target.slug) });
         const label = probe.fetchStatus === 'excluded-recovered' ? 'RECOV' : 'DEBT ';
         console.log(`  ${label} ${target.slug} — source-side debt (snapshot not written)`);
         excluded += 1;
@@ -405,7 +357,7 @@ export async function main(argv) {
     } catch (error) {
       if (excludedSlug) {
         // fetch が throw しても excluded 経路は debt にとどめる
-        const probe = runRecoveryProbe({ content: null, exclusionEntry: getExclusion(target.slug) });
+        const probe = runRecoveryProbe({ rawEnHtml: null, jaBody: target.jaBody, exclusionEntry: getExclusion(target.slug) });
         console.log(`  DEBT ${target.slug} — source-side debt (fetch failed: ${error.message})`);
         excluded += 1;
         pageResults.push({

--- a/scripts/snapshot_update.mjs
+++ b/scripts/snapshot_update.mjs
@@ -32,6 +32,10 @@ import {
 import { fetchTocData, buildSidebarSnapshot, extractSlugsFromSnapshot } from './lib/madcap_toc.mjs';
 import { isDirectRun } from './lib/cli.mjs';
 import { buildRunScope, buildSourceSyncStatus } from './lib/source_sync_health.mjs';
+import { isSourceSideDebt } from './lib/source_sync_exclusions.mjs';
+import { extractSegmentsFromHtml } from './lib/source_parity_segments_en.mjs';
+import { extractSegmentsFromMarkdown } from './lib/source_parity_segments_ja.mjs';
+import { detectSourceUsability } from './lib/source_parity_source_usability.mjs';
 
 const SNAPSHOTS_DIR = path.join(ROOT_DIR, 'snapshots', 'en');
 const CONTENT_DIR = path.join(SNAPSHOTS_DIR, 'content');
@@ -60,7 +64,11 @@ function parseArgs(argv = process.argv.slice(2)) {
 }
 
 /**
- * Build list of { slug, sourceUrl, relativePath } from doc files.
+ * Build list of { slug, sourceUrl, relativePath, jaBody } from doc files.
+ *
+ * `jaBody` is included so the recovery-probe path (for source-side debt
+ * pages) can diff the raw EN HTML against the JA body without re-reading
+ * the same file. Normal pages ignore it.
  */
 function collectTargets({ section, slug }) {
   const files = findMdFiles(DOCS_DIR);
@@ -85,10 +93,69 @@ function collectTargets({ section, slug }) {
       slug: fileSlug,
       sourceUrl: data.sourceUrl,
       relativePath: doc.relativePath,
+      jaBody: doc.body,
     });
   }
 
   return targets;
+}
+
+/**
+ * Run the source-usability detector against freshly fetched HTML for a
+ * known source-side debt page. Returns:
+ *   - { fetchStatus: 'excluded-broken', recoveryProbe: { issueType, reason } }
+ *     if the detector still flags the page as unusable (debt persists).
+ *   - { fetchStatus: 'excluded-recovered', recoveryProbe: null }
+ *     if the detector returns null (upstream likely recovered — candidate
+ *     for registry removal; decided by a human).
+ *
+ * `content` is the raw `#mc-main-content` inner HTML extracted from the
+ * live page. When fetch itself failed, `content` will be null and we still
+ * return `excluded-broken` with a synthetic probe so the debt counter is
+ * not silently reset by a transient network blip.
+ */
+function runRecoveryProbe({ content, jaBody }) {
+  if (!content) {
+    // Fetch failed or extractor found no mc-main-content. Treat as still
+    // broken — never flip to recovered on a missing payload.
+    return {
+      fetchStatus: 'excluded-broken',
+      recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'fetch-failed' },
+    };
+  }
+
+  let enSegments = [];
+  let jaSegments = [];
+  let extractError = null;
+  try {
+    enSegments = extractSegmentsFromHtml(content);
+  } catch (e) {
+    extractError = e;
+  }
+  try {
+    jaSegments = extractSegmentsFromMarkdown(jaBody || '');
+  } catch {
+    jaSegments = [];
+  }
+
+  const issue = detectSourceUsability({
+    rawEnHtml: content,
+    enSegments,
+    jaSegments,
+    extractError,
+  });
+
+  if (!issue) {
+    return { fetchStatus: 'excluded-recovered', recoveryProbe: null };
+  }
+
+  return {
+    fetchStatus: 'excluded-broken',
+    recoveryProbe: {
+      issueType: issue.type,
+      reason: issue.usabilitySignals?.reason ?? 'unknown',
+    },
+  };
 }
 
 const FETCH_TIMEOUT_MS = 30_000;
@@ -236,14 +303,33 @@ export async function main(argv) {
   let fetched = 0;
   let notFound = 0;
   let errors = 0;
+  let excluded = 0;
   const pageResults = [];
 
   for (const target of targets) {
+    const excludedSlug = isSourceSideDebt(target.slug);
+
     try {
       const { content, status, reason } = await fetchHtmlContent(target.sourceUrl);
       const snapshotPath = path.join(CONTENT_DIR, target.slug + '.html');
 
-      if (status === 404) {
+      if (excludedSlug) {
+        // Issue #255 — source-side debt: fetch しても snapshot file は
+        // 絶対に上書きしない (hand-authored を凍結参照として温存)。
+        // recovery probe を実行し、結果は excluded-broken / excluded-recovered
+        // として pageResults に載せる。404 / HTTP エラーも debt 側に吸収し、
+        // 一時的な network 障害で counter が broken にフリップしないようにする。
+        const probe = runRecoveryProbe({ content, jaBody: target.jaBody });
+        const label = probe.fetchStatus === 'excluded-recovered' ? 'RECOV' : 'DEBT ';
+        console.log(`  ${label} ${target.slug} — source-side debt (snapshot not written)`);
+        excluded += 1;
+        pageResults.push({
+          slug: target.slug,
+          fetchStatus: probe.fetchStatus,
+          recoveryProbe: probe.recoveryProbe,
+          debtCategory: 'source-side-debt',
+        });
+      } else if (status === 404) {
         if (!args.dryRun) {
           fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
           fs.writeFileSync(snapshotPath, MARKER_404(target.sourceUrl));
@@ -268,9 +354,22 @@ export async function main(argv) {
         pageResults.push({ slug: target.slug, fetchStatus: 'ok' });
       }
     } catch (error) {
-      console.log(`  ERR  ${target.slug} — ${error.message}`);
-      errors += 1;
-      pageResults.push({ slug: target.slug, fetchStatus: 'error', errorDetail: error.message });
+      if (excludedSlug) {
+        // fetch が throw しても excluded 経路は debt にとどめる
+        const probe = runRecoveryProbe({ content: null, jaBody: target.jaBody });
+        console.log(`  DEBT ${target.slug} — source-side debt (fetch failed: ${error.message})`);
+        excluded += 1;
+        pageResults.push({
+          slug: target.slug,
+          fetchStatus: probe.fetchStatus,
+          recoveryProbe: probe.recoveryProbe,
+          debtCategory: 'source-side-debt',
+        });
+      } else {
+        console.log(`  ERR  ${target.slug} — ${error.message}`);
+        errors += 1;
+        pageResults.push({ slug: target.slug, fetchStatus: 'error', errorDetail: error.message });
+      }
     }
 
     await sleep(THROTTLE_MS);
@@ -298,11 +397,21 @@ export async function main(argv) {
   );
 
   console.log();
-  console.log(`Done: ${fetched} fetched, ${notFound} not found, ${errors} errors`);
+  console.log(
+    `Done: ${fetched} fetched, ${notFound} not found, ${errors} errors, ${excluded} excluded (source-side debt)`,
+  );
   console.log(`Freshness: ${sourceSyncStatus.freshnessState}`);
   if (args.dryRun) console.log('(dry-run — snapshots not written, source-sync-status.json updated)');
 
-  return { fetched, notFound, errors, skipped: 0, sidebarVerified: sidebarResult.ok, sourceSyncStatus };
+  return {
+    fetched,
+    notFound,
+    errors,
+    excluded,
+    skipped: 0,
+    sidebarVerified: sidebarResult.ok,
+    sourceSyncStatus,
+  };
 }
 
 if (isDirectRun(import.meta.url)) {

--- a/scripts/snapshot_update.mjs
+++ b/scripts/snapshot_update.mjs
@@ -34,8 +34,7 @@ import { isDirectRun } from './lib/cli.mjs';
 import { buildRunScope, buildSourceSyncStatus } from './lib/source_sync_health.mjs';
 import { isSourceSideDebt, getExclusion } from './lib/source_sync_exclusions.mjs';
 import { extractSegmentsFromHtml } from './lib/source_parity_segments_en.mjs';
-import { extractSegmentsFromMarkdown } from './lib/source_parity_segments_ja.mjs';
-import { detectSourceUsability } from './lib/source_parity_source_usability.mjs';
+import { preprocessEnHtml } from './lib/turndown.mjs';
 
 const SNAPSHOTS_DIR = path.join(ROOT_DIR, 'snapshots', 'en');
 const CONTENT_DIR = path.join(SNAPSHOTS_DIR, 'content');
@@ -64,11 +63,7 @@ function parseArgs(argv = process.argv.slice(2)) {
 }
 
 /**
- * Build list of { slug, sourceUrl, relativePath, jaBody } from doc files.
- *
- * `jaBody` is included so the recovery-probe path (for source-side debt
- * pages) can diff the raw EN HTML against the JA body without re-reading
- * the same file. Normal pages ignore it.
+ * Build list of { slug, sourceUrl, relativePath } from doc files.
  */
 function collectTargets({ section, slug }) {
   const files = findMdFiles(DOCS_DIR);
@@ -93,7 +88,6 @@ function collectTargets({ section, slug }) {
       slug: fileSlug,
       sourceUrl: data.sourceUrl,
       relativePath: doc.relativePath,
-      jaBody: doc.body,
     });
   }
 
@@ -101,76 +95,123 @@ function collectTargets({ section, slug }) {
 }
 
 /**
- * Run the source-usability detector against freshly fetched HTML for a
- * known source-side debt page. Returns:
- *   - { fetchStatus: 'excluded-broken', recoveryProbe: { issueType, reason, expectedMatch } }
- *     if the detector still flags the page as unusable (debt persists).
- *   - { fetchStatus: 'excluded-recovered', recoveryProbe: null }
- *     if the detector returns null (upstream likely recovered — candidate
- *     for registry removal; decided by a human).
- *
- * `content` is the raw `#mc-main-content` inner HTML extracted from the
- * live page. When fetch itself failed, `content` will be null and we still
- * return `excluded-broken` with a synthetic probe so the debt counter is
- * not silently reset by a transient network blip.
- *
- * `exclusionEntry` is the registry metadata for this slug — used to
- * compare `expectedIssueType` / `expectedReason` against the actual
- * detector output. The comparison result is emitted as `expectedMatch`
- * so that humans reviewing the status can spot shape drift (e.g.
- * upstream changed from `extractor-empty` to `shallow-snapshot`).
+ * Count occurrences of a global regex pattern in a string.
+ * @param {string} str
+ * @param {RegExp} pattern  g flag required
+ * @returns {number}
  */
-function runRecoveryProbe({ content, jaBody, exclusionEntry }) {
+function countMatches(str, pattern) {
+  let n = 0;
+  for (const _ of str.matchAll(pattern)) n++;
+  return n;
+}
+
+// Thresholds for shallow-snapshot EN-only check (aligned with
+// source_parity_source_usability.mjs but used independently).
+const SHALLOW_MAX_EN_BODY = 2;
+const SHALLOW_MAX_EN_RAW_HTML = 800;
+
+/**
+ * EN-only, registry-aware recovery probe for a known source-side debt page.
+ *
+ * Checks whether the page is still broken for the **specific reason**
+ * recorded in the registry (`exclusionEntry.expectedReason`). This is a
+ * narrow / fail-close probe — it does NOT run the full `detectSourceUsability`
+ * pipeline and has zero dependency on JA body / segments / parse state.
+ *
+ * Unsupported `expectedReason` values are treated as excluded-broken with
+ * `expectedMatch: false` so that new registry reasons don't silently fall
+ * through to recovered.
+ *
+ * @param {string} rawEnHtml   inner HTML of `#mc-main-content`
+ * @param {object} exclusionEntry   registry entry (from `getExclusion`)
+ * @returns {{ issueType: string, reason: string, expectedMatch: boolean } | null}
+ *          object → still broken, null → recovered
+ */
+function probeRecoveryEnOnly(rawEnHtml, exclusionEntry) {
+  // Segment extraction — needed for extractor-empty / shallow checks
+  let enSegments = [];
+  let extractError = null;
+  try {
+    enSegments = extractSegmentsFromHtml(rawEnHtml);
+  } catch (e) {
+    extractError = e;
+  }
+
+  const expType = exclusionEntry.expectedIssueType;
+  const expReason = exclusionEntry.expectedReason;
+
+  function broken(reason, match) {
+    return { issueType: expType, reason, expectedIssueType: expType, expectedReason: expReason, expectedMatch: match };
+  }
+
+  // extractError → fail-close: broken with probe-specific reason
+  if (extractError) {
+    return broken('extract-error', false);
+  }
+
+  const enBodyCount = enSegments.filter((s) => s.segmentKind !== 'heading').length;
+
+  switch (expReason) {
+    case 'extractor-empty':
+      if (enBodyCount === 0) return broken('extractor-empty', true);
+      return null; // recovered
+
+    case 'escaped-details-residue': {
+      const preprocessed = preprocessEnHtml(rawEnHtml);
+      const openCount = countMatches(preprocessed, /&lt;details(\b[^>]*)?&gt;/gi);
+      const closeCount = countMatches(preprocessed, /&lt;\/details&gt;/gi);
+      if (openCount !== closeCount) return broken('escaped-details-residue', true);
+      return null; // recovered
+    }
+
+    case 'shallow-snapshot':
+      if (enBodyCount <= SHALLOW_MAX_EN_BODY && rawEnHtml.length <= SHALLOW_MAX_EN_RAW_HTML) {
+        return broken('shallow-snapshot', true);
+      }
+      return null; // recovered
+
+    default:
+      // Unsupported reason → fail-close: broken + expectedMatch: false
+      return broken(expReason, false);
+  }
+}
+
+/**
+ * Run the EN-only recovery probe for a known source-side debt page.
+ *
+ * `content` is the raw `#mc-main-content` inner HTML from the live page.
+ * When fetch failed (`content` is null), returns `excluded-broken` with a
+ * synthetic probe so the debt counter is not reset by a network blip.
+ *
+ * JA body / segments / parse state には一切依存しない。translation-side
+ * state と切り離した EN-only の fail-close 判定。
+ *
+ * @param {{ content: string|null, exclusionEntry: object }} opts
+ * @returns {{ fetchStatus: string, recoveryProbe: object|null }}
+ */
+function runRecoveryProbe({ content, exclusionEntry }) {
   if (!content) {
     return {
       fetchStatus: 'excluded-broken',
       recoveryProbe: {
-        issueType: 'snapshot-incomplete',
+        issueType: exclusionEntry.expectedIssueType ?? 'snapshot-incomplete',
         reason: 'fetch-failed',
+        expectedIssueType: exclusionEntry.expectedIssueType,
+        expectedReason: exclusionEntry.expectedReason,
         expectedMatch: false,
       },
     };
   }
 
-  let enSegments = [];
-  let jaSegments = [];
-  let extractError = null;
-  try {
-    enSegments = extractSegmentsFromHtml(content);
-  } catch (e) {
-    extractError = e;
-  }
-  try {
-    jaSegments = extractSegmentsFromMarkdown(jaBody || '');
-  } catch {
-    jaSegments = [];
-  }
-
-  const issue = detectSourceUsability({
-    rawEnHtml: content,
-    enSegments,
-    jaSegments,
-    extractError,
-  });
-
-  if (!issue) {
+  const probe = probeRecoveryEnOnly(content, exclusionEntry);
+  if (!probe) {
     return { fetchStatus: 'excluded-recovered', recoveryProbe: null };
   }
 
-  const actualType = issue.type;
-  const actualReason = issue.usabilitySignals?.reason ?? 'unknown';
-  const expectedMatch =
-    exclusionEntry != null &&
-    actualType === exclusionEntry.expectedIssueType &&
-    actualReason === exclusionEntry.expectedReason;
-
   return {
     fetchStatus: 'excluded-broken',
-    recoveryProbe: {
-      issueType: actualType,
-      reason: actualReason,
-      expectedMatch,
-    },
+    recoveryProbe: probe,
   };
 }
 
@@ -335,7 +376,7 @@ export async function main(argv) {
         // recovery probe を実行し、結果は excluded-broken / excluded-recovered
         // として pageResults に載せる。404 / HTTP エラーも debt 側に吸収し、
         // 一時的な network 障害で counter が broken にフリップしないようにする。
-        const probe = runRecoveryProbe({ content, jaBody: target.jaBody, exclusionEntry: getExclusion(target.slug) });
+        const probe = runRecoveryProbe({ content, exclusionEntry: getExclusion(target.slug) });
         const label = probe.fetchStatus === 'excluded-recovered' ? 'RECOV' : 'DEBT ';
         console.log(`  ${label} ${target.slug} — source-side debt (snapshot not written)`);
         excluded += 1;
@@ -372,7 +413,7 @@ export async function main(argv) {
     } catch (error) {
       if (excludedSlug) {
         // fetch が throw しても excluded 経路は debt にとどめる
-        const probe = runRecoveryProbe({ content: null, jaBody: target.jaBody, exclusionEntry: getExclusion(target.slug) });
+        const probe = runRecoveryProbe({ content: null, exclusionEntry: getExclusion(target.slug) });
         console.log(`  DEBT ${target.slug} — source-side debt (fetch failed: ${error.message})`);
         excluded += 1;
         pageResults.push({

--- a/scripts/snapshot_update.mjs
+++ b/scripts/snapshot_update.mjs
@@ -89,11 +89,33 @@ function collectTargets({ section, slug }) {
       slug: fileSlug,
       sourceUrl: data.sourceUrl,
       relativePath: doc.relativePath,
-      jaBody: doc.body,
     });
   }
 
   return targets;
+}
+
+/**
+ * Synthetic JA segments for recovery probe.
+ *
+ * detectSourceUsability は JA body segment 数を閾値に使う (extractor-empty
+ * は jaBody >= 3, shallow-snapshot は jaBody >= 5)。recovery probe が
+ * 実 JA に依存すると、未翻訳や短い JA で false recovery が発生する。
+ * reason ごとに detector の閾値を満たす synthetic segments を返すことで、
+ * EN-only の判定を維持する。
+ */
+function buildProbeJaSegments(expectedReason) {
+  switch (expectedReason) {
+    case 'extractor-empty':
+      return extractSegmentsFromMarkdown('# Probe\n\nA\n\nB\n\nC');
+    case 'shallow-snapshot':
+      return extractSegmentsFromMarkdown('# Probe\n\nA\n\nB\n\nC\n\nD\n\nE');
+    case 'escaped-details-residue':
+      return extractSegmentsFromMarkdown('# Probe\n\n## Section\n\nA');
+    default:
+      // 未知の reason は最も厳しい shallow-snapshot の閾値で安全側に倒す
+      return extractSegmentsFromMarkdown('# Probe\n\nA\n\nB\n\nC\n\nD\n\nE');
+  }
 }
 
 /**
@@ -104,23 +126,12 @@ function collectTargets({ section, slug }) {
  * `extractor-empty` / `shallow-snapshot` / `escaped-details-residue` を
  * そのまま扱えるため、registry 追加だけで新しい debt reason を運用に載せられる。
  *
- * @param {{ rawEnHtml: string|null, jaBody: string, exclusionEntry: object }} opts
+ * JA body には依存しない — synthetic segments を使って EN-only 判定を維持。
+ *
+ * @param {{ rawEnHtml: string, exclusionEntry: object }} opts
  * @returns {{ fetchStatus: string, recoveryProbe: object|null }}
  */
-function runRecoveryProbe({ rawEnHtml, jaBody, exclusionEntry }) {
-  if (!rawEnHtml) {
-    return {
-      fetchStatus: 'excluded-broken',
-      recoveryProbe: {
-        issueType: exclusionEntry.expectedIssueType ?? 'snapshot-incomplete',
-        reason: 'fetch-failed',
-        expectedIssueType: exclusionEntry.expectedIssueType,
-        expectedReason: exclusionEntry.expectedReason,
-        expectedMatch: false,
-      },
-    };
-  }
-
+function runRecoveryProbe({ rawEnHtml, exclusionEntry }) {
   let enSegments = [];
   let extractError = null;
   try {
@@ -129,7 +140,7 @@ function runRecoveryProbe({ rawEnHtml, jaBody, exclusionEntry }) {
     extractError = error;
   }
 
-  const jaSegments = extractSegmentsFromMarkdown(jaBody ?? '');
+  const jaSegments = buildProbeJaSegments(exclusionEntry.expectedReason);
 
   const issue = detectSourceUsability({
     rawEnHtml,
@@ -317,19 +328,37 @@ export async function main(argv) {
       if (excludedSlug) {
         // Issue #255 — source-side debt: fetch しても snapshot file は
         // 絶対に上書きしない (hand-authored を凍結参照として温存)。
-        // recovery probe を実行し、結果は excluded-broken / excluded-recovered
-        // として pageResults に載せる。404 / HTTP エラーも debt 側に吸収し、
-        // 一時的な network 障害で counter が broken にフリップしないようにする。
-        const probe = runRecoveryProbe({ rawEnHtml: content, jaBody: target.jaBody, exclusionEntry: getExclusion(target.slug) });
-        const label = probe.fetchStatus === 'excluded-recovered' ? 'RECOV' : 'DEBT ';
-        console.log(`  ${label} ${target.slug} — source-side debt (snapshot not written)`);
-        excluded += 1;
-        pageResults.push({
-          slug: target.slug,
-          fetchStatus: probe.fetchStatus,
-          recoveryProbe: probe.recoveryProbe,
-          debtCategory: 'source-side-debt',
-        });
+        //
+        // fetch 失敗 (HTTP error / 404 / mc-main-content missing) と
+        // 正常 fetch + recovery probe は分離する。fetch 失敗は
+        // excluded-fetch-error として errors に計上し、freshness 劣化を
+        // 可視化する。probe は content が取れたときのみ実行する。
+        if (!content) {
+          const detail =
+            status !== 200 ? `HTTP ${status}` :
+            reason === 'mc-main-content-not-found' ? '#mc-main-content not found' :
+            'fetch failed';
+          console.log(`  FERR ${target.slug} — source-side debt (${detail})`);
+          errors += 1;
+          pageResults.push({
+            slug: target.slug,
+            fetchStatus: 'excluded-fetch-error',
+            debtCategory: 'source-side-debt',
+            errorDetail: detail,
+            recoveryProbe: null,
+          });
+        } else {
+          const probe = runRecoveryProbe({ rawEnHtml: content, exclusionEntry: getExclusion(target.slug) });
+          const label = probe.fetchStatus === 'excluded-recovered' ? 'RECOV' : 'DEBT ';
+          console.log(`  ${label} ${target.slug} — source-side debt (snapshot not written)`);
+          excluded += 1;
+          pageResults.push({
+            slug: target.slug,
+            fetchStatus: probe.fetchStatus,
+            recoveryProbe: probe.recoveryProbe,
+            debtCategory: 'source-side-debt',
+          });
+        }
       } else if (status === 404) {
         if (!args.dryRun) {
           fs.mkdirSync(path.dirname(snapshotPath), { recursive: true });
@@ -356,15 +385,16 @@ export async function main(argv) {
       }
     } catch (error) {
       if (excludedSlug) {
-        // fetch が throw しても excluded 経路は debt にとどめる
-        const probe = runRecoveryProbe({ rawEnHtml: null, jaBody: target.jaBody, exclusionEntry: getExclusion(target.slug) });
-        console.log(`  DEBT ${target.slug} — source-side debt (fetch failed: ${error.message})`);
-        excluded += 1;
+        // fetch が throw した → excluded-fetch-error として errors に計上。
+        // live EN を観測できなかったことを source-sync 劣化として可視化する。
+        console.log(`  FERR ${target.slug} — source-side debt (fetch failed: ${error.message})`);
+        errors += 1;
         pageResults.push({
           slug: target.slug,
-          fetchStatus: probe.fetchStatus,
-          recoveryProbe: probe.recoveryProbe,
+          fetchStatus: 'excluded-fetch-error',
           debtCategory: 'source-side-debt',
+          errorDetail: error.message,
+          recoveryProbe: null,
         });
       } else {
         console.log(`  ERR  ${target.slug} — ${error.message}`);

--- a/scripts/snapshot_update.mjs
+++ b/scripts/snapshot_update.mjs
@@ -32,7 +32,7 @@ import {
 import { fetchTocData, buildSidebarSnapshot, extractSlugsFromSnapshot } from './lib/madcap_toc.mjs';
 import { isDirectRun } from './lib/cli.mjs';
 import { buildRunScope, buildSourceSyncStatus } from './lib/source_sync_health.mjs';
-import { isSourceSideDebt } from './lib/source_sync_exclusions.mjs';
+import { isSourceSideDebt, getExclusion } from './lib/source_sync_exclusions.mjs';
 import { extractSegmentsFromHtml } from './lib/source_parity_segments_en.mjs';
 import { extractSegmentsFromMarkdown } from './lib/source_parity_segments_ja.mjs';
 import { detectSourceUsability } from './lib/source_parity_source_usability.mjs';
@@ -103,7 +103,7 @@ function collectTargets({ section, slug }) {
 /**
  * Run the source-usability detector against freshly fetched HTML for a
  * known source-side debt page. Returns:
- *   - { fetchStatus: 'excluded-broken', recoveryProbe: { issueType, reason } }
+ *   - { fetchStatus: 'excluded-broken', recoveryProbe: { issueType, reason, expectedMatch } }
  *     if the detector still flags the page as unusable (debt persists).
  *   - { fetchStatus: 'excluded-recovered', recoveryProbe: null }
  *     if the detector returns null (upstream likely recovered — candidate
@@ -113,14 +113,22 @@ function collectTargets({ section, slug }) {
  * live page. When fetch itself failed, `content` will be null and we still
  * return `excluded-broken` with a synthetic probe so the debt counter is
  * not silently reset by a transient network blip.
+ *
+ * `exclusionEntry` is the registry metadata for this slug — used to
+ * compare `expectedIssueType` / `expectedReason` against the actual
+ * detector output. The comparison result is emitted as `expectedMatch`
+ * so that humans reviewing the status can spot shape drift (e.g.
+ * upstream changed from `extractor-empty` to `shallow-snapshot`).
  */
-function runRecoveryProbe({ content, jaBody }) {
+function runRecoveryProbe({ content, jaBody, exclusionEntry }) {
   if (!content) {
-    // Fetch failed or extractor found no mc-main-content. Treat as still
-    // broken — never flip to recovered on a missing payload.
     return {
       fetchStatus: 'excluded-broken',
-      recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'fetch-failed' },
+      recoveryProbe: {
+        issueType: 'snapshot-incomplete',
+        reason: 'fetch-failed',
+        expectedMatch: false,
+      },
     };
   }
 
@@ -149,11 +157,19 @@ function runRecoveryProbe({ content, jaBody }) {
     return { fetchStatus: 'excluded-recovered', recoveryProbe: null };
   }
 
+  const actualType = issue.type;
+  const actualReason = issue.usabilitySignals?.reason ?? 'unknown';
+  const expectedMatch =
+    exclusionEntry != null &&
+    actualType === exclusionEntry.expectedIssueType &&
+    actualReason === exclusionEntry.expectedReason;
+
   return {
     fetchStatus: 'excluded-broken',
     recoveryProbe: {
-      issueType: issue.type,
-      reason: issue.usabilitySignals?.reason ?? 'unknown',
+      issueType: actualType,
+      reason: actualReason,
+      expectedMatch,
     },
   };
 }
@@ -319,7 +335,7 @@ export async function main(argv) {
         // recovery probe を実行し、結果は excluded-broken / excluded-recovered
         // として pageResults に載せる。404 / HTTP エラーも debt 側に吸収し、
         // 一時的な network 障害で counter が broken にフリップしないようにする。
-        const probe = runRecoveryProbe({ content, jaBody: target.jaBody });
+        const probe = runRecoveryProbe({ content, jaBody: target.jaBody, exclusionEntry: getExclusion(target.slug) });
         const label = probe.fetchStatus === 'excluded-recovered' ? 'RECOV' : 'DEBT ';
         console.log(`  ${label} ${target.slug} — source-side debt (snapshot not written)`);
         excluded += 1;
@@ -356,7 +372,7 @@ export async function main(argv) {
     } catch (error) {
       if (excludedSlug) {
         // fetch が throw しても excluded 経路は debt にとどめる
-        const probe = runRecoveryProbe({ content: null, jaBody: target.jaBody });
+        const probe = runRecoveryProbe({ content: null, jaBody: target.jaBody, exclusionEntry: getExclusion(target.slug) });
         console.log(`  DEBT ${target.slug} — source-side debt (fetch failed: ${error.message})`);
         excluded += 1;
         pageResults.push({

--- a/scripts/snapshot_update.mjs
+++ b/scripts/snapshot_update.mjs
@@ -34,7 +34,6 @@ import { isDirectRun } from './lib/cli.mjs';
 import { buildRunScope, buildSourceSyncStatus } from './lib/source_sync_health.mjs';
 import { isSourceSideDebt, getExclusion } from './lib/source_sync_exclusions.mjs';
 import { extractSegmentsFromHtml } from './lib/source_parity_segments_en.mjs';
-import { preprocessEnHtml } from './lib/turndown.mjs';
 
 const SNAPSHOTS_DIR = path.join(ROOT_DIR, 'snapshots', 'en');
 const CONTENT_DIR = path.join(SNAPSHOTS_DIR, 'content');
@@ -95,23 +94,6 @@ function collectTargets({ section, slug }) {
 }
 
 /**
- * Count occurrences of a global regex pattern in a string.
- * @param {string} str
- * @param {RegExp} pattern  g flag required
- * @returns {number}
- */
-function countMatches(str, pattern) {
-  let n = 0;
-  for (const _ of str.matchAll(pattern)) n++;
-  return n;
-}
-
-// Thresholds for shallow-snapshot EN-only check (aligned with
-// source_parity_source_usability.mjs but used independently).
-const SHALLOW_MAX_EN_BODY = 2;
-const SHALLOW_MAX_EN_RAW_HTML = 800;
-
-/**
  * EN-only, registry-aware recovery probe for a known source-side debt page.
  *
  * Checks whether the page is still broken for the **specific reason**
@@ -154,26 +136,17 @@ function probeRecoveryEnOnly(rawEnHtml, exclusionEntry) {
 
   switch (expReason) {
     case 'extractor-empty':
+      // EN body segments が 0 のままなら broken。唯一 EN-only で安全に
+      // 判定できる reason — false recovery のリスクが無い。
       if (enBodyCount === 0) return broken('extractor-empty', true);
       return null; // recovered
 
-    case 'escaped-details-residue': {
-      const preprocessed = preprocessEnHtml(rawEnHtml);
-      const openCount = countMatches(preprocessed, /&lt;details(\b[^>]*)?&gt;/gi);
-      const closeCount = countMatches(preprocessed, /&lt;\/details&gt;/gi);
-      if (openCount !== closeCount) return broken('escaped-details-residue', true);
-      return null; // recovered
-    }
-
-    case 'shallow-snapshot':
-      if (enBodyCount <= SHALLOW_MAX_EN_BODY && rawEnHtml.length <= SHALLOW_MAX_EN_RAW_HTML) {
-        return broken('shallow-snapshot', true);
-      }
-      return null; // recovered
-
     default:
-      // Unsupported reason → fail-close: broken + expectedMatch: false
-      return broken(expReason, false);
+      // escaped-details-residue / shallow-snapshot / 将来の reason は
+      // EN-only では安全に判定できない (false recovery のリスクがある)。
+      // fail-close: broken に倒して自動 recovery しない。
+      // 人間が upstream を目視確認して registry から除外解除する運用。
+      return broken('unsupported-recovery-probe', false);
   }
 }
 

--- a/scripts/snapshot_update.mjs
+++ b/scripts/snapshot_update.mjs
@@ -110,12 +110,13 @@ function collectTargets({ section, slug }) {
  * @returns {{ issueType: string, reason: string, expectedMatch: boolean } | null}
  *          object → still broken, null → recovered
  */
-function probeRecoveryEnOnly(rawEnHtml, exclusionEntry) {
-  // Segment extraction — needed for extractor-empty / shallow checks
+function probeRecoveryEnOnly(rawEnHtml, exclusionEntry, { extractFn = extractSegmentsFromHtml } = {}) {
+  // Segment extraction — needed for extractor-empty check.
+  // extractFn is injectable for testing the extract-error branch.
   let enSegments = [];
   let extractError = null;
   try {
-    enSegments = extractSegmentsFromHtml(rawEnHtml);
+    enSegments = extractFn(rawEnHtml);
   } catch (e) {
     extractError = e;
   }

--- a/scripts/snapshot_update.mjs
+++ b/scripts/snapshot_update.mjs
@@ -135,20 +135,35 @@ function probeRecoveryEnOnly(rawEnHtml, exclusionEntry, { extractFn = extractSeg
 
   const enBodyCount = enSegments.filter((s) => s.segmentKind !== 'heading').length;
 
-  switch (expReason) {
-    case 'extractor-empty':
-      // EN body segments が 0 のままなら broken。唯一 EN-only で安全に
-      // 判定できる reason — false recovery のリスクが無い。
-      if (enBodyCount === 0) return broken('extractor-empty', true);
-      return null; // recovered
+  // すべての expectedReason で自動 recovery しない (fail-close)。
+  //
+  // extractor-empty でも body > 0 になっただけでは usable とは限らない
+  // (shallow-snapshot 等の別種 unusable に移行した可能性がある)。
+  // EN-only probe で「usable になったか」を安全に判定するには
+  // detectSourceUsability 相当の全レイヤーが必要だが、それは JA 依存を
+  // 戻すことになる。false recovery を完全に排除するため、probe は
+  // 「registry の expected と同じ broken shape か」だけを観測し、
+  // 復旧判定は人間に委ねる。
+  //
+  // expectedMatch の意味:
+  //   true  = expected と同じ shape で壊れている (想定どおり)
+  //   false = 壊れ方が変わった or 判定できない (registry 更新を検討)
+  //
+  // excluded-recovered になるのは runRecoveryProbe の fetch-failed 以外では
+  // 起きない (= 自動 recovery は無い)。
 
-    default:
-      // escaped-details-residue / shallow-snapshot / 将来の reason は
-      // EN-only では安全に判定できない (false recovery のリスクがある)。
-      // fail-close: broken に倒して自動 recovery しない。
-      // 人間が upstream を目視確認して registry から除外解除する運用。
-      return broken('unsupported-recovery-probe', false);
+  if (expReason === 'extractor-empty' && enBodyCount === 0) {
+    return broken('extractor-empty', true);
   }
+
+  if (expReason === 'extractor-empty' && enBodyCount > 0) {
+    // body が出現したが usable かは不明。false recovery を避けるため
+    // broken に倒す。expectedMatch=false で「壊れ方が変わった」と通知。
+    return broken('body-appeared-inconclusive', false);
+  }
+
+  // その他の reason は EN-only で安全に判定できない。
+  return broken('unsupported-recovery-probe', false);
 }
 
 /**

--- a/scripts/snapshot_update.mjs
+++ b/scripts/snapshot_update.mjs
@@ -98,24 +98,20 @@ function collectTargets({ section, slug }) {
 /**
  * Synthetic JA segments for recovery probe.
  *
- * detectSourceUsability は JA body segment 数を閾値に使う (extractor-empty
- * は jaBody >= 3, shallow-snapshot は jaBody >= 5)。recovery probe が
- * 実 JA に依存すると、未翻訳や短い JA で false recovery が発生する。
- * reason ごとに detector の閾値を満たす synthetic segments を返すことで、
- * EN-only の判定を維持する。
+ * detectSourceUsability は JA body / heading 数を閾値に使う
+ * (`extractor-empty`: jaBody >= 3, `shallow-snapshot`: jaBody >= 5,
+ * `escaped-details-residue`: jaHeading >= 2)。recovery probe が実 JA に
+ * 依存すると、未翻訳や短い JA で false recovery が発生する。
+ *
+ * recovery probe は "現在の expectedReason" ではなく detector が持つ
+ * すべての閾値を一度に満たす synthetic JA を使う。これにより
+ * `extractor-empty` → `shallow-snapshot` のような cross-reason drift でも
+ * fail-close を維持できる。
  */
-function buildProbeJaSegments(expectedReason) {
-  switch (expectedReason) {
-    case 'extractor-empty':
-      return extractSegmentsFromMarkdown('# Probe\n\nA\n\nB\n\nC');
-    case 'shallow-snapshot':
-      return extractSegmentsFromMarkdown('# Probe\n\nA\n\nB\n\nC\n\nD\n\nE');
-    case 'escaped-details-residue':
-      return extractSegmentsFromMarkdown('# Probe\n\n## Section\n\nA');
-    default:
-      // 未知の reason は最も厳しい shallow-snapshot の閾値で安全側に倒す
-      return extractSegmentsFromMarkdown('# Probe\n\nA\n\nB\n\nC\n\nD\n\nE');
-  }
+function buildProbeJaSegments() {
+  return extractSegmentsFromMarkdown(
+    '# Probe\n\n## Section One\n\nA\n\nB\n\n## Section Two\n\nC\n\nD\n\nE',
+  );
 }
 
 const SUPPORTED_RECOVERY_REASONS = new Set([
@@ -189,7 +185,7 @@ export function runRecoveryProbe({
     });
   }
 
-  const jaSegments = buildProbeJaSegments(exclusionEntry.expectedReason);
+  const jaSegments = buildProbeJaSegments();
 
   const issue = detectSourceUsability({
     rawEnHtml,

--- a/scripts/snapshot_update.mjs
+++ b/scripts/snapshot_update.mjs
@@ -118,6 +118,31 @@ function buildProbeJaSegments(expectedReason) {
   }
 }
 
+const SUPPORTED_RECOVERY_REASONS = new Set([
+  'extractor-empty',
+  'shallow-snapshot',
+  'escaped-details-residue',
+]);
+
+function buildBrokenRecoveryProbe({
+  actualIssueType,
+  actualReason,
+  exclusionEntry,
+}) {
+  return {
+    fetchStatus: 'excluded-broken',
+    recoveryProbe: {
+      issueType: actualIssueType,
+      reason: actualReason,
+      expectedIssueType: exclusionEntry.expectedIssueType,
+      expectedReason: exclusionEntry.expectedReason,
+      expectedMatch:
+        actualIssueType === exclusionEntry.expectedIssueType &&
+        actualReason === exclusionEntry.expectedReason,
+    },
+  };
+}
+
 /**
  * Recovery probe for a known source-side debt page.
  *
@@ -128,16 +153,40 @@ function buildProbeJaSegments(expectedReason) {
  *
  * JA body には依存しない — synthetic segments を使って EN-only 判定を維持。
  *
- * @param {{ rawEnHtml: string, exclusionEntry: object }} opts
+ * Unsupported registry reasons and extractor exceptions both fail closed.
+ * A debt page is only `excluded-recovered` when the extractor succeeds and
+ * `detectSourceUsability()` returns no issue.
+ *
+ * @param {{ rawEnHtml: string, exclusionEntry: object, extractSegments?: (html: string) => any[] }} opts
  * @returns {{ fetchStatus: string, recoveryProbe: object|null }}
  */
-function runRecoveryProbe({ rawEnHtml, exclusionEntry }) {
+export function runRecoveryProbe({
+  rawEnHtml,
+  exclusionEntry,
+  extractSegments = extractSegmentsFromHtml,
+}) {
+  if (!SUPPORTED_RECOVERY_REASONS.has(exclusionEntry.expectedReason)) {
+    return buildBrokenRecoveryProbe({
+      actualIssueType: 'probe-failed',
+      actualReason: 'unsupported-expected-reason',
+      exclusionEntry,
+    });
+  }
+
   let enSegments = [];
   let extractError = null;
   try {
-    enSegments = extractSegmentsFromHtml(rawEnHtml);
+    enSegments = extractSegments(rawEnHtml);
   } catch (error) {
     extractError = error;
+  }
+
+  if (extractError !== null) {
+    return buildBrokenRecoveryProbe({
+      actualIssueType: 'probe-failed',
+      actualReason: 'extractor-throw',
+      exclusionEntry,
+    });
   }
 
   const jaSegments = buildProbeJaSegments(exclusionEntry.expectedReason);
@@ -149,25 +198,13 @@ function runRecoveryProbe({ rawEnHtml, exclusionEntry }) {
     extractError,
   });
 
-  if (!issue) {
-    return { fetchStatus: 'excluded-recovered', recoveryProbe: null };
-  }
+  if (!issue) return { fetchStatus: 'excluded-recovered', recoveryProbe: null };
 
-  const actualType = issue.type;
-  const actualReason = issue.usabilitySignals?.reason ?? 'unknown';
-
-  return {
-    fetchStatus: 'excluded-broken',
-    recoveryProbe: {
-      issueType: actualType,
-      reason: actualReason,
-      expectedIssueType: exclusionEntry.expectedIssueType,
-      expectedReason: exclusionEntry.expectedReason,
-      expectedMatch:
-        actualType === exclusionEntry.expectedIssueType &&
-        actualReason === exclusionEntry.expectedReason,
-    },
-  };
+  return buildBrokenRecoveryProbe({
+    actualIssueType: issue.type,
+    actualReason: issue.usabilitySignals?.reason ?? 'unknown',
+    exclusionEntry,
+  });
 }
 
 const FETCH_TIMEOUT_MS = 30_000;

--- a/scripts/snapshot_update.mjs
+++ b/scripts/snapshot_update.mjs
@@ -194,6 +194,9 @@ const FETCH_TIMEOUT_MS = 30_000;
  * Extract the main content HTML from a full page.
  * Targets `<div id="mc-main-content" ...>...</div>` (MadCap Flare).
  */
+// Exported for unit testing of fail-close branches.
+export { probeRecoveryEnOnly as _probeRecoveryEnOnly };
+
 export function extractMainContent(html) {
   const startMatch = /<div[^>]*\bid=["']mc-main-content["'][^>]*>/i.exec(html);
   if (!startMatch) return null;


### PR DESCRIPTION
## 概要

Issue #247 で `testops/testops-version-control/pull-requests` の hand-authored snapshot は一時的に clean に見せたが、次回の `check:snapshots` で必ず再破壊される構造的問題があった。

Issue #255 で broken upstream source を **明示 registry** で管理する運用に切り替え、representative から分離。`scripts/lib/source_sync_exclusions.mjs` に登録された slug は snapshot write をスキップしつつ、毎回 `detectSourceUsability` で recovery probe を実行し、`source-sync-status.json` の独立カウンタに `excluded-broken` / `excluded-recovered` として可視化される。

あわせて `docs-update-summary.md` と workflow の人間可読出力を日本語化した。

## 運用決定 (事前 Q&A 済み)

| | 決定 |
|---|---|
| Q1 | hand-authored snapshot は凍結参照として残す (registry が write をブロック) |
| Q2 | representative から外し source-side debt 専用テストに分離 |
| Q3 | excluded は freshness 計算から除外、独立 counter で可視化 |
| Q4 | 人が読むものは日本語、JSON/schema field 名は英語維持 |
| Q5 | 復旧候補は自動解除せず人間判断で registry 削除 |

## 実装

### 新規ファイル (3)

- `scripts/lib/source_sync_exclusions.mjs` — exclusion registry (pull-requests を初回 entry として登録)
- `scripts/__tests__/source_sync_exclusions.test.mjs` — registry shape / lookup helper 契約 (13 tests)
- `scripts/__tests__/source_parity_source_side_debt.test.mjs` — registry/repo 整合性 + end-to-end 統合 (10 tests)

### 変更ファイル (12)

| ファイル | 内容 |
|---|---|
| `scripts/snapshot_update.mjs` | exclusion 分岐: fetch 実行・write スキップ・recovery probe |
| `scripts/lib/source_sync_health.mjs` | excluded counter / freshness 除外 / page 単位 debtCategory & recoveryProbe |
| `scripts/lib/detection_reports.mjs` | `## ソース側 debt` 日本語セクション + 既存セクション全体の日本語化 + managed issue body 日本語化 + `sourceSideDebt` JSON 露出 |
| `.github/workflows/scheduled-actionable.yml` | warning / error / step summary を日本語化 |
| `docs/OPS_DESIGN.md` | Issue #247 完了条件を source-side debt 分離前提に更新 |
| `docs/DOCS_DATE_TRACKING.md` | Source-side debt 隔離節を追加 |
| `scripts/README.md` | 除外運用節 + 新 counter + test table 追記 |
| `.claude/CLAUDE.md` | Snapshot pipeline 節に 1 行 pointer を追加 |
| `scripts/__tests__/source_parity_representative_summary.test.mjs` | RESOLVED_PAGES を 8→7 (pull-requests を外す) |
| `scripts/__tests__/source_sync_health.test.mjs` | excluded-broken / excluded-recovered / counter 契約 (+8 tests) |
| `scripts/__tests__/snapshot_update.test.mjs` | exclusion 分岐と fs.writeFileSync spy (+5 tests) |
| `scripts/__tests__/detection_reports.test.mjs` | ソース側 debt セクション契約 + Japanization 更新 (+4 新規、~25 既存更新) |

## TDD で進めた Phase

- **Phase 2**: exclusion registry 導入 (13 tests)
- **Phase 3a**: source_sync_health 拡張 (+8 tests)
- **Phase 3b**: snapshot_update wiring (+5 tests)
- **Phase 1**: 契約整理 (representative 縮小 + source-side debt 専用テスト新設)
- **Phase 4**: detection reports + workflow 日本語化 (+4 新規テスト、既存 ~25 更新)
- **Phase 5**: end-to-end 統合テスト

各 Phase で RED→GREEN→REFACTOR を遵守。

## 検証

- [x] 1623 tests pass (全 suite、新規 5 テストファイル追加)
- [x] `npm run lint` clean (288 files)
- [x] `npm run build` success (290 pages)
- [x] `npm run check:parity -- --slug=pull-requests` で live HTML に対して excluded-broken → extractor-empty 判定を実際に確認

**実際の `source-sync-status.json` 出力:**

\`\`\`json
{
  "freshnessState": "fresh",
  "summary": {
    "targetPages": 1,
    "fetchedPages": 0,
    "excludedPages": 1,
    "excludedBrokenPages": 1
  },
  "pages": [{
    "slug": "testops/testops-version-control/pull-requests",
    "fetchStatus": "excluded-broken",
    "debtCategory": "source-side-debt",
    "recoveryProbe": {
      "issueType": "snapshot-incomplete",
      "reason": "extractor-empty"
    }
  }]
}
\`\`\`

debt 単独の run でも `freshnessState=fresh` を維持し、独立 counter に集計されることを live 確認。

## Test Plan

- [ ] `npm test` で 1623 tests 全 pass することを確認
- [ ] `npm run lint && npm run build` が通ることを確認
- [ ] `scripts/lib/source_sync_exclusions.mjs` の registry shape がレビュー観点で妥当か確認
- [ ] `scripts/snapshot_update.mjs` の exclusion 分岐が hand-authored snapshot を保護していることを確認
- [ ] `docs-update-summary.md` の日本語セクションが読みやすいか確認 (workflow run で step summary を確認)
- [ ] `docs/OPS_DESIGN.md` の Issue #247 完了条件の記述が正確か確認
- [ ] `.github/workflows/scheduled-actionable.yml` の警告/エラー文言の日本語が適切か確認

Closes #255
Refs #247