### PR TITLE
Fix slug cache reset contract

### DIFF
--- a/scripts/__tests__/lib_project.test.mjs
+++ b/scripts/__tests__/lib_project.test.mjs
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { buildSlugIndex, buildDocsIndex, buildBasenameToPathMap, extractSourceContentPath, filePathToSlug, matchesSectionFilter, resolveSlug, splitFrontmatter, toKebab, resetProjectCachesForTest } from '../lib/project.mjs';
+import { buildSlugIndex, buildDocsIndex, buildBasenameToPathMap, extractSourceContentPath, filePathToSlug, matchesSectionFilter, resolveSlug, resolveToFullSlug, splitFrontmatter, toKebab, resetProjectCachesForTest } from '../lib/project.mjs';
 
 describe('buildSlugIndex', () => {
   it('returns an object with slug keys mapping to categoryFolder and filePath', () => {
@@ -337,6 +337,81 @@ describe('buildBasenameToPathMap', () => {
     const map = buildBasenameToPathMap(dir);
     assert.equal(map.size, 0);
     fs.rmSync(dir, { recursive: true });
+  });
+});
+
+describe('resolveToFullSlug', () => {
+  it('returns the full slug as-is when it exists in the docs index', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'resolve-full-'));
+    fs.mkdirSync(path.join(dir, 'salesforce-testing', 'salesforce-steps'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'salesforce-testing', 'salesforce-steps', 'sfdc-step-apex-action.md'),
+      '',
+    );
+
+    try {
+      assert.equal(
+        resolveToFullSlug('salesforce-testing/salesforce-steps/sfdc-step-apex-action', dir),
+        'salesforce-testing/salesforce-steps/sfdc-step-apex-action',
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      resetProjectCachesForTest();
+    }
+  });
+
+  it('falls back to the unique basename when the input slug is truncated', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'resolve-fallback-'));
+    fs.mkdirSync(path.join(dir, 'salesforce-testing', 'salesforce-steps'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'salesforce-testing', 'salesforce-steps', 'sfdc-step-apex-action.md'),
+      '',
+    );
+
+    try {
+      assert.equal(
+        resolveToFullSlug('salesforce-steps/sfdc-step-apex-action', dir),
+        'salesforce-testing/salesforce-steps/sfdc-step-apex-action',
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      resetProjectCachesForTest();
+    }
+  });
+
+  it('returns stale cached resolution until reset, then re-scans after reset', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'resolve-reset-'));
+    const oldPath = path.join(dir, 'salesforce-testing', 'salesforce-steps', 'sfdc-step-apex-action.md');
+    const newPath = path.join(dir, 'zzz-temp', 'sfdc-step-apex-action.md');
+    fs.mkdirSync(path.dirname(oldPath), { recursive: true });
+    fs.writeFileSync(oldPath, '');
+
+    try {
+      assert.equal(
+        resolveToFullSlug('salesforce-steps/sfdc-step-apex-action', dir),
+        'salesforce-testing/salesforce-steps/sfdc-step-apex-action',
+      );
+
+      fs.mkdirSync(path.dirname(newPath), { recursive: true });
+      fs.renameSync(oldPath, newPath);
+
+      assert.equal(
+        resolveToFullSlug('salesforce-steps/sfdc-step-apex-action', dir),
+        'salesforce-testing/salesforce-steps/sfdc-step-apex-action',
+        'without reset, cached value should remain stale',
+      );
+
+      resetProjectCachesForTest();
+
+      assert.equal(
+        resolveToFullSlug('salesforce-steps/sfdc-step-apex-action', dir),
+        'zzz-temp/sfdc-step-apex-action',
+        'after reset, cache should refresh from disk',
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      resetProjectCachesForTest();
+    }
   });
 });
 

--- a/scripts/lib/project.mjs
+++ b/scripts/lib/project.mjs
@@ -125,12 +125,23 @@ export function buildBasenameToPathMap(docsDir = DOCS_DIR) {
 }
 
 /**
+ * Lazy-cached full slug → resolved full slug lookup.
+ *
+ * `resolveToFullSlug` is used from the parity extraction hot path, so repeated
+ * lookups for the same truncated slug are memoized per docsDir. The cache must
+ * stay under `resetProjectCachesForTest()` so test-only callers can force a
+ * fresh scan after mutating a temp docs tree.
+ */
+const _resolveToFullSlugCache = new Map();
+
+/**
  * Reset all module-level caches. Test-only API.
  */
 export function resetProjectCachesForTest() {
   _sectionCache.clear();
   _basenameMapCache.clear();
   _slugIndexCache.clear();
+  _resolveToFullSlugCache.clear();
 }
 
 /**
@@ -162,6 +173,45 @@ export function buildSlugIndex(docsDir = DOCS_DIR) {
   walk(docsDir);
   _slugIndexCache.set(docsDir, index);
   return index;
+}
+
+/**
+ * Resolve a possibly truncated slug to the full slug present in the docs tree.
+ *
+ * Resolution order:
+ *   1. Exact full-slug match in the docs index
+ *   2. Unique basename fallback
+ *   3. Original slug (safe fallback for ambiguous / missing entries)
+ *
+ * Cache is keyed by docsDir so temp test trees stay isolated from the real
+ * repository docs tree.
+ *
+ * @param {string} slug
+ * @param {string} [docsDir]
+ * @returns {string}
+ */
+export function resolveToFullSlug(slug, docsDir = DOCS_DIR) {
+  let dirCache = _resolveToFullSlugCache.get(docsDir);
+  if (!dirCache) {
+    dirCache = new Map();
+    _resolveToFullSlugCache.set(docsDir, dirCache);
+  }
+
+  const cached = dirCache.get(slug);
+  if (cached !== undefined) return cached;
+
+  const index = buildSlugIndex(docsDir);
+  let resolved;
+  if (Object.prototype.hasOwnProperty.call(index, slug)) {
+    resolved = slug;
+  } else {
+    const basename = slug.split('/').pop();
+    const basenameMap = buildBasenameToPathMap(docsDir);
+    resolved = basenameMap.get(basename) ?? slug;
+  }
+
+  dirCache.set(slug, resolved);
+  return resolved;
 }
 
 /**

--- a/scripts/lib/source_parity_extract.mjs
+++ b/scripts/lib/source_parity_extract.mjs
@@ -1,6 +1,6 @@
 /** Markdown structure extraction and parsing functions for source parity analysis. */
 import { extractSlug as extractSlugFromUrl } from './madcap_toc.mjs';
-import { buildBasenameToPathMap, buildSlugIndex } from './project.mjs';
+import { resolveToFullSlug } from './project.mjs';
 import { FENCE_LINE_RE } from './source_parity_types.mjs';
 
 const IMAGE_PATTERNS = [
@@ -503,50 +503,8 @@ export function extractHtmlTables(body) {
   return tables;
 }
 
-/**
- * Resolve a (possibly relative / basename-only) slug to the full slug that
- * exists in the docs tree.
- *
- * MadCap が emit する相対リンク `href="category/page.htm"` は、当該ページの
- * 親ディレクトリを省いた形で extractor に届く。例えば
- * `salesforce-testing/faq.htm` の中にある
- * `<a href="salesforce-steps/sfdc-step-apex-action.htm">` は
- * `salesforce-steps/sfdc-step-apex-action` として届き、これは docs tree 上の
- * 正式 slug ではない (正しくは `salesforce-testing/salesforce-steps/...`)。
- *
- * 解決順:
- *   1. slug が docs index に既に存在するなら、そのまま返す (正式 full path)
- *   2. そうでなければ basename lookup を試す (unique basename のときだけ
- *      fallback。ambiguous basename は null なので safe に原 slug を返す)
- *
- * Issue #247 re-review 第三弾 — この関数は `extractInvariantTokens` →
- * `createSegment` の hot path で呼ばれるため、同じ slug を何千回も resolve
- * することになる。戻り値を Map で memoize し、backing の `buildSlugIndex` /
- * `buildBasenameToPathMap` もそれぞれ docsDir-keyed cache を持つので、
- * 2 回目以降は純粋に Map lookup のみで済む。`resetProjectCachesForTest` で
- * 上流 cache がクリアされる場面ではこの Map も同期クリアする必要がある
- * が、現状 production / main loop では不要。
- *
- * @param {string} slug
- * @returns {string}
- */
-const _resolveToFullSlugCache = new Map();
-function resolveToFullSlug(slug) {
-  const cached = _resolveToFullSlugCache.get(slug);
-  if (cached !== undefined) return cached;
-  const index = buildSlugIndex();
-  let resolved;
-  if (slug in index) {
-    resolved = slug;
-  } else {
-    const map = buildBasenameToPathMap();
-    const basename = slug.split('/').pop();
-    resolved = map.get(basename) ?? slug;
-  }
-  _resolveToFullSlugCache.set(slug, resolved);
-  return resolved;
-}
-
+// Relative `.htm` links can omit parent segments, so normalize them through the
+// project-level slug resolver before comparing invariant URL tokens.
 function normalizeUrlToken(url) {
   if (url.match(/^https?:\/\/docs\.tricentis\.com\/testim\/content\//)) {
     const slug = extractSlugFromUrl(url.replace(/[?#].*$/, ''));


### PR DESCRIPTION
## Summary
- move `resolveToFullSlug()` into `scripts/lib/project.mjs` so its cache is owned by the project-level cache layer
- clear the slug-resolution cache from `resetProjectCachesForTest()` to restore the test-only full-reset contract
- add regression tests for exact slug resolution, basename fallback, and stale-cache invalidation after a temp docs tree mutation

## Validation
- `node --test scripts/__tests__/lib_project.test.mjs scripts/__tests__/source_parity.test.mjs`
- `npm test`
- `node scripts/check_source_parity.mjs --json`