### PR TITLE
fix: eliminate paragraph-count false positives, surface baseline debt in Issue

### DIFF
--- a/scripts/__tests__/source_parity.test.mjs
+++ b/scripts/__tests__/source_parity.test.mjs
@@ -1224,6 +1224,12 @@ describe('extractBulletCounts', () => {
     assert.equal(result.get('Section'), 2);
   });
 
+  it('counts image+unordered-list concatenation as a bullet (turndown artifact)', () => {
+    const body = '## Section\n![](images/foo.png)- Bullet item\n';
+    const result = extractBulletCounts(body);
+    assert.equal(result.get('Section'), 1);
+  });
+
   it('excludes bullets inside code blocks', () => {
     const body = '## Section\n- Real item\n```\n- Fake item\n```\n';
     const result = extractBulletCounts(body);
@@ -1296,6 +1302,12 @@ describe('extractStepCounts edge cases', () => {
     assert.equal(result.get('Section'), 1);
   });
 
+  it('counts image+ordered-list concatenation as a step (turndown artifact)', () => {
+    const body = '## Section\n![](images/foo.png)3. Step three\n';
+    const result = extractStepCounts(body);
+    assert.equal(result.get('Section'), 1);
+  });
+
   it('resets callout state at heading boundary', () => {
     const body = '## Section A\n:::note\nUnclosed note\n## Section B\n1. Step one\n';
     const result = extractStepCounts(body);
@@ -1358,6 +1370,22 @@ describe('section-count-mismatch', () => {
     const issues = compareSnapshotStructure(en, ja);
     const sectionIssues = issues.filter((i) => i.type === 'section-count-mismatch');
     assert.equal(sectionIssues.length, 0);
+  });
+
+  it('does not emit step-count mismatch for image+ordered-list concatenation', () => {
+    const en = '# Title\n## Steps\n![](images/foo.png)3. Item one\n';
+    const ja = '## Steps\n3. Item one\n';
+    const issues = compareSnapshotStructure(en, ja);
+    const stepIssues = issues.filter((i) => i.type === 'step-count-mismatch');
+    assert.equal(stepIssues.length, 0);
+  });
+
+  it('does not emit bullet-count mismatch for image+unordered-list concatenation', () => {
+    const en = '# Title\n## Bullets\n![](images/foo.png)- Bullet one\n';
+    const ja = '## Bullets\n- Bullet one\n';
+    const issues = compareSnapshotStructure(en, ja);
+    const bulletIssues = issues.filter((i) => i.type === 'bullet-count-mismatch');
+    assert.equal(bulletIssues.length, 0);
   });
 
   it('counts H4 headings in section count', () => {

--- a/scripts/__tests__/source_parity.test.mjs
+++ b/scripts/__tests__/source_parity.test.mjs
@@ -2109,6 +2109,24 @@ describe('classifyLine', () => {
     const result = classifyLine(':::');
     assert.equal(result.kind, 'paragraph-start');
   });
+
+  it('classifies image+ordered-list concatenation as ordered-list (turndown artifact)', () => {
+    const result = classifyLine('![](images/bc293ae-image.png "image.png")3.  If you have already registered');
+    assert.equal(result.kind, 'ordered-list');
+    assert.equal(result.nextState.inParagraph, false);
+  });
+
+  it('classifies image+unordered-list concatenation as unordered-list (turndown artifact)', () => {
+    const result = classifyLine('![](images/foo.png)- Bullet item text');
+    assert.equal(result.kind, 'unordered-list');
+    assert.equal(result.nextState.inParagraph, false);
+  });
+
+  it('classifies image+plain-text concatenation as paragraph-start (unchanged)', () => {
+    const result = classifyLine('![](images/foo.png)Some trailing text');
+    assert.equal(result.kind, 'paragraph-start');
+    assert.equal(result.nextState.inParagraph, true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -716,6 +716,10 @@ function buildParityFollowupBody({
   advisoryQueueScope,
   includeAdvisoryInBody,
   sourceUnusable,
+  baselinedIssues = 0,
+  baselinedFiles = 0,
+  baselinedByType = {},
+  topBaselinedPages = [],
 }) {
   const lines = [
     '## サマリー',
@@ -735,6 +739,31 @@ function buildParityFollowupBody({
       `  - ブロッキング: ${blockingAdvisoryItems.length}`,
       '',
     );
+  }
+
+  if (baselinedIssues > 0) {
+    const sortedTypes = Object.keys(baselinedByType).sort();
+    lines.push(
+      '## ベースライン残債',
+      '',
+      `- 合計: ${baselinedIssues} 件 (${baselinedFiles} ファイル)`,
+      '- EN 原文との既知の構造差分です。翻訳を修正して返済してください。',
+    );
+    if (sortedTypes.length > 0) {
+      lines.push('- 種別別:');
+      for (const type of sortedTypes) {
+        lines.push(`  - ${type}: ${baselinedByType[type]}`);
+      }
+    }
+    if (topBaselinedPages.length > 0) {
+      lines.push('', '### 上位ファイル', '');
+      lines.push(
+        formatList(
+          topBaselinedPages.map((p) => `\`${p.file}\` (${p.issueCount} 件)`),
+        ),
+      );
+    }
+    lines.push('');
   }
 
   // source-unusable は新規 issue を開く条件には含めず、本文だけに併記する。
@@ -856,10 +885,15 @@ function buildParityFollowup(parity, options = {}) {
     snapshotUnusableByType: summary.snapshotUnusableByType ?? {},
   };
 
+  const baselinedIssues = summary.baselinedIssues ?? 0;
+  const baselinedFiles = summary.baselinedFiles ?? 0;
+  const baselinedByType = summary.baselinedByType ?? {};
+
   const blockingAdvisoryItems = advisoryQueue.filter((e) => e.blocking);
   const hasBlockingAdvisory = isComplete === true && blockingAdvisoryItems.length > 0;
 
   const shouldOpenIssue =
+    baselinedIssues > 0 ||
     expiredBaselineEntries > 0 ||
     expiringBaselineEntries30d > 0 ||
     baselineInvalidatedSlugs.length > 0 ||
@@ -904,6 +938,8 @@ function buildParityFollowup(parity, options = {}) {
     tokenlessNearTieExamples: buildTokenlessNearTieExamples(advisoryQueue, maxEntries),
   };
 
+  const topBaselinedPages = buildTopBaselinedPages(files, maxEntries);
+
   const body = shouldOpenIssue
     ? withFamilyMarker(
         buildParityFollowupBody({
@@ -918,6 +954,10 @@ function buildParityFollowup(parity, options = {}) {
           advisoryQueueScope,
           includeAdvisoryInBody: isComplete === true,
           sourceUnusable,
+          baselinedIssues,
+          baselinedFiles,
+          baselinedByType,
+          topBaselinedPages,
         }),
         FAMILY_KEYS.PARITY_FOLLOWUP,
       )

--- a/scripts/lib/source_parity_extract.mjs
+++ b/scripts/lib/source_parity_extract.mjs
@@ -285,10 +285,20 @@ export function classifyLine(line, state = {}) {
     return { kind: 'unordered-list', nextState };
   }
   if (/^!\[/.test(trimmed) || /<img\b/i.test(trimmed) || /<Image\b/.test(trimmed)) {
-    // 画像記法の後ろに本文が続く行は paragraph-start として数える。
+    // 画像記法の後ろに本文が続く行の分類。turndown が `![](img)3.  text`
+    // のように画像とリスト項目を 1 行に連結することがあるため、後続部分の
+    // 構造を判定してリスト / 段落を正しく分類する。
     if (/^!\[/.test(trimmed)) {
-      const afterImage = trimmed.replace(/^!\[[^\]]*\]\([^)]*(?:\s+"[^"]*")?\)\s*/, '');
+      const afterImage = trimmed.replace(/^!\[[^\]]*\]\([^)"]*(?:\s+"[^"]*")?\)\s*/, '');
       if (afterImage.length > 0 && !/^!\[/.test(afterImage)) {
+        if (/^\d+(?:\\)?\.\s/.test(afterImage)) {
+          nextState.inParagraph = false;
+          return { kind: 'ordered-list', nextState };
+        }
+        if (/^[-*+]\s/.test(afterImage)) {
+          nextState.inParagraph = false;
+          return { kind: 'unordered-list', nextState };
+        }
         nextState.inParagraph = true;
         return { kind: 'paragraph-start', nextState };
       }

--- a/scripts/lib/source_parity_extract.mjs
+++ b/scripts/lib/source_parity_extract.mjs
@@ -74,6 +74,13 @@ export function extractCalloutPositions(body) {
   return callouts;
 }
 
+function extractTrailingContentAfterLeadingMarkdownImage(line) {
+  if (!/^!\[/.test(line)) return null;
+  const afterImage = line.replace(/^!\[[^\]]*\]\([^)"]*(?:\s+"[^"]*")?\)\s*/, '');
+  if (afterImage.length === 0 || /^!\[/.test(afterImage)) return null;
+  return afterImage;
+}
+
 export function extractStepCounts(body) {
   const lines = body.split('\n');
   const sections = new Map();
@@ -111,7 +118,8 @@ export function extractStepCounts(body) {
       continue;
     }
 
-    if (!inCallout && /^\d+(?:\\)?\.\s/.test(line)) {
+    const listCandidate = extractTrailingContentAfterLeadingMarkdownImage(trimmed) ?? line;
+    if (!inCallout && /^\d+(?:\\)?\.\s/.test(listCandidate)) {
       sections.set(currentSection, (sections.get(currentSection) || 0) + 1);
     }
   }
@@ -201,7 +209,9 @@ export function extractBulletCounts(body) {
       continue;
     }
 
-    if (!inCallout && /^[-*+]\s/.test(trimmed)) {
+    const listCandidate =
+      extractTrailingContentAfterLeadingMarkdownImage(trimmed) ?? trimmed;
+    if (!inCallout && /^[-*+]\s/.test(listCandidate)) {
       sections.set(currentSection, (sections.get(currentSection) || 0) + 1);
     }
   }
@@ -289,8 +299,8 @@ export function classifyLine(line, state = {}) {
     // のように画像とリスト項目を 1 行に連結することがあるため、後続部分の
     // 構造を判定してリスト / 段落を正しく分類する。
     if (/^!\[/.test(trimmed)) {
-      const afterImage = trimmed.replace(/^!\[[^\]]*\]\([^)"]*(?:\s+"[^"]*")?\)\s*/, '');
-      if (afterImage.length > 0 && !/^!\[/.test(afterImage)) {
+      const afterImage = extractTrailingContentAfterLeadingMarkdownImage(trimmed);
+      if (afterImage) {
         if (/^\d+(?:\\)?\.\s/.test(afterImage)) {
           nextState.inParagraph = false;
           return { kind: 'ordered-list', nextState };


### PR DESCRIPTION
## Summary

- **classifyLine 偽陽性修正**: turndown が `![](img.png)3.  text` のように画像+リスト項目を1行に連結する出力を `paragraph-start` と誤分類していた問題を修正。後続テキストのリストパターンを判定して `ordered-list` / `unordered-list` として正しく分類。画像 URL 正規表現の title 内 `)` 問題も修正
- **parity-followup Issue にベースライン残債を表示**: `shouldOpenIssue` に `baselinedIssues > 0` 条件を追加。Issue body に種別別内訳・上位ファイル一覧を含む「ベースライン残債」セクションを追加し、1,104件の既知 EN/JA 構造差分を可視化
- 監査シグナル: 50件 → 26件（24件の偽陽性を解消）。残り26件は全て baselined segment-level issues でカバー済み

## Test plan

- [x] `npm test` — 全1673テスト通過
- [x] `npm run build` — ビルド成功
- [x] `npm run check:parity` — 監査シグナル 50→26 に削減確認
- [x] `npm run check:summary -- --strict` — `parityFollowup.shouldOpenIssue: true` 確認
- [ ] scheduled-actionable ワークフロー実行後、parity-followup Issue が作成されることを確認