### PR TITLE
refactor: Phase 4 PR A — mechanism infrastructure (pre-cutover)

### DIFF
--- a/docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md
+++ b/docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md
@@ -1,449 +1,1492 @@
-# Parity Phase 4 — Schema 簡素化 + 残存整理 Plan
+# Parity Phase 4 — Final Cutover Implementation Plan (Revision 6)
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (inline batch with checkpoints). Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`). Worktree: `noble-squishing-bee` / branch: `worktree-noble-squishing-bee`.
 
-**Goal:** Phase 3 完了後の残 baseline (推定 10-20 件の `segment-inconclusive` + `segment-order-mismatch` + 潜在的 EN-side artifact) を最終整理し、`parity-baseline.json` schema を "allowlist" 前提から "bug backlog" 前提にリファクタする。micro-exclusion 層の必要性も残件を見て判断する。
+**Goal:** Phase 4 を「最終 cutover」として parity 運用の数値状態をすべて 0 に落とす。`parity-baseline.json.entries = 0`、`summary.baselinedIssues = 0`、`summary.advisoryQueueIssues = 0`、`summary.auditSignalIssues = 0`、`snapshot-diff-status.summary.{changed, added, removed} = 0`。残る EN-side artifact / URL normalizer ターゲット / intentional divergence は checker 側で吸収する。schema を v1→v2 に atomic cutover し、baseline 契約から非 JA-actionable な type (`segment-inconclusive` / `snapshot-incomplete` / `source-unusable`) を除外する。
 
-**Architecture:** 1 PR、単独 worktree。(a) 残 inconclusive の個別判断 → (b) micro-exclusion 必要性判定 → (c) schema migration (`reviewAfter` 等削除) → (d) `source_parity_baseline.mjs` リファクタ → (e) 運用ドキュメント最終更新。
+**Architecture:** 1 PR / 1 worktree。順序: (0) DoD 再定義 → (1) 5-bucket 残件実測 (JSON + md) → (2) parity_artifact_registry (slug-scope token + runtime coverage aggregator) + `alignSegments({slug, coverage})` への全呼出更新 → (3) URL normalizer 対称化 → (4) HTML extractor (`preprocessHtml`) で EN blockquote→callout 限定正規化 → (5) 残 baseline を 0 まで解消 → (6) schema v2 atomic cutover (types / loader / generator / advisory / summary / check / issue_state / detection_reports / status / migration / tests) → (7) docs 最終化 (scripts/README.md を含む) → (8) E2E JSON assertion → report → push → PR。
 
-**Tech Stack:** Node.js 20, 既存パイプライン + migration test。
-
-**Prerequisite:** Phase 3 がマージ済み、baseline が最新。
-
-**File ownership map:**
-- `parity-baseline.json` — schema migration
-- `scripts/lib/source_parity_baseline.mjs` — allowlist 前提コード除去
-- `scripts/lib/source_parity_types.mjs` — 必要に応じて型定義更新
-- `scripts/__tests__/source_parity_baseline.test.mjs` — schema migration test 追加
-- `scripts/phase4/migrate_baseline_schema.mjs` — migration スクリプト (新規、one-shot)
-- `docs/OPS_DESIGN.md` — 最終運用記述更新
-- `docs/PARITY_GUIDE.md` — 最終運用記述更新
-- `docs/superpowers/specs/2026-04-14-parity-phase4-report.md` — 完了レポート (新規、最終)
-- `scripts/lib/parity_token_exclusions.mjs` — micro-exclusion 層 (残件次第で新規作成、条件付き)
-
-**Worktree:** `worktree-phase4-schema-cleanup`
+**Tech Stack:** Node.js 20, node:test。
 
 ---
 
-## Task 4.1: 残 inconclusive / order-mismatch の個別判断
+## Execution Strategy — PR 分割 (2026-04-15 追記)
 
-**Files:**
-- 各該当 slug の md (1-20 件程度)
+本 plan Rev 6 は **PR Z (final cutover)** の contract 定義として維持する。
+ただし Task 4.1 inventory 実測で判明した baseline 1873 entries のうち
+~1851 件が JA 側翻訳 / 整合性修正を要する actionable entries であり、
+1 セッション / 1 PR での完遂は非現実的であることが明らかになった。
+よって実行は 3 段階に分割する。
 
-- [ ] **Step 1: 残 entry 一覧化**
+### PR A — Pre-Cutover Mechanism Infrastructure
 
-```bash
-node -e "
-const b = require('./parity-baseline.json');
-const residual = b.entries.filter(e => ['segment-inconclusive', 'segment-order-mismatch'].includes(e.issueType));
-console.log('Residual: ' + residual.length);
-for (const e of residual) {
-  console.log(e.issueType + ' | ' + e.slug + ' | section: ' + e.sectionPath);
-  if (e.inconclusiveReason) console.log('  reason: ' + e.inconclusiveReason);
-}
-" > /tmp/phase4-residual.md
-cat /tmp/phase4-residual.md
+本 worktree (`noble-squishing-bee`) のスコープ。Task 4.0–4.4 のみを入れ、
+baseline / schema / docs 運用は現状のまま残す (schema v1 維持)。
+
+- Task 4.0: DoD 再定義 + final-goal.md
+- Task 4.1: 5-bucket residual inventory
+- Task 4.2: parity_artifact_registry + alignSegments({slug, coverage}) 全呼出移行
+- Task 4.3: URL normalizer 対称化
+- Task 4.4: preprocessHtml で EN blockquote→callout-note 限定正規化
+
+成果: runtime で artifact 抑止 / URL 対称化 / extractor 正規化が発火する状態
+になる。baseline 再生成 (非必須) を行えば、mechanism で自動解消される ~10 件
+(artifact 7 + extractor 3) が orphan 化する。schema migration は PR Z。
+
+### 中間 PRs — Bulk Remediation (multi-session / multi-PR)
+
+別 plan `docs/superpowers/plans/2026-04-15-parity-bulk-remediation.md` に従い、
+新規 worktree を per-Stage で切って以下 bucket を順次消化する:
+
+- segment-untranslated 1571 件 (LLM pipeline 優先)
+- segment-missing 107 件
+- segment-extra 87 件
+- section-structure-mismatch 56 件
+- segment-token-gap 残 ~39 件
+- advisoryResidual (segment-inconclusive) 11 件
+
+### PR Z — Final Cutover
+
+baseline が十分に薄くなってから (目標: advisoryResidual ~10 件未満) 新しい
+worktree で Task 4.5–4.8 を実行する:
+
+- Task 4.5: 残 baseline entries=0 + status 4 counter=0
+- Task 4.6.1–4.6.3: schema v1→v2 atomic cutover (types / loader / generator /
+  advisory / summary / issue_state / detection_reports / check / migration)
+- Task 4.7: 運用 docs 最終化 (scripts/README.md 含む)
+- Task 4.8: E2E 5 counter 0 検証 + report + push + PR
+
+この時点で Rev 6 の 5-counter 0 DoD を完全達成する。
+
+### PR 境界の理由
+
+1. **atomic cutover 規律**: schema v2 migration は baseline.entries=0 を前提
+   に設計されている (`feedback_parity_phase_discipline` memory #2)。bulk
+   remediation を同一 PR に混ぜると、翻訳 regression が schema migration を
+   巻き込む危険がある。
+2. **review 性**: 1500+ translation diff と runtime / schema 変更が同一 PR
+   だと意味のある review が不可能。
+3. **rollback 単位**: mechanism 変更 / bulk translation / schema migration は
+   それぞれ異なる failure mode を持ち、独立 rollback できるべき。
+
+---
+
+## Context — Review 2 findings (Rev 5 → Rev 6) と対応
+
+| # | Finding | Rev 6 の対応 |
+|---|---|---|
+| 1 | Rev 5 の empty baseline default test は `checkSourceParity()` 戻り値を status として読んでいた。実際は `outputPath` に JSON 書き出し、戻り値は exit code | test を `outputPath` + tmp dir + `readFileSync` で payload を読む形に具体化。実装側は `status.debug.baselineSchemaVersion = baselineData.schemaVersion` を追加 |
+| 2 | Task 4.6.3 で参照していた `source_parity_summary.test.mjs` は存在せず、実在は `source_parity_summary_format.test.mjs` | owner / `git add` を実在 file 名に統一 |
+
+---
+
+## Context — Review 4 findings (Rev 4 → Rev 5) と対応
+
+| # | Finding | Rev 5 の対応 |
+|---|---|---|
+| 1 | `source_parity_baseline_recall.test.mjs` が schema cutover ownership から漏れ、v2 契約に適合しない (`segment-inconclusive` / `inconclusiveReason` / `reviewAfter` を前提) | **Task 4.6.1** ownership に追加、v2 eligible type への差し替え / 削除を明記 |
+| 2 | Rev 4 の `loadBaselineFileSafe returns v2 empty` test は private helper を直接 import している。現物は export していない | Rev 5 は public behavior 経由 (`checkSourceParity({ baselinePath: '/nonexistent' })` と `status.debug.baselineSchemaVersion` で検証) に変更 |
+| 3 | Task 4.7 Step 5 の "本 Rev 3 内容で上書き" が過去 Rev 参照 | "本 Rev 4 内容で上書き" → Rev 5 では本ファイル最終状態を意味 |
+| 4 | bucket 数 (4-bucket vs 5 実装) / test 数 (8 vs 7) の表現ズレ | "5-bucket" と "7 tests" に全面統一 |
+
+---
+
+## Context — Review 6 findings (Rev 3 → Rev 4) と対応
+
+| # | Finding | Rev 4 の対応 |
+|---|---|---|
+| 1 | `scripts/__tests__/generate_parity_baseline.test.mjs` (1014 行、41×`reviewAfter` / 6×`segment-inconclusive` / 4×`schemaVersion`) が Task 4.6.2 ownership から漏れている | **Task 4.6.2** ownership に明示追加、更新項目をチェックリスト化 |
+| 2 | `scripts/lib/parity_check_status.mjs` / `scripts/__tests__/parity_check_status.test.mjs` は repo に**存在しない**。Rev 3 は実在しない file を commit に列挙 | Rev 4 は status 書き出しを `check_source_parity.mjs` に寄せ、status shape test は既存 `check_source_parity.test.mjs` / `detection_reports.test.mjs` を更新対象にする。新 file は作らない |
+| 3 | EN extractor の public API は `extractSegmentsFromHtml` (L595)、既存 test は `segmentKind === 'callout-body'`。Rev 3 の `extractEnSegments` / `kind === 'callout'` は現実装と不整合 | **Task 4.4** を `extractSegmentsFromHtml(html, options)` signature 拡張 + `segmentKind === 'callout-body'` assertion に書き換え。caller (`check_source_parity.mjs:453`) を ownership 追加 |
+| 4 | Task 4.2 Step 1 の RED test は `http://google.com` 等の具体 entry 前提だが Step 2 は空 registry を返す。順序矛盾 | **Task 4.2** を 2 段に分割: 先に shape / empty / coverage aggregator を通す → inventory 反映後に具体 exclusion test を追加 |
+| 5 | `check_source_parity.mjs:300-302, 342` の empty baseline default が `{ schemaVersion: 1, entries: [] }`。v2 cutover 後もこの既定値が残ると schema 契約が崩れる | **Task 4.6.1** に `loadBaselineFileSafe()` の empty return を `{ schemaVersion: 2, entries: [] }` へ変更 / `baselineData` init も v2 に統一する task を明記 (acknowledgements の v1 既定は不触) |
+| 6 | `callout-normalization-slugs` を docs (`final-goal.md`) と code (`CALLOUT_NORMALIZATION_SLUGS`) の両方に書くと二重管理 | **Task 4.4** で code 側 `CALLOUT_NORMALIZATION_SLUGS` を single source of truth と宣言、docs は参照 / 説明のみ (値を docs には書かない) |
+
+---
+
+## Context — Rev 2 → Rev 3 で解消済み findings (履歴)
+
+| # | Finding | Rev 3 の対応 |
+|---|---|---|
+| 1 | `snapshot-diff-status` の field は `summary.{changed, added, removed, unchanged}` (確認: `scripts/snapshot_diff.mjs:399-407`)。Rev 2 は `deleted` / top-level を使用 | **DoD / Task 4.1 / Task 4.8** を `summary.changed/added/removed = 0` に統一 |
+| 2 | `source_parity_segments_en.mjs` は HTML 直接抽出 (`preprocessHtml` L44 / `walkBlock` L411)。MD `^>` ベースの正規化は入らない | **Task 4.4** を HTML layer の `preprocessHtml()` 拡張に書き直す。fixture は HTML 入力 |
+| 3 | api-access の実 slug は `administration/api-access` (md: `src/content/docs/administration/api-access.md` / snapshot: `snapshots/en/content/administration/api-access.html`) | **Task 4.1 / 4.4** 全参照を `administration/api-access` に統一 |
+| 4 | `alignSegments(` は 10 file で call (`source_parity_align.mjs` / `check_source_parity.mjs` + 8 tests)。Rev 2 は test 1 本しか修正せず他は 2 引数のまま壊れる | **Task 4.2** owner に 8 test 全件追加、最後に `grep -n "alignSegments\\s*(" scripts/ \| grep -v "{ slug"` が 0 件を確認する gate step を追加 |
+| 5 | `baselineExpired` / `isFrozenByBaseline` は 12 file (lib 5 + check + 6 tests)。Rev 2 は 4 file のみ列挙 | **Task 4.6.3** owner に `source_parity_issue_state.mjs` + 4 tests を追加。`isFrozenByBaseline(issue) === (issue.baselined === true)` に縮約する契約を明記 |
+| 6 | `debug.artifactCoverage` の contract は「この run で何件抑止したか」が traceable。Rev 2 は静的 `{entries, bySlug}` のみで runtime 集計がない | **Task 4.2** に `createArtifactCoverage()` (runtime aggregator) を新設。`alignSegments({slug, coverage})` で `coverage.record()` を叩き、`check_source_parity` が `status.debug.artifactCoverage = coverage.snapshot()` を出力 (shape: `{ registryEntries, matchedHits, bySlug, byToken }`) |
+| 7 | Rev 2 の `KNOWN_ARTIFACT_URL_PATTERNS` に `help.testim.io` を入れると Task 4.3 の normalizer 対象が artifact に誤送される | **Task 4.1 classify_residual** の bucket を 4 種 (`actionable` / `artifactCandidates` / `normalizerCandidates` / `intentionalDivergenceCandidates`) に分離 |
+| 8 | `option A` で runtime `inconclusiveReason` は残る方針。grep が必ずヒット。`scripts/README.md` に `reviewAfter` 言及あり (Rev 2 owner に未掲載) | **Task 4.8 Step 6** の grep scope を `scripts/lib scripts/check_source_parity.mjs docs/OPS_DESIGN.md docs/PARITY_GUIDE.md scripts/README.md` に限定し、対象 field も `reviewAfter / baselineReviewAfter / baselineExpired` のみ。`inconclusiveReason` は runtime 残存 (deprecated check から外す)。**Task 4.7** owner に `scripts/README.md` を追加 |
+
+---
+
+## 最終 DoD (Definition of Done)
+
+以下すべてが true であること:
+
+```
+# baseline
+parity-baseline.json.entries.length === 0
+parity-baseline.json.schemaVersion  === 2
+
+# parity-check-status.json
+summary.reportableActiveFiles === 0
+summary.baselinedIssues       === 0
+summary.advisoryQueueIssues   === 0
+summary.auditSignalIssues     === 0
+debug.artifactCoverage exists with keys { registryEntries, matchedHits, bySlug, byToken }
+
+# snapshot-diff-status.json
+summary.changed === 0 && summary.added === 0 && summary.removed === 0
+
+# schema / runtime
+BASELINE_ELIGIBLE_TYPES ⊆ { segment-missing, segment-extra, segment-shifted,
+                             segment-untranslated, segment-token-gap,
+                             section-structure-mismatch, segment-order-mismatch }
+(reviewAfter は baseline schema / runtime tagging / summary / queue どこにも存在しない)
+(baselineReviewAfter / baselineExpired は issue / queue / issue_state どこにも存在しない)
+(inconclusiveReason は runtime issue 側にのみ存在。baseline entry schema には存在しない)
+isFrozenByBaseline(issue) ≡ issue.baselined === true
+alignSegments は必ず { slug } option 付きで呼ばれる (grep 検証)
+
+# gates
+npm run test && npm run lint && npm run build が green
+npm run check:parity && npm run check:snapshots:diff が green
 ```
 
-- [ ] **Step 2: 各 entry を分類**
+---
 
-以下 3 つのいずれかに分類:
+## Schema v2 仕様 (最終形)
 
-1. **翻訳修正で解決可能**: segment 境界を揃える、順序を EN に合わせる等で解消
-2. **EN-side artifact**: EN 原文が曖昧で JA が正しい → `source_sync_exclusions.mjs` (page-level) 登録 or micro-exclusion 検討
-3. **真に曖昧**: 自動判定限界で残すしかない → baseline に残す (ただし `reviewAfter` なし、bug backlog フィールドに)
+### Entry fields
 
-- [ ] **Step 3: 分類 1 (翻訳修正) を適用**
+| field | v1 | v2 | 備考 |
+|---|---|---|---|
+| `slug` | ✓ | ✓ | identity |
+| `issueType` | ✓ | ✓ | identity |
+| `snapshotFingerprint` | ✓ | ✓ | page-scope invalidation |
+| `reviewAfter` | ✓ | **削除** | allowlist era 残滓 |
+| `sectionPath` | ✓ | ✓ | segment identity (structure 系除外) |
+| `segmentKind` | ✓ | ✓ | segment identity |
+| `enSegmentIndex` / `jaSegmentIndex` | ✓ | ✓ | segment identity |
+| `enSourceFingerprint` / `jaSourceFingerprint` | ✓ | ✓ | segment identity |
+| `missingTokens` | ✓ | ✓ | registry 適用後の残トークン |
+| `inconclusiveCategory` | ✓ | — | baseline 型集合から除外するため entry には不在。runtime issue で保持 |
+| `inconclusiveReason` | ✓ | — | 同上 (runtime issue のみ) |
+| `sectionIndex` / `structureCategory` / `structureFingerprint` | ✓ | ✓ | structure mismatch identity |
+| `usabilityReason` | ✓ | — | baseline 対象外 (snapshot-incomplete / source-unusable 除外) |
+| `priority` | ✗ | **追加** | `high` / `medium` / `low` (default=`medium`) |
+| `note` | ✗ | **追加** | 任意 free-text (max 500 chars) |
+| `schemaVersion` (root) | `1` | **`2`** | loader/validator で排他的に受理 |
 
-各該当 slug で修正を入れて commit:
-
-```bash
-git add src/content/docs/<slug>.md
-git commit -m "fix: Phase 4 inconclusive 修正 (<slug>, 分類1: 境界/順序調整)"
-```
-
-## Task 4.2: micro-exclusion 層の必要性判断
-
-**Context:** Phase 3 完了時点で残る EN-side artifact (baseline に残すには位置づけが曖昧、page-level exclusion では大粒すぎるもの) の件数を見て、micro-exclusion 層を作るかを判断する。Codex の指摘通り、**件数が少なければ汎用レイヤーは作らず個別対応**。
-
-### Task 4.2.1: EN-side artifact の件数確認
-
-- [ ] **Step 1: 現状の EN artifact 性質別件数**
-
-```bash
-node -e "
-const b = require('./parity-baseline.json');
-// WRITING_GUIDE §60 で明記されている EN 側 artifact 例
-const artifactSlugs = [
-  'advanced-editing/validations/validate-element-text',
-  'advanced-editing/configuration-file-parameters',
-  'getting-started/creating-your-first-codeless-test',
-];
-for (const slug of artifactSlugs) {
-  const e = b.entries.filter(x => x.slug === slug);
-  console.log(slug + ': ' + e.length + ' entries');
-  for (const ent of e) console.log('  ' + ent.issueType + ' | ' + ent.sectionPath);
-}
-"
-```
-
-### Task 4.2.2: 判定分岐
-
-- [ ] **Step 1: 件数に応じて対応を決定**
-
-- **残 EN-artifact が 0-5 件**: micro-exclusion 層を作らない。個別に `source_sync_exclusions.mjs` (page-level) 登録 or baseline 個別 entry として残す
-- **残 EN-artifact が 6-15 件で共通パターンあり**: micro-exclusion 層 (`parity_token_exclusions.mjs`) を新設する。以下の Task 4.2.3 を実施
-- **残 EN-artifact が 15+ 件**: Phase 3 で見逃しがある可能性。Phase 3 に差し戻し
-
-### Task 4.2.3 (条件付き): micro-exclusion 層を新設
-
-このタスクは Task 4.2.2 で "6-15 件で共通パターンあり" を選んだ場合のみ実施。
-
-**Files:**
-- Create: `scripts/lib/parity_token_exclusions.mjs`
-- Create: `scripts/__tests__/parity_token_exclusions.test.mjs`
-
-- [ ] **Step 1: registry を作成**
+### BASELINE_ELIGIBLE_TYPES (v2)
 
 ```js
-// scripts/lib/parity_token_exclusions.mjs
-/**
- * Token-level exclusion registry for EN-side artifacts that don't warrant
- * full page-level exclusion but produce noise in baseline.
- *
- * Same philosophy as source_sync_exclusions.mjs: human must explicitly register.
- * Auto-detection never populates this.
- */
-
-export const TOKEN_EXCLUSIONS = Object.freeze({
-  // 例: display text と href が一致しない EN artifact
-  'getting-started/creating-your-first-codeless-test': Object.freeze({
-    reason: 'en-side-artifact',
-    note: 'EN source has <a href="http://google.com">demo.testim.io</a> — display text is correct, JA uses the correct URL. token-gap for google.com is an EN artifact.',
-    expectedIssueType: 'segment-token-gap',
-    tokenPatterns: ['http://google.com', 'https://www.google.com'],
-    addedAt: '2026-04-14',
-    linkedIssue: null,
-  }),
-  // 必要に応じて追加
-});
-
-export function isTokenExcluded(slug, token) {
-  const entry = TOKEN_EXCLUSIONS[slug];
-  if (!entry) return false;
-  return entry.tokenPatterns.some((p) => token === p || token.includes(p));
-}
-
-export function listExclusions() {
-  return Object.entries(TOKEN_EXCLUSIONS).map(([slug, entry]) => ({
-    slug,
-    ...entry,
-  }));
-}
+export const BASELINE_ELIGIBLE_TYPES = Object.freeze(new Set([
+  'segment-missing', 'segment-extra', 'segment-shifted',
+  'segment-untranslated', 'segment-token-gap',
+  'section-structure-mismatch', 'segment-order-mismatch',
+]));
+export const TYPES_ARG_ALLOWLIST = Object.freeze(new Set([
+  'section-structure-mismatch', 'segment-order-mismatch',
+]));
 ```
 
-- [ ] **Step 2: test 作成**
+### `isFrozenByBaseline` 契約 (v2)
 
 ```js
-// scripts/__tests__/parity_token_exclusions.test.mjs
-import { before, describe, it } from 'node:test';
-import assert from 'node:assert/strict';
-
-let isTokenExcluded;
-
-before(async () => {
-  ({ isTokenExcluded } = await import('../lib/parity_token_exclusions.mjs'));
-});
-
-describe('parity_token_exclusions', () => {
-  it('excludes google.com artifact from creating-your-first-codeless-test', () => {
-    assert.equal(
-      isTokenExcluded('getting-started/creating-your-first-codeless-test', 'http://google.com'),
-      true,
-    );
-  });
-
-  it('does not affect unrelated slugs', () => {
-    assert.equal(
-      isTokenExcluded('editing-tests/steps', 'http://google.com'),
-      false,
-    );
-  });
-});
+// scripts/lib/source_parity_issue_state.mjs
+export function isFrozenByBaseline(issue) {
+  return issue.baselined === true;
+}
 ```
 
-- [ ] **Step 3: align.mjs の token-gap 判定に exclusion を組み込む**
+expiry logic (旧 `baselineExpired` / `reviewAfter` 参照) は全撤去。
 
-`scripts/lib/source_parity_align.mjs` の token-gap 比較箇所で `isTokenExcluded(slug, token)` をチェックし、excluded token は `missingTokens` に含めない。
+---
 
-- [ ] **Step 4: 対応する baseline entry を削除**
+## 重要ファイルマップ
 
-```bash
-node scripts/phase4/migrate_baseline_schema.mjs --remove-excluded-artifacts
-```
+### 新規
+- `scripts/lib/parity_artifact_registry.mjs` — static registry + `isArtifactExcluded` + `registryEntries` + `createArtifactCoverage()` (runtime aggregator)
+- `scripts/__tests__/parity_artifact_registry.test.mjs`
+- `scripts/phase4/classify_residual.mjs` — 5-bucket JSON 出力
+- `scripts/phase4/render_residual_inventory.mjs` — JSON → md
+- `scripts/phase4/migrate_baseline_schema.mjs` — one-shot v1→v2 migration (export)
+- `scripts/__tests__/baseline_schema_migration.test.mjs`
+- `docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md`
+- `docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.{json,md}`
+- `docs/superpowers/specs/2026-04-14-parity-phase4-report.md`
 
-(migrate スクリプトは Task 4.3 で作成)
+### 変更 (runtime — Task 4.2 ownership)
+- `scripts/lib/source_parity_align.mjs:527-577` — `alignSegments(enSections, jaSections, { slug, coverage })` 化、`isArtifactExcluded` + `coverage.record()` 注入
+- `scripts/check_source_parity.mjs` — `createArtifactCoverage()` 生成、`alignSegments` を `{ slug, coverage }` 付きで呼ぶ、`status.debug.artifactCoverage = coverage.snapshot()` をここで書き出す (新 module は作らない)
+- `scripts/__tests__/source_parity_align.test.mjs`
+- `scripts/__tests__/source_parity_align_runtime.test.mjs`
+- `scripts/__tests__/source_parity_recall.test.mjs`
+- `scripts/__tests__/source_parity_baseline_recall.test.mjs`
+- `scripts/__tests__/source_parity_structure_fixtures.test.mjs`
+- `scripts/__tests__/source_parity_clean_page_fixtures.test.mjs`
+- `scripts/__tests__/source_parity_source_usability_fixtures.test.mjs`
+- `scripts/phase2/lib/baseline.mjs` — re-export (import path: `../../lib/parity_artifact_registry.mjs`)
+- `scripts/phase2/enumerate_token_gaps.mjs` — registry 参照に更新 (あるいは archive)
 
-- [ ] **Step 5: test + commit**
+### 変更 (runtime — Task 4.3 / 4.4)
+- `scripts/lib/parity_normalize.mjs:11-37` — `help.testim.io#fragment` ↔ `/docs/...#fragment` 対称化
+- `scripts/__tests__/parity_normalize.test.mjs`
+- `scripts/lib/source_parity_segments_en.mjs:44, 595` — `preprocessHtml(html, options)` / `extractSegmentsFromHtml(html, options)` 双方を options 対応化。`CALLOUT_NORMALIZATION_SLUGS` 定数を export (allow list の single source of truth)
+- `scripts/check_source_parity.mjs:453` — EN extractor caller を `{ slug, calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS }` 付きで呼ぶ
+- `scripts/__tests__/source_parity_segments_en.test.mjs` — HTML fixture で `segmentKind === 'callout-body'` assertion
 
-```bash
-node --test scripts/__tests__/parity_token_exclusions.test.mjs
-git add scripts/lib/parity_token_exclusions.mjs scripts/__tests__/parity_token_exclusions.test.mjs scripts/lib/source_parity_align.mjs
-git commit -m "feat: parity_token_exclusions (micro-exclusion 層) を新設"
-```
+### 変更 (runtime — Task 4.6 schema cutover)
+- `scripts/lib/source_parity_types.mjs` — entry 型刷新 (priority/note 追加、reviewAfter/inconclusiveReason 削除)
+- `scripts/lib/source_parity_baseline.mjs:31-48, 52-72, 198-204, 233, 264, 269-282, 317-335, 405-440, 454, 460-552, 560-615` — BASELINE_ELIGIBLE_TYPES / TYPES_ARG_ALLOWLIST 縮約、v2 validator、expiry 関数削除、`tagIssuesWithBaseline` の `baselineReviewAfter/Expired` 撤去、priority/note 対応
+- `scripts/generate_parity_baseline.mjs:184-225, 262-282, 308, 500-533` — v2 出力、`--review-after` option 削除 (usage 文面更新)
+- `scripts/check_source_parity.mjs:78, 520, 615-620` — `baselineReviewAfter` 付与撤去
+- `scripts/lib/source_parity_advisory_queue.mjs:104-128` — queue entry から `baselineReviewAfter` / `baselineExpired` 削除。`inconclusiveReason` は runtime issue 直読みで残す (option A)
+- `scripts/lib/source_parity_summary.mjs:50-131` — `baselineExpired` / `baselineExpiringSoon` 集計撤去、`priorityCounts` 追加
+- `scripts/lib/source_parity_issue_state.mjs` — `isFrozenByBaseline(issue) === issue.baselined === true` に縮約、`baselineExpired` 参照全撤去
+- `scripts/lib/detection_reports.mjs` — `reviewAfter` / `baselineExpired` 参照削除
+- `scripts/__tests__/source_parity_baseline.test.mjs`
+- `scripts/__tests__/source_parity_advisory_queue.test.mjs`
+- `scripts/__tests__/source_parity_summary_format.test.mjs` (存在すれば)
+- `scripts/__tests__/source_parity_issue_state.test.mjs`
+- `scripts/__tests__/source_parity.test.mjs`
+- `scripts/__tests__/detection_reports.test.mjs`
+- `scripts/__tests__/check_source_parity.test.mjs`
+- `scripts/__tests__/source_parity_acknowledgements.test.mjs` (`baselineExpired` 参照があれば更新)
+- `scripts/__tests__/check_source_parity.test.mjs` (`status.debug.artifactCoverage` shape + v2 empty baseline default を既存 test に追記)
 
-## Task 4.3: baseline schema migration
+### 変更 (docs — Task 4.7)
+- `docs/superpowers/specs/2026-04-14-parity-burndown-roadmap.md:120-127`
+- `docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md` — 本 plan で置換
+- `docs/OPS_DESIGN.md`
+- `docs/PARITY_GUIDE.md`
+- `docs/WRITING_GUIDE.md`
+- `scripts/README.md` — `reviewAfter` 言及削除、v2 運用に更新
+
+### baseline
+- `parity-baseline.json` — v2 化、最終 entries=0
+
+---
+
+## Task 4.0: DoD 再定義 + artifact coverage 契約
 
 **Files:**
-- Create: `scripts/phase4/migrate_baseline_schema.mjs`
-- Modify: `parity-baseline.json`
-- Modify: `scripts/lib/source_parity_baseline.mjs`
-- Modify: `scripts/lib/source_parity_types.mjs` (必要に応じて)
+- Modify: `docs/superpowers/specs/2026-04-14-parity-burndown-roadmap.md:120-127`
+- Create: `docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md`
 
-**Context:** baseline schema から allowlist 前提のフィールドを削除し、bug backlog 前提に簡素化する。
+- [ ] **Step 1: roadmap DoD を 5 counter 0 に書き換え**
 
-### 削除対象フィールド
+上記 "最終 DoD" セクションを roadmap §5 に反映。`snapshot-diff-status.summary.{changed, added, removed} = 0` を明示。
 
-- `reviewAfter` — "方針再検討" 前提、bug backlog では不要
-- `inconclusiveCategory` / `inconclusiveReason` — Phase 0 で inconclusive 分岐が縮小、残件は自由記述の note で十分
-- `usabilityReason` — page-level exclusion へ責務移動済み
+- [ ] **Step 2: final-goal.md 作成**
 
-### 追加する推奨フィールド
-
-- `priority`: `high` / `medium` / `low` — bug backlog の burn-down 優先度
-- `note`: string — 自由記述 (任意)
-
-### Task 4.3.1: migration スクリプト作成
-
-- [ ] **Step 1: migration スクリプト**
-
-```js
-// scripts/phase4/migrate_baseline_schema.mjs
-/**
- * Phase 4: baseline schema migration.
- *
- * Removes allowlist-era fields (reviewAfter, inconclusiveCategory,
- * inconclusiveReason, usabilityReason) and adds bug-backlog fields
- * (priority default=medium).
- */
-
-import { readFileSync, writeFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const REPO_ROOT = join(__dirname, '../..');
-const BASELINE_PATH = join(REPO_ROOT, 'parity-baseline.json');
-
-const DROP_FIELDS = new Set([
-  'reviewAfter',
-  'inconclusiveCategory',
-  'inconclusiveReason',
-  'usabilityReason',
-]);
-
-function migrate(oldEntry) {
-  const migrated = {};
-  for (const [k, v] of Object.entries(oldEntry)) {
-    if (!DROP_FIELDS.has(k)) migrated[k] = v;
-  }
-  if (!migrated.priority) migrated.priority = 'medium';
-  return migrated;
-}
-
-function main() {
-  const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
-  const migrated = {
-    ...baseline,
-    schemaVersion: 2, // bump
-    generatedAt: new Date().toISOString(),
-    rationale: 'Phase 4: schema migration to bug-backlog model',
-    entries: baseline.entries.map(migrate),
-  };
-  writeFileSync(BASELINE_PATH, JSON.stringify(migrated, null, 2));
-  console.log('Migrated ' + migrated.entries.length + ' entries to schema v2');
-}
-
-main();
-```
-
-- [ ] **Step 2: migration の RED → GREEN test**
-
-`scripts/__tests__/baseline_schema_migration.test.mjs` を新規作成:
-
-```js
-import { describe, it } from 'node:test';
-import assert from 'node:assert/strict';
-
-describe('baseline schema migration', () => {
-  it('removes reviewAfter, inconclusiveCategory, inconclusiveReason, usabilityReason', () => {
-    // migration 関数を export して単体 test
-    // (migrate_baseline_schema.mjs から migrate() を export)
-  });
-
-  it('adds priority=medium default', () => {
-    // ...
-  });
-
-  it('preserves all other fields', () => {
-    // ...
-  });
-});
-```
-
-(migration スクリプトから `migrate()` を export して単体 test で pin)
-
-### Task 4.3.2: migration 実行 + test 更新
-
-- [ ] **Step 1: migration 実行**
-
-```bash
-node scripts/phase4/migrate_baseline_schema.mjs
-```
-
-- [ ] **Step 2: 既存 test を新 schema に合わせて更新**
-
-`scripts/__tests__/source_parity_baseline.test.mjs` で `reviewAfter` / `inconclusiveCategory` / `usabilityReason` を参照している箇所を削除。`priority` を使うように更新。
-
-- [ ] **Step 3: `source_parity_baseline.mjs` の allowlist コード除去**
-
-- `BASELINE_ELIGIBLE_TYPES` のドキュメント修正 (allowlist 前提の記述 → bug backlog 前提)
-- `reviewAfter` による match ロジック (もしあれば) を削除
-- identity key 生成から削除フィールドを除外
-
-- [ ] **Step 4: test + commit**
-
-```bash
-npm run test 2>&1 | tail -20
-git add parity-baseline.json scripts/phase4/migrate_baseline_schema.mjs scripts/lib/source_parity_baseline.mjs scripts/__tests__/*.mjs
-git commit -m "refactor: Phase 4 baseline schema v2 migration (allowlist -> bug backlog)"
-```
-
-## Task 4.4: 運用ドキュメント最終更新
-
-**Files:**
-- Modify: `docs/OPS_DESIGN.md`
-- Modify: `docs/PARITY_GUIDE.md`
-
-- [ ] **Step 1: OPS_DESIGN.md を burn-down 完了後の定常運用に更新**
-
-- Baseline は完全に bug backlog、新規 issue は baseline に入れず修正 or page-level/token-level exclusion で対応
-- `reviewAfter` による期日管理は廃止、`priority` による優先度管理
-- 新規コンテンツ追加時は parity check が green であることが gate
-
-- [ ] **Step 2: PARITY_GUIDE.md を最終化**
-
-- §残債返済優先順位 → §Bug backlog の優先度管理 に改題
-- 完了後の定常運用セクションを追加
+内容:
+- 5 カウンタ 0 DoD の根拠と測定方法 (JSON 参照先フィールド確定)
+- runtime 検出 3 枠: actionable-baseline / parity-artifact-registry / advisory-residual
+- `debug.artifactCoverage` 契約: `{ registryEntries, matchedHits, bySlug, byToken }` (runtime aggregate)
+- `debug.maskCoverage` は glossary/invariant mask 専用、artifact とは分離 (Phase 0 契約再掲)
+- intentional divergence は HTML extractor (`preprocessHtml`) の slug-allow-list 限定 rule で吸収 (turndown singleton 非侵襲)
+- page-level exclusion (`source_sync_exclusions.mjs`) は壊れた page の lock のみ
+- **callout-normalization** section を作り、仕組みの説明のみ記載。slug 値は docs に書かず、`scripts/lib/source_parity_segments_en.mjs` の `CALLOUT_NORMALIZATION_SLUGS` が single source of truth と明記 (Finding 6)
 
 - [ ] **Step 3: commit**
 
 ```bash
-git add docs/OPS_DESIGN.md docs/PARITY_GUIDE.md
-git commit -m "docs: Phase 4 burn-down 完了後の定常運用に更新"
-```
-
-## Task 4.5: 最終 E2E 確認 + PR
-
-- [ ] **Step 1: 全テスト + lint + build + parity**
-
-```bash
-npm run test 2>&1 | tail -20
-npm run lint 2>&1 | tail -20
-npm run build 2>&1 | tail -20
-npm run check:parity 2>&1 | tail -20
-```
-
-Expected: all green。baseline entries は ~10 件以下の inconclusive + priority 管理のみ。
-
-- [ ] **Step 2: PR 作成**
-
-```bash
-git push -u origin worktree-phase4-schema-cleanup
-gh pr create --title "refactor: Phase 4 baseline schema 簡素化 + burn-down 完了" --body "## Summary
-
-Parity baseline の burn-down 最終 Phase。
-
-- 残 inconclusive/order-mismatch を個別解消 (??? 件)
-- micro-exclusion 層 (parity_token_exclusions.mjs) を ??? 件の EN-artifact で新設 (or 省略)
-- baseline schema v1 -> v2 migration (reviewAfter, inconclusiveCategory, inconclusiveReason, usabilityReason を削除、priority を追加)
-- source_parity_baseline.mjs の allowlist 前提コードを bug backlog 前提にリファクタ
-- 運用ドキュメントを burn-down 完了後の定常運用に更新
-
-## Final state
-
-- baseline entries: 622 (before Phase 0) -> ??? (after Phase 4)
-- segment-extra / segment-missing / section-structure-mismatch / segment-untranslated / segment-token-gap / segment-order-mismatch: 全て 0
-- 残は真に曖昧な segment-inconclusive のみ
-
-## Roadmap 完了
-
-- Phase 0: 契約整備 ✓
-- Phase 1: 頻出パターン ✓
-- Phase 2: 手動修正 ✓
-- Phase 3: JA 独自 callout 削除 ✓
-- Phase 4: schema 簡素化 + 残整理 ✓
-
-## 参考
-
-- Roadmap: docs/superpowers/specs/2026-04-14-parity-burndown-roadmap.md
-- Phase 0-4 各 Report: docs/superpowers/specs/2026-04-14-parity-oracle-phase0-report.md 他
-"
-```
-
-## Task 4.6: 最終レポート
-
-**Files:**
-- Create: `docs/superpowers/specs/2026-04-14-parity-phase4-report.md`
-
-- [ ] **Step 1: レポート作成**
-
-```markdown
-# Parity Phase 4 — Schema 簡素化 + burn-down 完了 Final Report
-
-## 最終削減結果
-
-| 種別 | Phase 0 前 | Phase 4 後 | 削減 |
-| --- | --- | --- | --- |
-| segment-extra | 193 | 0 | 193 |
-| segment-missing | 136 | 0 | 136 |
-| segment-untranslated | 146 | 0 | 146 |
-| section-structure-mismatch | 86 | 0 | 86 |
-| segment-token-gap | 49 | 0 | 49 |
-| segment-inconclusive | 11 | (実測 ~0-10) | (実測) |
-| segment-order-mismatch | 1 | 0 | 1 |
-| **合計** | **622** | **(実測)** | **(実測)** |
-
-## Schema migration
-
-- v1 -> v2
-- 削除: reviewAfter, inconclusiveCategory, inconclusiveReason, usabilityReason
-- 追加: priority (high/medium/low, default=medium), note (任意)
-
-## Micro-exclusion 層
-
-- 残 EN-artifact: ??? 件
-- 判定: (新設 / 省略)
-
-## 定常運用への移行
-
-- baseline = bug backlog として運用開始
-- 新規 issue は baseline に入れず、即修正 or exclusion 登録
-- CI gate: parity check が green であることが merge 条件
-
-## 学びと今後の運用
-```
-
-- [ ] **Step 2: commit**
-
-```bash
-git add docs/superpowers/specs/2026-04-14-parity-phase4-report.md
-git commit -m "docs: Phase 4 完了レポート (burn-down 全体の最終報告)"
+git add docs/superpowers/specs/2026-04-14-parity-burndown-roadmap.md \
+        docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md
+git commit -m "docs: Phase 4 DoD を 5 counter 0 に / artifactCoverage を final-goal に明記"
 ```
 
 ---
 
-## Execution Handoff
+## Task 4.1: 残件実測 (5-bucket JSON) + md render
 
-Phase 4 は単独 worktree で順次実行。migration は 1 回こなせば戻る理由はないので、test で入念に pin してから実行する。
+**Context:** Finding 7 対応。5 bucket (actionable / artifactCandidates / normalizerCandidates / intentionalDivergenceCandidates / advisoryResidual) に分離することで Task 4.2 (artifact registry) と Task 4.3 (normalizer) の入力混線を防ぐ。
+
+**Files:**
+- Create: `scripts/phase4/classify_residual.mjs`
+- Create: `scripts/phase4/render_residual_inventory.mjs`
+- Create: `docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.{json,md}`
+
+- [ ] **Step 1: classify_residual.mjs**
+
+```js
+// scripts/phase4/classify_residual.mjs
+// Output: JSON to stdout
+import { readFileSync } from 'node:fs';
+
+// 本物の EN artifact (翻訳でも normalizer でも直らない)
+const ARTIFACT_TOKEN_MATCHERS = [
+  (t) => t === '/docs/index',
+  (t) => t === 'http://google.com',
+];
+// Task 4.3 の URL normalizer が正規化すべきもの
+const NORMALIZER_TOKEN_MATCHERS = [
+  (t) => typeof t === 'string' && /^https?:\/\/help\.testim\.io/.test(t),
+];
+// Task 4.4 の HTML extractor で正規化すべき intentional divergence 候補
+const INTENTIONAL_SLUGS = new Set(['administration/api-access']);
+
+function classify(entry) {
+  if (entry.issueType === 'segment-inconclusive') return 'advisoryResidual';
+  if (INTENTIONAL_SLUGS.has(entry.slug)) return 'intentionalDivergenceCandidates';
+  const tokens = entry.missingTokens ?? [];
+  if (tokens.length > 0) {
+    if (tokens.every(t => NORMALIZER_TOKEN_MATCHERS.some(f => f(t)))) return 'normalizerCandidates';
+    if (tokens.every(t => ARTIFACT_TOKEN_MATCHERS.some(f => f(t)))) return 'artifactCandidates';
+  }
+  return 'actionable';
+}
+
+function main() {
+  const baseline = JSON.parse(readFileSync('./parity-baseline.json', 'utf8'));
+  let status = null, snapDiff = null;
+  try { status = JSON.parse(readFileSync('./parity-check-status.json', 'utf8')); } catch {}
+  try { snapDiff = JSON.parse(readFileSync('./snapshot-diff-status.json', 'utf8')); } catch {}
+
+  const out = {
+    baseline: { total: baseline.entries.length, byIssueType: {} },
+    buckets: {
+      actionable: [],
+      artifactCandidates: [],
+      normalizerCandidates: [],
+      intentionalDivergenceCandidates: [],
+      advisoryResidual: [],
+    },
+    summary: {
+      reportableActiveFiles: status?.summary?.reportableActiveFiles ?? null,
+      baselinedIssues: status?.summary?.baselinedIssues ?? null,
+      advisoryQueueIssues: status?.summary?.advisoryQueueIssues ?? null,
+      auditSignalIssues: status?.summary?.auditSignalIssues ?? null,
+    },
+    snapshotDiff: {
+      changed: snapDiff?.summary?.changed ?? null,
+      added:   snapDiff?.summary?.added   ?? null,
+      removed: snapDiff?.summary?.removed ?? null,
+    },
+  };
+  for (const e of baseline.entries) {
+    out.baseline.byIssueType[e.issueType] = (out.baseline.byIssueType[e.issueType] ?? 0) + 1;
+    out.buckets[classify(e)].push({
+      slug: e.slug,
+      issueType: e.issueType,
+      sectionPath: e.sectionPath,
+      segmentKind: e.segmentKind,
+      missingTokens: e.missingTokens,
+      inconclusiveCategory: e.inconclusiveCategory,
+      inconclusiveReason: e.inconclusiveReason,
+    });
+  }
+  process.stdout.write(JSON.stringify(out, null, 2));
+}
+main();
+```
+
+- [ ] **Step 2: 実行 & JSON 固定**
+
+```bash
+node scripts/phase4/classify_residual.mjs > docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.json
+```
+
+- [ ] **Step 3: render_residual_inventory.mjs**
+
+JSON を読み、md で以下 section を出力:
+- 概要 (合計 / byIssueType)
+- 5 bucket 別 entry 表 (slug | issueType | key meta)
+- summary counters / snapshotDiff
+
+```bash
+node scripts/phase4/render_residual_inventory.mjs \
+  docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.json \
+  > docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.md
+```
+
+- [ ] **Step 4: inventory 末尾に分配方針を手動追記**
+
+- `artifactCandidates` → Task 4.2 registry の初期 entries に登録 (slug list 固定)
+- `normalizerCandidates` → Task 4.3 で normalizer 修正
+- `intentionalDivergenceCandidates` → Task 4.4 の slug allow list に追加
+- `actionable` → Task 4.5 で翻訳修正
+- `advisoryResidual` → Task 4.5 で全件解消 (翻訳 / alignment 改善 / artifact 昇格いずれか)
+
+- [ ] **Step 5: commit**
+
+```bash
+git add scripts/phase4/classify_residual.mjs \
+        scripts/phase4/render_residual_inventory.mjs \
+        docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.json \
+        docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.md
+git commit -m "chore: Phase 4 residual inventory (5-bucket) を実測"
+```
+
+---
+
+## Task 4.2: `parity_artifact_registry` 新設 + runtime coverage + `alignSegments({slug, coverage})` 全呼出更新
+
+**Context:** Finding 4 (blast radius) + 6 (runtime aggregate) + 11 (slug-scope) + 12 (import path) を反映。`alignSegments` の signature 変更は 10 file に波及する。
+
+**Files (ownership):**
+- Create: `scripts/lib/parity_artifact_registry.mjs`
+- Create: `scripts/__tests__/parity_artifact_registry.test.mjs`
+- Modify: `scripts/lib/source_parity_align.mjs:527-577`
+- Modify: `scripts/check_source_parity.mjs` (status 書き出しはここで行う — 新 module は作らない)
+- Modify (2 引数 → 3 引数移行): 
+  - `scripts/__tests__/source_parity_align.test.mjs`
+  - `scripts/__tests__/source_parity_align_runtime.test.mjs`
+  - `scripts/__tests__/source_parity_recall.test.mjs`
+  - `scripts/__tests__/source_parity_baseline_recall.test.mjs`
+  - `scripts/__tests__/source_parity_structure_fixtures.test.mjs`
+  - `scripts/__tests__/source_parity_clean_page_fixtures.test.mjs`
+  - `scripts/__tests__/source_parity_source_usability_fixtures.test.mjs`
+- Modify: `scripts/phase2/lib/baseline.mjs` (re-export path `../../lib/parity_artifact_registry.mjs`)
+- Modify: `scripts/phase2/enumerate_token_gaps.mjs` (registry 参照へ)
+- Modify: `scripts/__tests__/check_source_parity.test.mjs` (status.debug.artifactCoverage shape assertion 追加)
+- Modify: `scripts/__tests__/detection_reports.test.mjs` (artifactCoverage field passthrough が壊れないことを assert)
+
+- [ ] **Step 1a: registry shape + empty-safe + coverage aggregator の RED テスト (inventory 非依存)**
+
+```js
+// scripts/__tests__/parity_artifact_registry.test.mjs
+import { before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+let isArtifactExcluded, registryEntries, createArtifactCoverage;
+before(async () => {
+  ({ isArtifactExcluded, registryEntries, createArtifactCoverage } = await import('../lib/parity_artifact_registry.mjs'));
+});
+
+describe('parity_artifact_registry (shape / empty-safe)', () => {
+  it('isArtifactExcluded returns false for unregistered (slug, token)', () => {
+    assert.equal(isArtifactExcluded({ slug: 'nonexistent/slug', token: 'nonexistent-token' }), false);
+  });
+  it('registry entries have required shape (slugs non-empty, token string, dated)', () => {
+    for (const e of registryEntries()) {
+      assert.ok(Array.isArray(e.slugs) && e.slugs.length > 0);
+      assert.ok(typeof e.token === 'string' && e.token.length > 0);
+      assert.ok(/^\d{4}-\d{2}-\d{2}$/.test(e.addedAt));
+    }
+  });
+});
+
+describe('createArtifactCoverage', () => {
+  it('starts empty and records hits per (slug, token)', () => {
+    const c = createArtifactCoverage();
+    const s0 = c.snapshot();
+    assert.equal(s0.matchedHits, 0);
+    c.record({ slug: 'a', token: '/docs/index', reason: 'en-unresolvable' });
+    c.record({ slug: 'a', token: '/docs/index', reason: 'en-unresolvable' });
+    c.record({ slug: 'b', token: 'http://google.com', reason: 'en-demo' });
+    const s = c.snapshot();
+    assert.equal(s.matchedHits, 3);
+    assert.equal(s.bySlug.a, 2);
+    assert.equal(s.bySlug.b, 1);
+    assert.equal(s.byToken['/docs/index'], 2);
+    assert.equal(s.byToken['http://google.com'], 1);
+    assert.equal(typeof s.registryEntries, 'number');
+  });
+});
+```
+
+Run: `node --test scripts/__tests__/parity_artifact_registry.test.mjs` → FAIL (module absent)。
+
+- [ ] **Step 2: registry + coverage 実装 (GREEN)**
+
+```js
+// scripts/lib/parity_artifact_registry.mjs
+/**
+ * EN-side artifact registry (slug-scope, token) + runtime coverage aggregator.
+ * See docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md for contract.
+ */
+
+export const ARTIFACT_REGISTRY = Object.freeze([
+  // 初期 entries は Task 4.1 inventory に基づく。例:
+  // Object.freeze({
+  //   slugs: ['getting-started/creating-your-first-codeless-test'],
+  //   token: 'http://google.com',
+  //   reason: 'en-side-demo-link-artifact',
+  //   note: 'EN <a href="http://google.com">demo.testim.io</a>',
+  //   expectedIssueType: 'segment-token-gap',
+  //   addedAt: '2026-04-15',
+  //   linkedIssue: null,
+  // }),
+]);
+
+export function isArtifactExcluded({ slug, token }) {
+  for (const e of ARTIFACT_REGISTRY) {
+    if (!e.slugs.includes(slug)) continue;
+    if (e.token === token) return true;
+  }
+  return false;
+}
+
+export function registryEntries() {
+  return ARTIFACT_REGISTRY.slice();
+}
+
+export function createArtifactCoverage() {
+  const hits = [];
+  return {
+    record({ slug, token, reason }) {
+      hits.push({ slug, token, reason: reason ?? null });
+    },
+    snapshot() {
+      const bySlug = {};
+      const byToken = {};
+      for (const h of hits) {
+        bySlug[h.slug] = (bySlug[h.slug] ?? 0) + 1;
+        byToken[h.token] = (byToken[h.token] ?? 0) + 1;
+      }
+      return {
+        registryEntries: ARTIFACT_REGISTRY.length,
+        matchedHits: hits.length,
+        bySlug,
+        byToken,
+      };
+    },
+  };
+}
+
+// Call-site default — alignSegments で coverage 未指定時の no-op
+export const NOOP_COVERAGE = Object.freeze({
+  record() {},
+  snapshot: () => ({ registryEntries: ARTIFACT_REGISTRY.length, matchedHits: 0, bySlug: {}, byToken: {} }),
+});
+```
+
+Task 4.1 inventory を確定後、`ARTIFACT_REGISTRY` に slug/token pair を投入する (Step 3)。この時点で Step 1a は shape / empty-safe / coverage だけを通過できる。
+
+Run: PASS (Step 1a のみ、具体 exclusion test はまだ書かない)。
+
+- [ ] **Step 3: inventory から初期 entries を投入 + 具体 exclusion テストを追加 (Step 1b)**
+
+1. Task 4.1 inventory の `artifactCandidates` bucket から slug/token pair を抽出し `ARTIFACT_REGISTRY` に追加。
+2. `parity_artifact_registry.test.mjs` に inventory-driven な test を追記:
+
+```js
+describe('parity_artifact_registry (inventory-driven exclusion)', () => {
+  it('excludes http://google.com for creating-your-first-codeless-test (EN demo link artifact)', () => {
+    assert.equal(isArtifactExcluded({ slug: 'getting-started/creating-your-first-codeless-test', token: 'http://google.com' }), true);
+    assert.equal(isArtifactExcluded({ slug: 'editing-tests/steps', token: 'http://google.com' }), false);
+  });
+  // 他、inventory に挙がった (slug, token) pair ごとに slug-scope 抑止 / 未登録 slug 非抑止の pair 検証を追加
+});
+```
+
+Run: PASS (Step 1a + Step 1b 両方)。
+
+- [ ] **Step 4: `alignSegments` signature 変更 + coverage hook (RED → GREEN)**
+
+```js
+// scripts/lib/source_parity_align.mjs (L527 付近)
+import { isArtifactExcluded, NOOP_COVERAGE } from './parity_artifact_registry.mjs';
+
+export function alignSegments(enSections, jaSections, options = {}) {
+  const { slug, coverage = NOOP_COVERAGE } = options;
+  if (typeof slug !== 'string' || slug.length === 0) {
+    throw new Error('alignSegments: slug option is required');
+  }
+  // ... 既存ロジック ...
+  for (const [enIdx, jaIdx] of matched) {
+    const enSeg = enBody[enIdx];
+    const jaSeg = jaBody[jaIdx];
+    const jaTokenSet = new Set(normalizeSegmentTokens(jaSeg.tokensInvariant ?? []));
+    const enTokens = normalizeSegmentTokens(enSeg.tokensInvariant ?? []);
+    const missingTokens = [];
+    for (const token of enTokens) {
+      if (jaTokenSet.has(token)) continue;
+      if (isArtifactExcluded({ slug, token })) {
+        coverage.record({ slug, token, reason: 'artifact-registry' });
+        continue;
+      }
+      missingTokens.push(token);
+    }
+    if (missingTokens.length > 0) {
+      diffs.push(diffTokenGap(enSection, enSeg, jaSeg, enIdx, jaIdx, missingTokens));
+    }
+    // ...
+  }
+}
+```
+
+align test 追加:
+
+```js
+// scripts/__tests__/source_parity_align.test.mjs (追記)
+import { createArtifactCoverage } from '../lib/parity_artifact_registry.mjs';
+// ...
+it('throws when slug option is missing (safety guard)', () => {
+  assert.throws(() => alignSegments(enFixture, jaFixture), /slug option is required/);
+});
+it('suppresses segment-token-gap via artifact registry and records coverage', () => {
+  const coverage = createArtifactCoverage();
+  const diffs = alignSegments(enFixture, jaFixture, { slug: '<REGISTERED_SLUG>', coverage });
+  assert.equal(diffs.filter(d => d.type === 'segment-token-gap').length, 0);
+  const s = coverage.snapshot();
+  assert.ok(s.matchedHits >= 1);
+});
+```
+
+Run: PASS。
+
+- [ ] **Step 5: 全 test の 2 引数呼出を `{ slug }` 付きに移行**
+
+以下 7 test を順に修正:
+- `source_parity_align.test.mjs`
+- `source_parity_align_runtime.test.mjs`
+- `source_parity_recall.test.mjs`
+- `source_parity_baseline_recall.test.mjs`
+- `source_parity_structure_fixtures.test.mjs`
+- `source_parity_clean_page_fixtures.test.mjs`
+- `source_parity_source_usability_fixtures.test.mjs`
+
+fixture ごとに適切な slug を渡す (fixture 内で定義済みなら import、なければ dummy 'test/fixture' 等)。
+
+- [ ] **Step 6: `check_source_parity.mjs` で coverage 生成 → 集約 → status**
+
+```js
+// scripts/check_source_parity.mjs (該当箇所)
+import { createArtifactCoverage } from './lib/parity_artifact_registry.mjs';
+// ...
+const coverage = createArtifactCoverage();
+for (const slug of slugs) {
+  // ... existing per-slug work ...
+  const diffs = alignSegments(en, ja, { slug, coverage });
+  // ...
+}
+// status 書き出し直前
+status.debug = {
+  ...status.debug,
+  artifactCoverage: coverage.snapshot(),
+};
+```
+
+- [ ] **Step 7: `scripts/phase2/lib/baseline.mjs` を re-export に置換**
+
+```js
+export {
+  isArtifactExcluded, registryEntries, createArtifactCoverage,
+  ARTIFACT_REGISTRY, NOOP_COVERAGE,
+} from '../../lib/parity_artifact_registry.mjs';
+```
+
+`scripts/phase2/enumerate_token_gaps.mjs` が旧 `EN_SIDE_ARTIFACT_TOKENS` 等を使っていたら registry API に書き換え。
+
+- [ ] **Step 8: status.debug.artifactCoverage shape test を既存 check_source_parity.test.mjs に追加**
+
+新規 module / test file は作らず、既存 `scripts/__tests__/check_source_parity.test.mjs` に assertion を追記:
+
+```js
+// scripts/__tests__/check_source_parity.test.mjs (追記)
+it('status.debug.artifactCoverage has runtime aggregate shape', async () => {
+  // check_source_parity 相当を実行し、書き出された status を読む
+  const status = /* 既存 test の status 取得手順に合わせる */;
+  const ac = status.debug?.artifactCoverage;
+  assert.ok(ac, 'artifactCoverage missing');
+  assert.ok(typeof ac.registryEntries === 'number');
+  assert.ok(typeof ac.matchedHits === 'number');
+  assert.ok(typeof ac.bySlug === 'object' && ac.bySlug !== null);
+  assert.ok(typeof ac.byToken === 'object' && ac.byToken !== null);
+});
+```
+
+`scripts/__tests__/detection_reports.test.mjs` 側でも `debug.artifactCoverage` field が report 生成時に保持されることを確認する test を追加 (単純な passthrough assertion)。
+
+- [ ] **Step 9: 2 引数 alignSegments 残存の全滅 gate**
+
+```bash
+grep -rn "alignSegments\s*(" scripts/ \
+  | grep -v "^Binary" \
+  | grep -vE "\{\s*slug" \
+  | grep -v "function alignSegments" \
+  | grep -v "// "
+```
+
+Expected: 0 行 (定義行とコメント以外 0)。Hit があれば該当箇所を修正。
+
+```bash
+npm run test 2>&1 | tail -40
+```
+
+Expected: all green。
+
+- [ ] **Step 10: commit**
+
+```bash
+git add scripts/lib/parity_artifact_registry.mjs \
+        scripts/__tests__/parity_artifact_registry.test.mjs \
+        scripts/lib/source_parity_align.mjs \
+        scripts/check_source_parity.mjs \
+        scripts/__tests__/check_source_parity.test.mjs \
+        scripts/__tests__/detection_reports.test.mjs \
+        scripts/__tests__/source_parity_align.test.mjs \
+        scripts/__tests__/source_parity_align_runtime.test.mjs \
+        scripts/__tests__/source_parity_recall.test.mjs \
+        scripts/__tests__/source_parity_baseline_recall.test.mjs \
+        scripts/__tests__/source_parity_structure_fixtures.test.mjs \
+        scripts/__tests__/source_parity_clean_page_fixtures.test.mjs \
+        scripts/__tests__/source_parity_source_usability_fixtures.test.mjs \
+        scripts/phase2/lib/baseline.mjs \
+        scripts/phase2/enumerate_token_gaps.mjs
+git commit -m "feat: parity_artifact_registry + coverage / alignSegments({slug,coverage}) へ全呼出移行"
+```
+
+---
+
+## Task 4.3: URL normalizer 非対称性修正
+
+**Files:**
+- Modify: `scripts/lib/parity_normalize.mjs:11-37`
+- Modify: `scripts/__tests__/parity_normalize.test.mjs`
+
+- [ ] **Step 1: pin test (RED)**
+
+```js
+it('normalizes help.testim.io URL with fragment symmetrically', () => {
+  assert.equal(
+    normalizeUrlForParity('https://help.testim.io/docs/api-access#api-access'),
+    normalizeUrlForParity('/docs/api-access#api-access'),
+  );
+});
+it('preserves fragment on /docs path', () => {
+  assert.equal(
+    normalizeUrlForParity('https://help.testim.io/docs/index#top'),
+    '/docs/index#top',
+  );
+});
+it('drops trailing slash differences', () => {
+  assert.equal(
+    normalizeUrlForParity('https://help.testim.io/docs/api-access/'),
+    normalizeUrlForParity('/docs/api-access'),
+  );
+});
+```
+
+Run 現状確認: FAIL が 1 件以上。
+
+- [ ] **Step 2: normalizer 修正**
+
+canonical form:
+1. `https?://help.testim.io` prefix を削除
+2. path は `/docs/` 始まりで末尾 `/` を除去
+3. `#fragment` は保持
+4. `?query` は削除 (既存挙動)
+
+Run Step 1 test: PASS。
+
+- [ ] **Step 3: commit**
+
+```bash
+git add scripts/lib/parity_normalize.mjs scripts/__tests__/parity_normalize.test.mjs
+git commit -m "fix: URL normalizer を help.testim.io ↔ /docs で対称化"
+```
+
+---
+
+## Task 4.4: HTML extractor で EN `<blockquote>` → callout-body 限定正規化
+
+**Context:** Finding 2 + 3 + 6。EN extractor の public API は `extractSegmentsFromHtml(html)` (`source_parity_segments_en.mjs:595`)、callout segment は `segmentKind === 'callout-body'` で emit される (`source_parity_segments_en.test.mjs:153` 等で既に前提)。`preprocessHtml()` (L44) と `extractSegmentsFromHtml()` (L595) の両方に `options` を受け取らせ、slug allow list + warning-like 先頭 + 短長制約に該当する `<blockquote>` を callout HTML (例: `<div class="callout-note">`) に書き換える。turndown は不触。caller (`check_source_parity.mjs:453`) も options 付きで呼ぶよう更新。
+
+**allow list の single source of truth:** code 側の `CALLOUT_NORMALIZATION_SLUGS` (in `source_parity_segments_en.mjs`) を唯一の truth にする。`final-goal.md` は説明のみで、slug 値は docs に書かず「詳細は code 参照」と明記する (Finding 6)。
+
+**Files:**
+- Modify: `scripts/lib/source_parity_segments_en.mjs:44, 595` (`preprocessHtml(html, options)` / `extractSegmentsFromHtml(html, options)` 拡張 + `CALLOUT_NORMALIZATION_SLUGS` 定数 export)
+- Modify: `scripts/check_source_parity.mjs:453` (caller に `{ slug, calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS }` 付与)
+- Modify: `scripts/__tests__/source_parity_segments_en.test.mjs` (HTML fixture で assertion)
+- Read for design: `snapshots/en/content/administration/api-access.html` / `src/content/docs/administration/api-access.md`
+- Modify: `docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md` (callout-normalization 説明 only、slug 値は掲載しない)
+
+- [ ] **Step 1: 実体確認**
+
+```bash
+sed -n '1,300p' snapshots/en/content/administration/api-access.html
+sed -n '1,200p' src/content/docs/administration/api-access.md
+```
+
+`<blockquote>` の具体形、JA 側 `:::danger` / `:::note` などの期待形を読む。Task 4.1 `intentionalDivergenceCandidates` bucket と突合し、allow list 最終決定。
+
+- [ ] **Step 2: final-goal.md に callout-normalization の説明を掲載 (slug 値は書かない)**
+
+```md
+## callout-normalization (parity HTML extractor 限定正規化)
+
+EN snapshot の warning-like な短い `<blockquote>` は、slug allow list
+に含まれる場合に限り `<div class="callout-note">` に書き換え、JA 側
+callout と kind-level parity を保つ。
+
+**allow list の single source of truth:** `scripts/lib/source_parity_segments_en.mjs`
+の `CALLOUT_NORMALIZATION_SLUGS` 定数。slug を追加 / 削除する際は
+この定数を更新する (docs を先に書かない)。
+```
+
+- [ ] **Step 3: RED test (HTML fixture, `extractSegmentsFromHtml` + `callout-body` kind)**
+
+```js
+// scripts/__tests__/source_parity_segments_en.test.mjs (追記)
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+let preprocessHtml, extractSegmentsFromHtml, CALLOUT_NORMALIZATION_SLUGS;
+before(async () => {
+  ({ preprocessHtml, extractSegmentsFromHtml, CALLOUT_NORMALIZATION_SLUGS } =
+    await import('../lib/source_parity_segments_en.mjs'));
+});
+
+describe('preprocessHtml callout normalization', () => {
+  it('rewrites short warning-like <blockquote> to <div class="callout-note"> for allowed slug', () => {
+    const html = '<blockquote><p><strong>Note</strong>: Keep your API key safe.</p></blockquote>';
+    const out = preprocessHtml(html, { slug: 'administration/api-access', calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS });
+    assert.match(out, /<div class="callout-note">/);
+    assert.doesNotMatch(out, /<blockquote>/);
+  });
+  it('does NOT rewrite when slug is not allowed', () => {
+    const html = '<blockquote><p><strong>Note</strong>: Keep.</p></blockquote>';
+    const out = preprocessHtml(html, { slug: 'editing-tests/steps', calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS });
+    assert.match(out, /<blockquote>/);
+  });
+  it('does NOT rewrite long (>3 paragraph) blockquote', () => {
+    const html = '<blockquote><p>a</p><p>b</p><p>c</p><p>d</p></blockquote>';
+    const out = preprocessHtml(html, { slug: 'administration/api-access', calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS });
+    assert.match(out, /<blockquote>/);
+  });
+  it('does NOT rewrite blockquote without warning-like leading token', () => {
+    const html = '<blockquote><p>This is a quotation.</p></blockquote>';
+    const out = preprocessHtml(html, { slug: 'administration/api-access', calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS });
+    assert.match(out, /<blockquote>/);
+  });
+});
+
+describe('extractSegmentsFromHtml emits callout-body after normalization', () => {
+  it('emits segmentKind=callout-body for allowed slug + warning-like short blockquote', () => {
+    const html = '<h2>Heading</h2><blockquote><p><strong>Warning</strong>: drop zone</p></blockquote>';
+    const segments = extractSegmentsFromHtml(html, { slug: 'administration/api-access', calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS });
+    const kinds = segments.map(s => s.segmentKind);
+    assert.ok(kinds.includes('callout-body'));
+  });
+  it('legacy 1-arg call still works (backward compat, no normalization)', () => {
+    const html = '<blockquote><p>Quote</p></blockquote>';
+    const segments = extractSegmentsFromHtml(html);
+    // 既存 test (L153 等) の kind 前提が壊れないこと
+    assert.ok(Array.isArray(segments));
+  });
+});
+```
+
+Run: FAIL (signature 拡張未実装)。
+
+- [ ] **Step 4: `preprocessHtml` + `extractSegmentsFromHtml` を options 対応化 + caller 更新 (GREEN)**
+
+実装方針:
+1. `source_parity_segments_en.mjs` に `CALLOUT_NORMALIZATION_SLUGS` 定数を export (single source of truth):
+   ```js
+   export const CALLOUT_NORMALIZATION_SLUGS = Object.freeze(new Set([
+     'administration/api-access',
+     // Task 4.1 inventory 追加分
+   ]));
+   ```
+2. `preprocessHtml(html, options = {})` に `{ slug, calloutAllowSlugs }` を受け取るよう signature 拡張。options なしは既存挙動 (normalize 無し) を維持。
+3. `extractSegmentsFromHtml(html, options = {})` も同様に options を受け、内部で `preprocessHtml(html, options)` を呼ぶ。options なしは既存挙動を維持 (後方互換)。
+4. allow list に含まれる slug のみで `<blockquote>...</blockquote>` を検出 (既存 parser に沿って簡潔な regex / HTML walker、既存スタイルに合わせる)。
+5. warning-like 判定: blockquote 内の最初の段落テキストが `(Note|Warning|Important|Caution|Tip|Danger)` (case-insensitive、前後に `<strong>` / `<b>` / `:` を許容) で始まる。
+6. 短長制約: `<p>` 個数 ≤ 3。
+7. 該当 blockquote を `<div class="callout-note">...content...</div>` にリライト (中身の HTML はそのまま)。既存の callout 変換ロジック (既にある `<div class="caution">` 等の扱い) に揃える。
+8. `check_source_parity.mjs:453` 付近の `extractSegmentsFromHtml(html)` 呼び出しを `extractSegmentsFromHtml(html, { slug, calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS })` に書き換える。
+
+既存 `source_parity_segments_en.test.mjs` (約 260 行以降の `callout-body` 前提の test) は options なし呼び出しで通ることを確認する。
+
+Run: PASS。
+
+- [ ] **Step 5: `check:parity` で api-access を実機確認**
+
+```bash
+npm run check:snapshots:fetch -- --slug=administration/api-access
+npm run check:parity -- --slug=administration/api-access 2>&1 | tail -30
+```
+
+Expected: blockquote 起因の kind-level mismatch が消滅。残 issue があれば Task 4.5 で JA 側 `:::danger` → `:::note` 調整 (または allow list 再設計)。
+
+- [ ] **Step 6: commit**
+
+```bash
+git add scripts/lib/source_parity_segments_en.mjs \
+        scripts/check_source_parity.mjs \
+        scripts/__tests__/source_parity_segments_en.test.mjs \
+        docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md
+git commit -m "feat: preprocessHtml で EN blockquote→callout-note を slug 限定で正規化 (caller 更新含む)"
+```
+
+---
+
+## Task 4.5: 残 baseline を全解消 (entries = 0 / advisory = 0)
+
+**Files:**
+- Modify: `parity-baseline.json`
+- Modify: 対象 slug の `src/content/docs/**/*.md`
+- Modify: 必要に応じ `scripts/lib/parity_artifact_registry.mjs` (entry 追加) / `scripts/lib/parity_normalize.mjs` / `scripts/lib/source_parity_segments_en.mjs` (narrow 修正) / `scripts/lib/source_parity_align.mjs` (narrow alignment 修正)
+
+- [ ] **Step 1: baseline 再生成 (v1 のまま)**
+
+```bash
+node scripts/generate_parity_baseline.mjs --regenerate
+```
+
+Expected: exit 0。
+
+- [ ] **Step 2: 各残 entry を 1 件ずつ処理 (判定フロー)**
+
+1. 翻訳で直せる → md 修正 → slug 単位 commit
+2. EN artifact 追加 → registry に slug-scope 登録 → commit
+3. URL normalizer で直せる → normalizer narrow 修正 → commit
+4. HTML extractor 正規化候補 → allow list / 変換条件 narrow 修正 → commit
+5. alignment 誤判定 → align narrow 修正 (広範は別 PR 推奨) → commit
+6. segment-inconclusive で自動限界 → JA wording / section 境界調整 → md 修正 → commit
+7. 上記で解けない case が残れば plan 停止、user に scope 相談
+
+- [ ] **Step 3: 途中で baseline 再生成 → 0 を確認**
+
+```bash
+node scripts/generate_parity_baseline.mjs --regenerate
+node -e "
+const b = require('./parity-baseline.json');
+if (b.entries.length !== 0) {
+  console.error('entries:', b.entries.length);
+  console.error(b.entries.map(e => e.slug + '|' + e.issueType).slice(0,50).join('\n'));
+  process.exit(1);
+}
+console.log('baseline entries = 0');
+"
+```
+
+Expected: exit 0。
+
+- [ ] **Step 4: runtime counters 0 を確認**
+
+```bash
+npm run check:parity 2>&1 | tail -20
+node -e "
+const s = require('./parity-check-status.json');
+const z = s.summary;
+const ok = z.reportableActiveFiles===0 && z.baselinedIssues===0 && z.advisoryQueueIssues===0 && z.auditSignalIssues===0;
+if (!ok) { console.error('not zero', z); process.exit(1); }
+console.log('runtime counters all 0');
+"
+```
+
+Expected: exit 0。
+
+- [ ] **Step 5: commit 最終 baseline (v1 最終状態 entries=0)**
+
+```bash
+git add parity-baseline.json
+git commit -m "chore: Phase 4 baseline を entries=0 まで解消 (v1 最終)"
+```
+
+---
+
+## Task 4.6: schema v1 → v2 atomic cutover
+
+### Task 4.6.1: 型 + loader + BASELINE_ELIGIBLE_TYPES 縮約 + empty baseline default v2 化
+
+**Files:**
+- Modify: `scripts/lib/source_parity_types.mjs`
+- Modify: `scripts/lib/source_parity_baseline.mjs`
+- Modify: `scripts/check_source_parity.mjs:300-302, 342` (`loadBaselineFileSafe()` empty return / `baselineData` 初期値)
+- Modify: `scripts/__tests__/source_parity_baseline.test.mjs`
+- Modify: `scripts/__tests__/source_parity_baseline_recall.test.mjs` (`segment-inconclusive` / `inconclusiveReason` / `reviewAfter` 前提を v2 契約に更新 — baseline 対象外の issueType を baseline match させていた assertion を削除 or type を v2 eligible に差し替え)
+- Modify: `scripts/__tests__/check_source_parity.test.mjs` (empty baseline default が v2 であることを public behavior 経由で assertion 追加 — `loadBaselineFileSafe` は private helper のまま維持)
+
+- [ ] **Step 1: types**
+
+```js
+// scripts/lib/source_parity_types.mjs
+export const PRIORITY_VALUES = Object.freeze(['high', 'medium', 'low']);
+// BaselineEntry 型から reviewAfter / inconclusiveReason / inconclusiveCategory /
+// usabilityReason を除去 (eligible types 縮約に合わせる)。priority / note 追加
+```
+
+- [ ] **Step 2: BASELINE_ELIGIBLE_TYPES / TYPES_ARG_ALLOWLIST 縮約**
+
+```js
+// scripts/lib/source_parity_baseline.mjs L36-48 置換
+export const BASELINE_ELIGIBLE_TYPES = Object.freeze(new Set([
+  'segment-missing','segment-extra','segment-shifted',
+  'segment-untranslated','segment-token-gap',
+  'section-structure-mismatch','segment-order-mismatch',
+]));
+// L65-72 置換
+export const TYPES_ARG_ALLOWLIST = Object.freeze(new Set([
+  'section-structure-mismatch','segment-order-mismatch',
+]));
+```
+
+- [ ] **Step 3: validator / expiry / tag 撤去**
+
+- `schemaVersion` 受理は v2 のみ
+- `reviewAfter` 検証 (L269-282) 削除
+- `inconclusiveReason` / `inconclusiveCategory` / `usabilityReason` entry 検証は型集合縮約に伴い不要分岐削除
+- `isBaselineExpired` / `isBaselineExpiringSoon` (L405-440) 関数削除
+- `buildBaselineKey` / `buildBaselineKeyFromEntry` の `segment-inconclusive` / `source-unusable` / `snapshot-incomplete` 分岐削除
+- `tagIssuesWithBaseline` (L560) の `baselineReviewAfter` / `baselineExpired` 付与削除
+- priority enum (`PRIORITY_VALUES`) 検証追加
+- note (max 500 chars, optional) 検証追加
+
+- [ ] **Step 4: baseline test を v2 に**
+
+- 全 fixture に priority='medium' 追加、reviewAfter / inconclusiveReason / inconclusiveCategory / usabilityReason を除去
+- `it('rejects segment-inconclusive / snapshot-incomplete / source-unusable as baseline entry', ...)` を追加
+- schemaVersion=1 を reject する test を追加
+- priority / note invalid 系 test を追加
+
+Run: loader test のみ pass する想定。
+
+- [ ] **Step 5: empty baseline default を v2 化 + `debug.baselineSchemaVersion` を status に露出**
+
+```js
+// scripts/check_source_parity.mjs:300-302 差し替え
+function loadBaselineFileSafe(filePath = BASELINE_PATH) {
+  if (!fs.existsSync(filePath)) {
+    return { schemaVersion: 2, entries: [] }; // v2 へ
+  }
+  return loadBaselineFile(filePath);
+}
+
+// scripts/check_source_parity.mjs:342 差し替え
+let baselineData = { schemaVersion: 2, entries: [] }; // v2 へ
+
+// status payload 組み立て箇所 (L727 付近) に追加
+status.debug = {
+  ...status.debug,
+  baselineSchemaVersion: baselineData.schemaVersion,
+};
+```
+
+`ackData` の `{ schemaVersion: 1, entries: [] }` (L329) は acknowledgements 側の schema なので **不触** (範囲外)。
+
+`loadBaselineFileSafe()` は private helper のまま維持 (export しない)。`checkSourceParity()` の戻り値は status 本体ではなく exit code で、status 内容は `outputPath` に JSON で書き出される (`scripts/check_source_parity.mjs:307` 前提)。v2 empty default の検証は以下の 2 段階で行う:
+
+**実装側 (check_source_parity.mjs):** status payload に `debug.baselineSchemaVersion = baselineData.schemaVersion` を追加する。既存の `debug` 枠 (artifactCoverage と同じ) に載せる小さな追加で、public API 拡張は最小限。
+
+**test:**
+
+```js
+// scripts/__tests__/check_source_parity.test.mjs (追記)
+import { writeFileSync, mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+it('uses v2 empty baseline default when baseline file is missing', async () => {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'parity-v2-empty-'));
+  const tmpPath = join(tmpDir, 'parity-check-status.json');
+  await checkSourceParity({
+    baselinePath: '/nonexistent/path.json',
+    outputPath: tmpPath,
+    json: true,
+  });
+  const payload = JSON.parse(readFileSync(tmpPath, 'utf8'));
+  assert.equal(payload.debug?.baselineSchemaVersion, 2);
+});
+```
+
+- [ ] **Step 6: commit**
+
+```bash
+git add scripts/lib/source_parity_types.mjs \
+        scripts/lib/source_parity_baseline.mjs \
+        scripts/check_source_parity.mjs \
+        scripts/__tests__/source_parity_baseline.test.mjs \
+        scripts/__tests__/source_parity_baseline_recall.test.mjs \
+        scripts/__tests__/check_source_parity.test.mjs
+git commit -m "refactor: baseline v2 loader + BASELINE_ELIGIBLE_TYPES 縮約 + empty baseline default v2 化 / baseline_recall を v2 契約に更新"
+```
+
+### Task 4.6.2: generator v2 化 + migration script + 既存 generator test の全面更新
+
+**Files:**
+- Modify: `scripts/generate_parity_baseline.mjs:184-225, 262-282, 308, 500-533`
+- Modify: `scripts/__tests__/generate_parity_baseline.test.mjs` (1014 行、41 箇所の `reviewAfter` / 6 箇所の `segment-inconclusive` / 4 箇所の `schemaVersion` 参照を v2 契約に更新)
+- Create: `scripts/phase4/migrate_baseline_schema.mjs`
+- Create: `scripts/__tests__/baseline_schema_migration.test.mjs`
+
+**generator test 更新チェックリスト (Finding 1):**
+- [ ] `defaultReviewAfter` / `reviewAfterOverride` を使う assertion を削除 (または `--review-after` option 廃止に合わせて "該当 option が reject される" negative test に置換)
+- [ ] `segment-inconclusive` / `snapshot-incomplete` / `source-unusable` を baseline entry に含める assertion を削除 + "これらの type は generator が skip する" positive test を追加
+- [ ] root `schemaVersion: 2` を前提に書き換え
+- [ ] fixture entry に `priority: 'medium'` default が付与されることを assert
+- [ ] `--review-after` CLI arg が usage で削除 / reject されることを assert
+- [ ] `TYPES_ARG_ALLOWLIST` の縮約 (2 種のみ) が generator 側でも尊重されることを assert
+
+- [ ] **Step 1: generator v2 化**
+
+- root `schemaVersion: 2`
+- staggered `reviewAfter` 生成削除
+- `inconclusiveReason` / `inconclusiveCategory` / `usabilityReason` emission 削除
+- 除外 issueType (segment-inconclusive / snapshot-incomplete / source-unusable) の entry 生成 skip
+- `priority: 'medium'` default
+- `--review-after` option 削除、usage 文面更新 (`scripts/generate_parity_baseline.mjs:518-532`)
+
+- [ ] **Step 2: migration 関数 + test**
+
+```js
+// scripts/phase4/migrate_baseline_schema.mjs
+const DROP_FIELDS = new Set(['reviewAfter','inconclusiveReason','inconclusiveCategory','usabilityReason']);
+const DROP_ISSUE_TYPES = new Set(['segment-inconclusive','snapshot-incomplete','source-unusable']);
+
+export function migrateEntry(old) {
+  if (DROP_ISSUE_TYPES.has(old.issueType)) return null;
+  const out = {};
+  for (const [k, v] of Object.entries(old)) if (!DROP_FIELDS.has(k)) out[k] = v;
+  if (!out.priority) out.priority = 'medium';
+  return out;
+}
+export function migrateBaseline(b) {
+  return {
+    ...b,
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    rationale: `${b.rationale ?? ''} / Phase 4 v2`.trim(),
+    entries: b.entries.map(migrateEntry).filter(e => e !== null),
+  };
+}
+```
+
+test (baseline_schema_migration.test.mjs): DROP 4 fields / drop 3 issueTypes / default priority / existing priority 保持。
+
+Run: PASS。
+
+- [ ] **Step 3: baseline を v2 で再生成**
+
+```bash
+node scripts/generate_parity_baseline.mjs --regenerate
+node --test scripts/__tests__/source_parity_baseline.test.mjs
+```
+
+Expected: schemaVersion=2、entries=0、validator 通過。
+
+- [ ] **Step 4: commit**
+
+```bash
+git add scripts/generate_parity_baseline.mjs \
+        scripts/__tests__/generate_parity_baseline.test.mjs \
+        scripts/phase4/migrate_baseline_schema.mjs \
+        scripts/__tests__/baseline_schema_migration.test.mjs \
+        parity-baseline.json
+git commit -m "refactor: generate_parity_baseline を v2 出力化 / 既存 generator test を v2 契約に更新 / migration 関数を export"
+```
+
+### Task 4.6.3: advisory / summary / check / issue_state / detection_reports / status の v2 対応 (blast radius 対処)
+
+**Files (ownership expanded):**
+- Modify: `scripts/lib/source_parity_advisory_queue.mjs:104-128`
+- Modify: `scripts/lib/source_parity_summary.mjs`
+- Modify: `scripts/check_source_parity.mjs`
+- Modify: `scripts/lib/source_parity_issue_state.mjs`
+- Modify: `scripts/lib/detection_reports.mjs`
+- Modify: `scripts/__tests__/source_parity_advisory_queue.test.mjs`
+- Modify: `scripts/__tests__/source_parity_summary_format.test.mjs` (`baselineExpired` / `baselineExpiringSoon` 集計を参照する assertion があれば v2 契約に合わせて削除 / 書き換え。`priorityCounts` 追加分の assertion を追記)
+- Modify: `scripts/__tests__/source_parity_issue_state.test.mjs`
+- Modify: `scripts/__tests__/source_parity.test.mjs`
+- Modify: `scripts/__tests__/check_source_parity.test.mjs`
+- Modify: `scripts/__tests__/detection_reports.test.mjs`
+- Modify: `scripts/__tests__/source_parity_acknowledgements.test.mjs` (`baselineExpired` 参照箇所を削除)
+
+- [ ] **Step 1: `isFrozenByBaseline` 縮約 (`issue_state.mjs`)**
+
+```js
+// scripts/lib/source_parity_issue_state.mjs
+export function isFrozenByBaseline(issue) {
+  return issue.baselined === true;
+}
+// baselineExpired / reviewAfter を読んでいた分岐を全削除
+```
+
+対応 test (`source_parity_issue_state.test.mjs`) も v2 契約に書き換え:
+- baselined=true で freeze、baselined=false で freeze しない
+- 旧 `baselineExpired=true` によって freeze 解除されていた test は「v2 ではその概念がない」と明記して削除
+
+- [ ] **Step 2: advisory queue field 整理 (option A)**
+
+`source_parity_advisory_queue.mjs:104-128`:
+- 削除: `baselineReviewAfter`, `baselineExpired`
+- 維持: `inconclusiveCategory`, `inconclusiveReason` (runtime issue 直読み)
+- 維持: `baselined`, `acknowledged`, `ackExpired` (他機能の context)
+
+test 更新: 旧 field 参照を除去、runtime `inconclusiveReason` が entry に残る正常系 assertion。
+
+- [ ] **Step 3: summary v2 化**
+
+- 旧 `baselineExpired` / `baselineExpiringSoon` counter 削除
+- `priorityCounts` 追加 (baselined 内訳)
+- `advisoryQueueIssues` / `auditSignalIssues` / `reportableActiveFiles` / `baselinedIssues` field は維持 (DoD 測定用)
+
+対応 test 更新。
+
+- [ ] **Step 4: check_source_parity v2 対応 + artifactCoverage 出力**
+
+- `baselineReviewAfter` / `baselineExpired` tagging 削除
+- `alignSegments` 呼出に `{ slug, coverage }` (Task 4.2 Step 6 で反映済みなら確認のみ)
+- status 書出し前に `status.debug.artifactCoverage = coverage.snapshot()` (Task 4.2 Step 6 で反映済みなら確認のみ)
+- console 出力で `baselineReviewAfter` / `baselineExpired` 参照があれば削除
+
+対応 test (`check_source_parity.test.mjs`) 更新。
+
+- [ ] **Step 5: detection_reports v2 対応**
+
+- `reviewAfter` / `baselineExpired` 参照を全削除
+- v2 schema で想定される report 項目に整理
+
+対応 test (`detection_reports.test.mjs`) 更新。
+
+- [ ] **Step 6: source_parity.test.mjs / source_parity_acknowledgements.test.mjs の残留参照解消**
+
+- `baselineExpired` / `baselineReviewAfter` / `reviewAfter` 参照があれば v2 契約に合わせ削除 or 書き換え
+
+- [ ] **Step 7: 全 test 通す**
+
+```bash
+npm run test 2>&1 | tail -50
+```
+
+Expected: all green。
+
+- [ ] **Step 8: commit**
+
+```bash
+git add scripts/lib/source_parity_advisory_queue.mjs \
+        scripts/lib/source_parity_summary.mjs \
+        scripts/lib/source_parity_issue_state.mjs \
+        scripts/lib/detection_reports.mjs \
+        scripts/check_source_parity.mjs \
+        scripts/__tests__/source_parity_advisory_queue.test.mjs \
+        scripts/__tests__/source_parity_summary_format.test.mjs \
+        scripts/__tests__/source_parity_issue_state.test.mjs \
+        scripts/__tests__/source_parity.test.mjs \
+        scripts/__tests__/check_source_parity.test.mjs \
+        scripts/__tests__/detection_reports.test.mjs \
+        scripts/__tests__/source_parity_acknowledgements.test.mjs
+git commit -m "refactor: advisory/summary/issue_state/detection_reports/check を v2 に (baselineExpired 撤去 / isFrozenByBaseline 縮約)"
+```
+
+---
+
+## Task 4.7: 運用ドキュメント最終化
+
+**Files:**
+- Modify: `docs/OPS_DESIGN.md`
+- Modify: `docs/PARITY_GUIDE.md`
+- Modify: `docs/WRITING_GUIDE.md`
+- Modify: `scripts/README.md`
+- Modify: `docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md`
+
+- [ ] **Step 1: OPS_DESIGN.md**
+
+- `reviewAfter` 期日管理を全削除、priority burn-down に置換
+- baseline = JA-actionable、Phase 4 終了時点で 0
+- 新規 issue 発生フロー: 翻訳 / registry / normalizer / extractor / alignment / source lock
+- CI gate: status JSON の 4 counter + baseline entries + snapshot diff で機械判定
+
+- [ ] **Step 2: PARITY_GUIDE.md**
+
+- residual 3 分類 (actionable-baseline / parity-artifact-registry / advisory-residual) 正式記載
+- artifact registry 登録手順 (slug-scope のみ, global 禁止)
+- `debug.artifactCoverage` の読み方
+- `debug.maskCoverage` と `debug.artifactCoverage` の責務分離
+
+- [ ] **Step 3: WRITING_GUIDE.md**
+
+- source-first 契約再確認
+- EN artifact は JA 側で模倣しない (checker 吸収)
+- callout-normalization-slugs の truth source は `scripts/lib/source_parity_segments_en.mjs` の `CALLOUT_NORMALIZATION_SLUGS` 定数 (final-goal.md は仕組み説明のみ)
+
+- [ ] **Step 4: scripts/README.md**
+
+- `reviewAfter` / `--review-after` option 関連記述を削除
+- v2 schema (priority / note) と新規 artifact registry / coverage の説明を追加
+- `generate_parity_baseline.mjs` の最新 usage (`--regenerate` / `--slug` / `--types`)
+
+- [ ] **Step 5: Phase 4 plan ファイルを本 plan で置換**
+
+`docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md` を本 plan (Rev 6) 内容で上書き。
+
+- [ ] **Step 6: commit**
+
+```bash
+git add docs/OPS_DESIGN.md docs/PARITY_GUIDE.md docs/WRITING_GUIDE.md \
+        scripts/README.md \
+        docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md
+git commit -m "docs: Phase 4 完了後の定常運用 (5 counter 0 / artifact registry / README 更新)"
+```
+
+---
+
+## Task 4.8: 最終 E2E (JSON assertion) → report → push → PR
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-04-14-parity-phase4-report.md`
+
+- [ ] **Step 1: snapshot fresh fetch + diff 0 確認**
+
+```bash
+npm run check:snapshots:fetch
+npm run check:snapshots:diff 2>&1 | tail -20
+node -e "
+const d = require('./snapshot-diff-status.json');
+const s = d.summary ?? {};
+const ok = s.changed === 0 && s.added === 0 && s.removed === 0;
+if (!ok) { console.error('snapshot diff not zero', s); process.exit(1); }
+console.log('snapshot diff: changed/added/removed = 0');
+"
+```
+
+- [ ] **Step 2: parity + baseline + counters + artifactCoverage**
+
+```bash
+npm run test && npm run lint && npm run build
+npm run check:parity 2>&1 | tail -20
+node -e "
+const b = require('./parity-baseline.json');
+if (b.entries.length !== 0) { console.error('baseline not empty', b.entries.length); process.exit(1); }
+if (b.schemaVersion !== 2) { console.error('schema not v2', b.schemaVersion); process.exit(1); }
+const s = require('./parity-check-status.json');
+const z = s.summary ?? {};
+const ok = z.reportableActiveFiles===0 && z.baselinedIssues===0 && z.advisoryQueueIssues===0 && z.auditSignalIssues===0;
+if (!ok) { console.error('status counters not zero', z); process.exit(1); }
+const ac = s.debug?.artifactCoverage;
+if (!ac || typeof ac.registryEntries !== 'number' || typeof ac.matchedHits !== 'number' || typeof ac.bySlug !== 'object' || typeof ac.byToken !== 'object') {
+  console.error('artifactCoverage shape invalid', ac);
+  process.exit(1);
+}
+console.log('baseline=0, summary counters=0, schemaVersion=2, artifactCoverage shape OK');
+"
+```
+
+- [ ] **Step 3: alignSegments の 2 引数残存の最終確認**
+
+```bash
+LEAK=$(grep -rn "alignSegments\s*(" scripts/ \
+  | grep -v "^Binary" \
+  | grep -vE "\{\s*slug" \
+  | grep -v "function alignSegments" \
+  | grep -v "// ")
+if [ -n "$LEAK" ]; then echo "leak:\n$LEAK"; exit 1; fi
+echo "alignSegments call sites: all migrated"
+```
+
+- [ ] **Step 4: deprecated field の scope 限定 grep**
+
+```bash
+grep -nr "reviewAfter\|baselineReviewAfter\|baselineExpired" \
+  scripts/lib scripts/check_source_parity.mjs \
+  docs/OPS_DESIGN.md docs/PARITY_GUIDE.md scripts/README.md \
+  | grep -v "^Binary" \
+  || echo "clean"
+```
+
+Expected: `clean` または historical comment のみ (該当行は手動レビューで説明付与)。
+
+- [ ] **Step 5: 最終 report 作成**
+
+```markdown
+# Parity Phase 4 — Final Cutover Report
+
+## 完了条件 (all true)
+- parity-baseline.json.entries.length = 0
+- parity-baseline.json.schemaVersion = 2
+- parity-check-status.summary.{reportableActiveFiles, baselinedIssues, advisoryQueueIssues, auditSignalIssues} = 0
+- parity-check-status.debug.artifactCoverage = { registryEntries, matchedHits, bySlug, byToken }
+- snapshot-diff-status.summary.{changed, added, removed} = 0
+
+## 削減結果
+(表)
+
+## Schema migration
+- v1 → v2
+- 削除 (entry): reviewAfter / inconclusiveReason / inconclusiveCategory / usabilityReason
+- 削除 (tagging / queue): baselineReviewAfter / baselineExpired
+- 追加 (entry): priority / note
+- 追加 (status): debug.artifactCoverage
+- BASELINE_ELIGIBLE_TYPES = JA-actionable 7 種
+- isFrozenByBaseline(issue) ≡ issue.baselined === true
+
+## Checker simplification
+- parity_normalize: help.testim.io ↔ /docs URL fragment 対称化
+- parity_artifact_registry: slug-scope token + runtime coverage aggregator
+- preprocessHtml: slug allow list 限定 <blockquote>→<div class="callout-note"> (turndown 非侵襲)
+- alignSegments({slug, coverage}) 化 + 全呼出移行
+
+## 定常運用
+- CI gate: status / snapshot / baseline JSON で 機械判定
+- 新規 issue フロー: 翻訳 / registry / normalizer / extractor / alignment / source lock
+```
+
+- [ ] **Step 6: commit report (PR 作成より前)**
+
+```bash
+git add docs/superpowers/specs/2026-04-14-parity-phase4-report.md
+git commit -m "docs: Phase 4 最終 report"
+```
+
+- [ ] **Step 7: push**
+
+```bash
+git push -u origin worktree-noble-squishing-bee
+```
+
+- [ ] **Step 8: PR 作成**
+
+```bash
+gh pr create --title "refactor: Phase 4 final cutover (baseline=0 / schema v2 / artifact registry + coverage)" --body "$(cat <<'EOF'
+## Summary
+
+Parity burn-down の最終 cutover。5 counter (baseline.entries, baselinedIssues, advisoryQueueIssues, auditSignalIssues, snapshot-diff) をすべて 0 に落とし、schema を v2 に移行。
+
+- Task 4.0: DoD を 5 counter 0 に再定義、final-goal.md / debug.artifactCoverage 契約
+- Task 4.1: 5-bucket 残件 inventory (actionable / artifactCandidates / normalizerCandidates / intentionalDivergenceCandidates / advisoryResidual)
+- Task 4.2: parity_artifact_registry + createArtifactCoverage + alignSegments({slug,coverage}) へ全呼出移行
+- Task 4.3: URL normalizer 対称化
+- Task 4.4: preprocessHtml で EN blockquote→callout-note を slug 限定正規化 (turndown 非侵襲)
+- Task 4.5: 残 baseline 全解消 (entries=0)
+- Task 4.6: schema v1→v2 atomic cutover (types/loader/generator/advisory/summary/issue_state/detection_reports/check/status/migration/tests)
+- Task 4.7: OPS / PARITY / WRITING / Phase 4 plan / scripts/README 更新
+- Task 4.8: JSON assertion + alignSegments 呼出 leak 検証
+
+## Final state
+(前述 Final state 参照)
+
+## 参考
+- Roadmap / Final-goal / Residual inventory / Final report へのリンク
+EOF
+)"
+```
+
+---
+
+## Verification Summary
+
+Task 4.8 の各 Step が機械的に確認する条件の一覧:
+
+1. `npm run test && npm run lint && npm run build` green
+2. `snapshot-diff-status.summary.{changed, added, removed} = 0`
+3. `parity-baseline.json.entries.length = 0 && schemaVersion = 2`
+4. `parity-check-status.summary.{reportableActiveFiles, baselinedIssues, advisoryQueueIssues, auditSignalIssues} = 0`
+5. `parity-check-status.debug.artifactCoverage` が shape OK
+6. `alignSegments(` 呼出のうち `{ slug` を含まないものが 0 件 (定義行・コメント除く)
+7. `reviewAfter` / `baselineReviewAfter` / `baselineExpired` が scope (`scripts/lib`, `scripts/check_source_parity.mjs`, `docs/OPS_DESIGN.md`, `docs/PARITY_GUIDE.md`, `scripts/README.md`) で 0 件
+
+---
+
+## 実行順序サマリ
+
+```
+Task 4.0  DoD 再定義 + final-goal.md                 (docs)
+Task 4.1  residual inventory (5-bucket JSON + md)    (script)
+Task 4.2  parity_artifact_registry + coverage +
+          alignSegments({slug,coverage}) 全呼出移行  (runtime + 7 tests)
+Task 4.3  URL normalizer 対称化                      (runtime + test)
+Task 4.4  preprocessHtml で callout 限定正規化       (runtime + test)
+Task 4.5  残 baseline entries=0 まで解消             (md / registry / narrow 修正)
+Task 4.6  schema v2 atomic cutover
+  4.6.1 types / loader / BASELINE_ELIGIBLE_TYPES
+  4.6.2 generator + migration + test
+  4.6.3 advisory / summary / issue_state / detection_reports / check / status / tests
+Task 4.7  docs final (OPS / PARITY / WRITING / README / Phase 4 plan)
+Task 4.8  JSON assertion → alignSegments leak check → deprecated grep → report → push → PR
+```

--- a/docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md
+++ b/docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md
@@ -431,7 +431,7 @@ git commit -m "chore: Phase 4 residual inventory (5-bucket) を実測"
 - Create: `scripts/__tests__/parity_artifact_registry.test.mjs`
 - Modify: `scripts/lib/source_parity_align.mjs:527-577`
 - Modify: `scripts/check_source_parity.mjs` (status 書き出しはここで行う — 新 module は作らない)
-- Modify (2 引数 → 3 引数移行): 
+- Modify (2 引数 → 3 引数移行):
   - `scripts/__tests__/source_parity_align.test.mjs`
   - `scripts/__tests__/source_parity_align_runtime.test.mjs`
   - `scripts/__tests__/source_parity_recall.test.mjs`

--- a/docs/superpowers/plans/2026-04-15-parity-bulk-remediation.md
+++ b/docs/superpowers/plans/2026-04-15-parity-bulk-remediation.md
@@ -1,0 +1,132 @@
+# Parity Bulk Remediation — Pre-Cutover Burn-Down Plan
+
+**Date:** 2026-04-15
+**Status:** Draft (per-Stage で複数 PR に分割して実行)
+**Parent plan:** [docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md](./2026-04-14-parity-phase4-schema-cleanup.md) Rev 6 (PR Z の contract 定義)
+
+## 1. Context
+
+Phase 4 plan (Rev 6) は `parity-baseline.json.entries = 0` / 4 status counter = 0 の atomic cutover を最終目標とする。そのうち **PR A** (Task 4.0–4.4) は pre-cutover mechanism 層 (artifact registry / URL normalizer / HTML extractor 正規化) のみを投入し、schema v1 を維持する。
+
+本 plan はその後 **PR Z** (Task 4.5–4.8 final cutover) に着手できる水準まで baseline を burn down するための multi-session / multi-PR 計画である。
+
+## 2. Baseline snapshot (PR A 直前)
+
+source: [`docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.json`](../specs/2026-04-14-parity-phase4-residual-inventory.json)
+
+合計 **1873 entries**。
+
+| bucket (inventory 分類) | 件数 | byIssueType 内訳 | burn-down 手段 |
+|---|---|---|---|
+| actionable | 1851 | segment-untranslated 1571 / segment-missing 107 / segment-extra 87 / section-structure-mismatch 56 / segment-token-gap 29 / segment-order-mismatch 1 | Stage B1–B4 |
+| normalizerCandidates | 1 | segment-token-gap 1 (`/v2.0/docs/...` 版) | Stage B5 |
+| intentionalDivergenceCandidates | 3 | administration/api-access 3 | PR A merge + baseline 再生成で orphan 化 |
+| artifactCandidates | 7 | segment-token-gap 7 | PR A merge + baseline 再生成で orphan 化 |
+| advisoryResidual | 11 | segment-inconclusive 11 | Stage B6 |
+
+PR A merge 後の baseline 再生成で mechanism 自動解消分 **10 件** (artifact 7 + extractor 3) が orphan 化する。以降は actionable 1851 + normalizerCandidates 1 + advisoryResidual 11 = **1863 件** を burn down する。
+
+## 3. PR cadence / worktree hygiene
+
+- 各 Stage は **1 PR 以上** (bulk 内容に応じて複数 PR に分割)
+- 新 worktree を per-Stage で切る (例: `claude/parity-burndown-B1-untranslated`, `claude/parity-burndown-B2-missing`)
+- PR マージごとに baseline 再生成 (`node scripts/generate_parity_baseline.mjs --regenerate`) → 次 Stage の入力 inventory を更新
+- 各 PR で必須:
+  - 対象 slug list / 件数 (before / after)
+  - LLM 翻訳使用時は prompt / glossary / INVARIANT_TOKENS 記載
+  - `npm run test` / `npm run lint` / `npm run build` green
+  - `npm run check:parity` で対象 slug の runtime 0 化確認
+
+## 4. Stage B1: segment-untranslated (1571 件)
+
+**優先度:** 最高 (volume 最大、mechanism 層では解消不能)
+
+**手段:** 既存 LLM pipeline (`scripts/pipeline.mjs` / `scripts/apply_llm_translations.mjs` / checkpoint 再開可能) を使用。`docs/TRANSLATION_GUIDE.md` の terminology / NG-OK パターンに従う。glossary は `scripts/lib/glossary.mjs` (存在すれば)、INVARIANT_TOKENS も baseline 側と一致させる。
+
+**分割:**
+- slug 単位に集約 → ~100–200 件 (slug 単位) / PR を目安
+- 優先 order: 1) `overview/` / `getting-started/` (認知度高) → 2) 頻出 feature (editing-tests / recording-tests / testops) → 3) 残 area
+
+**Verification per PR:**
+1. `npm run check:parity -- --slug=<target>` で対象 slug の untranslated = 0
+2. `npm run lint:docs` で callout / 表記 / 記法 OK
+3. `scripts/pipeline.mjs --dry` で次 checkpoint 想定通り
+
+**Exit (Stage B1):** baseline の `segment-untranslated` 件数 = 0
+
+## 5. Stage B2: segment-missing (107 件)
+
+**手段:** JA 側に翻訳が「欠落」している segment の補完。per-slug に EN 原文と照合して該当 section / paragraph を追記。source-first 契約 (見出し対応 / 段落順 / リスト構造) を保つ。
+
+**分割:** ~20–30 件 / PR。per-slug commit で review 粒度を保つ。
+
+**Exit:** baseline の `segment-missing` 件数 = 0
+
+## 6. Stage B3: segment-extra (87 件)
+
+**手段:** JA 側に EN に存在しない segment が「余分」にある箇所の削除、または EN 側に無い情報を callout として統合する。Phase 3 で扱った JA 独自 callout の扱いに近い。`WRITING_GUIDE.md` の JA-only section 削除規約に沿う。
+
+**分割:** ~20–30 件 / PR。
+
+**Exit:** baseline の `segment-extra` 件数 = 0
+
+## 7. Stage B4: section-structure-mismatch (56 件)
+
+**手段:** 見出し階層 (H2/H3/H4) / section 区切りの EN/JA 不一致を是正。EN の section 構造を source-first 契約通りに複製する。
+
+**分割:** ~15 件 / PR。構造変更は review 負荷が高いため小さめ。
+
+**Exit:** baseline の `section-structure-mismatch` 件数 = 0
+
+## 8. Stage B5: segment-token-gap 残 (~29 + 1 件)
+
+**対象:**
+- actionable 側 29 件 (mechanism 未吸収の token gap)
+- normalizerCandidates 1 件 (`/v2.0/docs/scheduler#integrating-scheduler-with-slack` — Task 4.3 の対称化 regex に未該当)
+
+**手段 (優先順):**
+1. Task 4.2 artifact registry に slug-scope 追加 (「EN 固有の link 痕跡で JA 側に対応 link 不要」と判断できる場合)
+2. Task 4.3 URL normalizer に narrow rule 追加 (例: `/v2.0/docs/` → `/docs/` の正規化)
+3. JA 側 link 追加 / 修正 (JA ドキュメントに対応 page がある場合)
+4. EN 側 artifact 化 (Task 4.1 `artifactCandidates` bucket と同等に扱う)
+
+**Exit:** baseline の `segment-token-gap` 件数 = 0 または registry / normalizer で runtime 抑止される水準
+
+## 9. Stage B6: advisoryResidual (segment-inconclusive 11 件)
+
+**手段:** 各 entry の `inconclusiveReason` (align score の tie-break 失敗等) を読み、以下のいずれかで解消:
+
+- JA 側 wording 微調整で同点ブレーク (最も多い)
+- alignment score 判定の narrow rule 改善 (score 計算に影響、最小限)
+- 真に曖昧な case は artifact registry に昇格 (「EN 側の構造的不定性」と宣言)
+
+**Exit:** baseline の `segment-inconclusive` 件数 = 0 または PR Z 開始合意できる水準 (目標 0–5 件)
+
+## 10. Exit criteria → PR Z 着手
+
+以下がすべて true のとき PR Z (Phase 4 final cutover, Task 4.5–4.8) に着手可能とする:
+
+- `parity-baseline.json.entries.length` ≤ 20 (目標は 0)
+- `byIssueType` から以下がすべて 0:
+  - `segment-untranslated`
+  - `segment-missing`
+  - `segment-extra`
+  - `section-structure-mismatch`
+  - `segment-token-gap`
+  - `segment-order-mismatch`
+- 残るのは `segment-inconclusive` のみ。これは schema v2 migration で baseline 対象外になる (`BASELINE_ELIGIBLE_TYPES` 縮約対象)。
+
+この時点で PR Z の Task 4.5 (entries=0 絞り込み) は `segment-inconclusive` 消化のみで達成可能な水準に到達している。
+
+## 11. Non-goals
+
+- schema migration (PR Z で atomic cutover)
+- mechanism 変更 (PR A 済。追加が必要なら別 PR に切り出す)
+- runtime code の大幅 refactor (最小限、必要時のみ narrow 修正)
+- 翻訳品質の general review (別 audit task)
+- Phase 5 (定常運用 check gate 追加等) は PR Z 後に別 plan
+
+## 12. Tracking
+
+- 各 Stage PR description で before / after baseline entries / byIssueType 表を掲載
+- 全 Stage PR merge 後、`node scripts/phase4/classify_residual.mjs | node scripts/phase4/render_residual_inventory.mjs` で最終 inventory を出力し、PR Z の入力に流す

--- a/docs/superpowers/specs/2026-04-14-parity-burndown-roadmap.md
+++ b/docs/superpowers/specs/2026-04-14-parity-burndown-roadmap.md
@@ -117,15 +117,57 @@ Phase 0 (契約整備 + baseline 再生成) ───┐
 - Phase 2.1 / 2.2 / 2.3 は相互独立 → 3 並列可能
 - Phase 3 は Phase 2.2 (segment-missing) と間接依存 (同じ slug で両方発生するケースあり) — 同じ slug に触る場合は順次、そうでなければ並列可
 
-## 5. 完了判定基準
+## 5. 完了判定基準 (Final DoD — 5 counter 0)
 
-Phase 1-4 全体の完了条件:
+Phase 1-4 全体の完了条件は、以下 **5 つの counter がすべて 0** であること。測定は JSON artifact (`parity-baseline.json` / `parity-check-status.json` / `snapshot-diff-status.json`) に対する機械的判定で行う。詳細と runtime 検出 3 枠 (actionable-baseline / parity-artifact-registry / advisory-residual) の責務分離は `docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md` を参照。
 
-- `parity-baseline.json` の entries が 10-20 件以下（`segment-inconclusive` 残を想定）
-- `segment-extra` / `segment-missing` / `section-structure-mismatch` / `segment-untranslated` / `segment-token-gap` / `segment-order-mismatch` がすべて 0 件
-- `parity-baseline.json` schema から allowlist 系フィールドが削除され、`source_parity_baseline.mjs` が bug backlog 前提にリファクタ済み
-- `npm run test`、`npm run lint`、`npm run build`、`npm run check:parity` が全て通る
-- 運用ドキュメント (`docs/OPS_DESIGN.md`、`docs/PARITY_GUIDE.md`) が burn-down 完了後の定常運用 (バグ検知 ≡ 失敗 gate) を反映している
+### baseline
+
+```
+parity-baseline.json.entries.length === 0
+parity-baseline.json.schemaVersion  === 2
+```
+
+### parity-check-status.json (summary counters)
+
+```
+summary.reportableActiveFiles === 0
+summary.baselinedIssues       === 0
+summary.advisoryQueueIssues   === 0
+summary.auditSignalIssues     === 0
+debug.artifactCoverage exists with keys { registryEntries, matchedHits, bySlug, byToken }
+```
+
+### snapshot-diff-status.json
+
+```
+summary.changed === 0 && summary.added === 0 && summary.removed === 0
+```
+
+### schema / runtime invariants
+
+```
+BASELINE_ELIGIBLE_TYPES ⊆ { segment-missing, segment-extra, segment-shifted,
+                             segment-untranslated, segment-token-gap,
+                             section-structure-mismatch, segment-order-mismatch }
+(reviewAfter は baseline schema / runtime tagging / summary / queue どこにも存在しない)
+(baselineReviewAfter / baselineExpired は issue / queue / issue_state どこにも存在しない)
+(inconclusiveReason は runtime issue 側にのみ存在。baseline entry schema には存在しない)
+isFrozenByBaseline(issue) ≡ issue.baselined === true
+alignSegments は必ず { slug } option 付きで呼ばれる (grep 検証)
+```
+
+### gates
+
+```
+npm run test && npm run lint && npm run build が green
+npm run check:parity && npm run check:snapshots:diff が green
+```
+
+### 運用ドキュメント
+
+- `docs/OPS_DESIGN.md` / `docs/PARITY_GUIDE.md` が burn-down 完了後の定常運用 (バグ検知 ≡ 失敗 gate) を反映している
+- `docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md` が 5 counter 0 DoD の根拠・測定方法・runtime 検出 3 枠・`debug.artifactCoverage` 契約・callout-normalization の single source of truth を記述している
 
 ## 6. リスク・緩和
 

--- a/docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md
+++ b/docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md
@@ -1,0 +1,193 @@
+# Parity Phase 4 — Final Goal (5 counter 0 DoD と artifact coverage 契約)
+
+- **Date**: 2026-04-14
+- **Author**: Claude (design)
+- **親 spec**: `docs/superpowers/specs/2026-04-14-parity-burndown-roadmap.md` §5
+- **実装 plan**: `docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md`
+- **Phase 0 契約**: `docs/superpowers/specs/2026-04-14-parity-oracle-contract-design.md`
+
+---
+
+## 1. 目的
+
+Phase 4 完了時の **最終状態 (Final DoD)** を「5 つの counter がすべて 0」で定義し、測定方法と runtime の検出分類 (3 枠) の責務を確定させる。burn-down 完了以降の定常運用 (バグ検知 ≡ 失敗 gate) は、この契約に従って CI と人手レビューが同じ基準を参照できることを保証する。
+
+本 spec は **docs 面の single source of truth**。runtime 側の具体値 (slug / token) は code に置き、docs からは「どこを truth source として見るか」を指示するのみ。
+
+---
+
+## 2. 5 counter 0 DoD (測定根拠)
+
+Phase 4 完了時、以下の 5 つの field はすべて 0 でなければならない。測定は機械判定。
+
+| # | counter | 参照 JSON | field path | 期待値 |
+|---|---|---|---|---|
+| 1 | baseline entries | `parity-baseline.json` | `entries.length` | `0` |
+| 2 | reportable active files | `parity-check-status.json` | `summary.reportableActiveFiles` | `0` |
+| 3 | baselined issues | `parity-check-status.json` | `summary.baselinedIssues` | `0` |
+| 4 | advisory queue issues | `parity-check-status.json` | `summary.advisoryQueueIssues` | `0` |
+| 5 | audit signal issues | `parity-check-status.json` | `summary.auditSignalIssues` | `0` |
+
+さらに補助不変量として:
+
+| 不変量 | 参照 | 期待値 |
+|---|---|---|
+| baseline schema | `parity-baseline.json` | `schemaVersion === 2` |
+| snapshot diff — 変更 | `snapshot-diff-status.json` | `summary.changed === 0` |
+| snapshot diff — 追加 | `snapshot-diff-status.json` | `summary.added === 0` |
+| snapshot diff — 削除 | `snapshot-diff-status.json` | `summary.removed === 0` |
+| artifact coverage shape | `parity-check-status.json` | `debug.artifactCoverage` が `{ registryEntries, matchedHits, bySlug, byToken }` を持つ |
+
+### 測定
+
+- `npm run check:parity` が `parity-baseline.json` / `parity-check-status.json` を書き出す
+- `npm run check:snapshots:diff` が `snapshot-diff-status.json` を書き出す
+- CI は 5 counter と補助不変量を JSON から直接読み、ひとつでも非 0 / shape 不一致なら fail
+
+---
+
+## 3. Schema v2 (baseline entry の最終形)
+
+`schemaVersion = 2` の loader は v1 entry を排他的に拒否する (migration は Task 4.6 の一度きり)。
+
+### entry fields
+
+- **削除**: `reviewAfter` / `inconclusiveCategory` / `inconclusiveReason` / `usabilityReason`
+- **追加**: `priority` (`high` / `medium` / `low`, default=`medium`) / `note` (optional, max 500 chars)
+- root `schemaVersion = 2`
+
+### `BASELINE_ELIGIBLE_TYPES` (v2, 7 種)
+
+```
+segment-missing, segment-extra, segment-shifted,
+segment-untranslated, segment-token-gap,
+section-structure-mismatch, segment-order-mismatch
+```
+
+(`segment-inconclusive` は v2 で baseline 対象外 — advisory-residual 枠で吸収する。runtime issue 側には残る)
+
+### `TYPES_ARG_ALLOWLIST` (v2, 2 種)
+
+```
+section-structure-mismatch, segment-order-mismatch
+```
+
+### `isFrozenByBaseline` (v2)
+
+`issue.baselined === true` のみ。`baselineExpired` / `reviewAfter` 参照はすべて撤去。
+
+---
+
+## 4. Runtime 検出 3 枠 (責務分離)
+
+runtime (`check_source_parity.mjs` 経由) が検出する parity 差分は、以下 3 枠のいずれかに必ず分類される。どの枠が counter=0 にどう寄与するかも明記する。
+
+### 4.1 actionable-baseline
+
+- **定義**: 実コンテンツの parity bug (翻訳・構造・token 抜け)。baseline entry として登録され、修正対象。
+- **DoD 時の状態**: Phase 4 完了時に **entries.length === 0**。したがって `summary.baselinedIssues === 0` が連動して満たされる。
+- **測定**: `parity-baseline.json.entries[]` にすべてここから流入。
+
+### 4.2 parity-artifact-registry
+
+- **定義**: EN 側の不可解な残置物 (壊れたリンク、demo link など、翻訳でも normalizer でも直らないもの) を **slug-scope の static registry** で抑止する。runtime は該当 (slug, token) をマッチしたら issue を emit せず `coverage.record()` を叩く。
+- **Truth source**: `scripts/lib/parity_artifact_registry.mjs` の `ARTIFACT_REGISTRY` 定数 (entry は `{ slugs, token, reason, expectedIssueType, addedAt, linkedIssue? }` の frozen record)。
+- **DoD 時の状態**: baseline には登録しない。registry 抑止は `debug.artifactCoverage.matchedHits` に加算され、通過実績が可観測。
+- **docs に slug / token を書かない**: 「追加・削除時は `ARTIFACT_REGISTRY` を更新する」とだけ docs に書く (本 spec 含む)。
+
+### 4.3 advisory-residual
+
+- **定義**: alignment が確信を持てず判断保留にした issue (`segment-inconclusive`)。baseline にも artifact registry にも該当しない、自動判定の限界ケース。
+- **DoD 時の状態**: Phase 4 完了時に **全件解消** する方針 (翻訳 or alignment 改善 or artifact 昇格のいずれか)。`summary.advisoryQueueIssues === 0` で measure。
+- **注意**: baseline entry schema には `inconclusiveReason` / `inconclusiveCategory` を持たない。runtime issue 側にのみ存在する (v2 spec)。
+
+### 3 枠と counter の対応
+
+```
+actionable-baseline         → summary.baselinedIssues
+parity-artifact-registry    → debug.artifactCoverage.matchedHits (baseline には流さない)
+advisory-residual           → summary.advisoryQueueIssues
+reportable / audit signal   → 上記の複合 (いずれか > 0 なら非 0)
+```
+
+---
+
+## 5. `debug.artifactCoverage` 契約 (runtime aggregate)
+
+artifact registry の抑止が **どの run で何件効いたか** を traceable にするための、`parity-check-status.json` 上の専用 debug field。
+
+### shape (固定)
+
+```
+status.debug.artifactCoverage = {
+  registryEntries: <number>,  // ARTIFACT_REGISTRY.length (静的)
+  matchedHits:     <number>,  // 当該 run で registry 抑止が発火した延べ件数
+  bySlug:          <object>,  // { [slug]: hitCount, ... }
+  byToken:         <object>,  // { [token]: hitCount, ... }
+}
+```
+
+### 生成主体
+
+- `scripts/lib/parity_artifact_registry.mjs` の `createArtifactCoverage()` が runtime aggregator を返す (`record({ slug, token, reason })` / `snapshot()`)
+- `scripts/lib/source_parity_align.mjs` の `alignSegments(enSections, jaSections, { slug, coverage })` が抑止時に `coverage.record()` を叩く
+- `scripts/check_source_parity.mjs` が `status.debug.artifactCoverage = coverage.snapshot()` を書き出す (新 module は作らない)
+
+### CI / 人が読むときの規範
+
+- shape assertion (4 field の存在と型) は gate。`matchedHits` の絶対値は参考値。
+- registry に新 entry を加えると `registryEntries` が増える。
+- ある slug / token の `bySlug` / `byToken` が期待に反して 0 なら、**抑止対象が実在しない** (= registry entry が stale) か、runtime 側の配線不備を疑う。
+
+---
+
+## 6. `debug.maskCoverage` との分離 (Phase 0 契約再掲)
+
+`debug.maskCoverage` は **glossary / invariant mask** 専用の runtime observability で、Phase 0 で導入済み。`debug.artifactCoverage` とは **別責務・別 field** として独立に存続する。
+
+| field | 対象 | 生成 |
+|---|---|---|
+| `debug.maskCoverage` | glossary mask + invariant token mask の適用統計 | Phase 0 で整備済み (mask 層) |
+| `debug.artifactCoverage` | EN-side artifact registry の抑止統計 | Phase 4 Task 4.2 で新設 (registry 層) |
+
+artifact registry の抑止を mask 層に混ぜない。mask は segment text を書き換えるが、artifact registry は segment 判定結果を **間引く** 層であり、責務が異なる。
+
+---
+
+## 7. Intentional Divergence (turndown singleton 非侵襲)
+
+EN / JA で意図的に構造が異なる page (例: EN の `<blockquote>` warning 風 callout を JA で `<div class="callout-note">` に書いている、といった kind-level のズレ) は、**HTML extractor の slug allow-list 限定 rule** で吸収する。
+
+- **場所**: `scripts/lib/source_parity_segments_en.mjs` の `preprocessHtml(html, options)` / `extractSegmentsFromHtml(html, options)` が `{ slug, calloutAllowSlugs }` を受け取り、allow list に入る slug のときだけ EN 側 HTML を書き換える
+- **turndown singleton は触らない**: turndown の global replacement rule を変更すると全 slug に副作用が及ぶため、必ず HTML extractor 層 (preprocess) に封じ込める
+- **page-level exclusion (`source_sync_exclusions.mjs`) との違い**: exclusion は壊れた EN page を snapshot 同期から **丸ごと lock** するための別機能。artifact 抑止 / intentional divergence 正規化とは責務が異なる
+
+### page-level exclusion
+
+- `scripts/lib/source_sync_exclusions.mjs` の registry で壊れた EN page を隔離し、snapshot 上書きを抑止する (詳細は `docs/DOCS_DATE_TRACKING.md`)
+- `source-sync-status.json.excludedPages` counter で可視化
+- **artifact 抑止 (§4.2) や callout-normalization (§8) と混ぜない**: 対象も層も目的も異なる
+
+---
+
+## 8. callout-normalization (parity HTML extractor 限定正規化)
+
+EN snapshot の warning-like な短い `<blockquote>` は、slug allow list に含まれる場合に限り `<div class="callout-note">` に書き換え、JA 側 callout と kind-level parity を保つ。
+
+**allow list の single source of truth:** `scripts/lib/source_parity_segments_en.mjs` の `CALLOUT_NORMALIZATION_SLUGS` 定数。slug を追加 / 削除する際はこの定数を更新する (docs を先に書かない)。
+
+- 値 (slug list) を本 spec に書かない。code 側と二重管理になると stale の発生源になる。
+- 運用ドキュメント (`docs/PARITY_GUIDE.md` 等) からもこの定数を truth source として参照する。
+
+---
+
+## 9. Non-goals / 書かないこと
+
+本 spec には以下を書かない。truth source は code に置く:
+
+- `ARTIFACT_REGISTRY` の具体的な slug / token 値
+- `CALLOUT_NORMALIZATION_SLUGS` の具体的な slug 値
+- `BASELINE_ELIGIBLE_TYPES` の将来拡張案 (7 種固定)
+- Phase 4 完了後の hypothetical な拡張機能
+
+これらが必要になったら、先に code / plan を更新し、本 spec はあくまで契約 (何をどこで真とするか) のみを保持する。

--- a/docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.json
+++ b/docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.json
@@ -1,0 +1,16980 @@
+{
+  "baseline": {
+    "total": 1873,
+    "byIssueType": {
+      "section-structure-mismatch": 56,
+      "segment-extra": 87,
+      "segment-missing": 107,
+      "segment-untranslated": 1571,
+      "segment-token-gap": 40,
+      "segment-inconclusive": 11,
+      "segment-order-mismatch": 1
+    }
+  },
+  "buckets": {
+    "actionable": [
+      {
+        "slug": "administration/copilot-license-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assigning seats to users",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/copilot-license-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assigning seats to users",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/copilot-license-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing current Copilot license allocation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/copilot-license-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing current Copilot license allocation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-extra",
+        "sectionPath": "Using Encrypted Credentials in Tests > Adding encrypted credentials to Param File > Making the Param File compatible with encrypted credentials",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-missing",
+        "sectionPath": "Using Encrypted Credentials in Tests > Adding encrypted credentials to Param File > Making the Param File compatible with encrypted credentials",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Running test with encrypted credentials summary > Running tests with encrypted credentials in the Test Data",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": [
+          "/tests/run"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring the Encrypted Credentials > Creating an Encrypted Credential",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring the Encrypted Credentials > Creating an Encrypted Credential",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How encrypted credentials are used in test runs",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests with Encrypted Credentials > API Runs",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests with Encrypted Credentials > API Runs",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests with Encrypted Credentials > API Runs",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests with Encrypted Credentials > API Runs",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests with Encrypted Credentials > API Runs",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests with Encrypted Credentials > CLI Runs",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests with Encrypted Credentials > CLI Runs",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests with Encrypted Credentials > CLI Runs",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests with Encrypted Credentials > CLI Runs",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests with Encrypted Credentials > Scheduler Runs",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running test with encrypted credentials summary",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running test with encrypted credentials summary > Running tests with encrypted credentials in the Test Data",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running test with encrypted credentials summary > Running tests with encrypted credentials in the Test Data",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running test with encrypted credentials summary > Running tests with encrypted credentials in the Test Data",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running test with encrypted credentials summary > Running tests with encrypted credentials in the Test Data",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Encrypted Credentials in Tests",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Encrypted Credentials in Tests > Adding encrypted credentials to Config File",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Encrypted Credentials in Tests > Adding encrypted credentials to Config File > Encrypted credentials syntax",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Encrypted Credentials in Tests > Adding encrypted credentials to Param File > Encrypted credentials syntax",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Encrypted Credentials in Tests > Adding encrypted credentials to Param File > Making the Param File compatible with encrypted credentials",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Encrypted Credentials in Tests > Adding encrypted credentials to Test Data",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Encrypted Credentials in Tests > Adding encrypted credentials to Test Data > Encrypted credentials syntax",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/encrypted-credentials",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing Test Runs with Encrypted Credentials",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-and-user-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-and-user-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-and-user-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "View Company Teammates > Changing/Adding Company Owner and Project Owners",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-and-user-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "View Company Teammates > Remove Company Owner",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-and-user-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "View Company Teammates > Removing Company Teammates",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "General Settings > Project Name",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "General Settings > Default Base URL",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "General Settings > Hidden Parameters",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-missing",
+        "sectionPath": "General Settings > Default Base URL",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-missing",
+        "sectionPath": "General Settings > Hidden Parameters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-missing",
+        "sectionPath": "General Settings > Project Name",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "General Settings > Allow auto-complete suggestions",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "General Settings > Default Base URL",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "General Settings > Default Base URL",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "General Settings > Default Test Configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "General Settings > Hidden Parameters",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "General Settings > Hidden Parameters",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "General Settings > Project Name",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "General Settings > Project Name",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Pull Request Settings > Allowing self approval",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Pull Request Settings > Allowing self approval",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Pull Request Settings > Protecting branches from changes",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Pull Request Settings > Protecting branches from changes",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Pull Request Settings > Protecting branches from changes",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Pull Request Settings > Requiring approval from reviewer",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Pull Request Settings > Requiring approval from reviewer",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Pull Request Settings > Requiring approval from reviewer",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-user-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a teammate to a Project",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-user-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assigning and removing project owners",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-user-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assigning and removing project owners",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-user-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assigning and removing project owners",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-user-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Removing a teammate",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/project-user-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Removing a teammate",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Edit or Delete a Secret",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-extra",
+        "sectionPath": "Add Secrets to Param File > Making the Param File compatible with Secrets",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-extra",
+        "sectionPath": "Edit or Delete a Secret",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-extra",
+        "sectionPath": "Edit or Delete a Secret",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-extra",
+        "sectionPath": "Edit or Delete a Secret",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-extra",
+        "sectionPath": "Edit or Delete a Secret",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-missing",
+        "sectionPath": "Add Secrets to Param File > Making the Param File compatible with Secrets",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-missing",
+        "sectionPath": "Edit or Delete a Secret",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Add Secrets to Param File > Making the Param File compatible with Secrets",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a Secret",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a Secret",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Edit or Delete a Secret",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Secrets Manager",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Secrets Manager",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Use Secrets in Tests",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/secrets",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Use Secrets in Tests",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/subscription-plans",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "What is Counted Towards the Parallelism Quota",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/subscription-plans",
+        "issueType": "segment-extra",
+        "sectionPath": "What is Counted Towards the Parallelism Quota",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/subscription-plans",
+        "issueType": "segment-extra",
+        "sectionPath": "What is Counted Towards the Parallelism Quota",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/subscription-plans",
+        "issueType": "segment-extra",
+        "sectionPath": "What is Counted Towards the Parallelism Quota",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/subscription-plans",
+        "issueType": "segment-missing",
+        "sectionPath": "What is Counted Towards the Parallelism Quota",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/subscription-plans",
+        "issueType": "segment-untranslated",
+        "sectionPath": "What is Counted Towards the Parallelism Quota",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/advanced-js-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/advanced-js-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Where it can be used",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/advanced-js-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Where it can be used",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/advanced-set-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/advanced-set-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using a JavaScript expression to set text",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/advanced-set-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using a JavaScript expression to set text",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/advanced-set-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using a JavaScript expression to set text",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/advanced-set-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using a parameter to set text",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/advanced-set-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using a parameter to set text",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/advanced-set-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using a parameter to set text",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-extra",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate API Step > Checking the request outside of the context of the AUT",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an API Action Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an API Action Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an API Action Step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Including a File and/or Text field with an API Call Using Form Data",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Including a File and/or Text field with an API Call Using Form Data",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Parameters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Parameters > Using parameters in the sent HTTP request > Adding parameters to the URL",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the result after the run",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the result after the run",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the result after the run",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the result after the run",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/api-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the result after the run",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Reviewing auto-grouping suggestion",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-extra",
+        "sectionPath": "Reviewing auto-grouping suggestion",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-extra",
+        "sectionPath": "Reviewing auto-grouping suggestion",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-missing",
+        "sectionPath": "Reviewing auto-grouping suggestion",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-missing",
+        "sectionPath": "Reviewing auto-grouping suggestion",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating the shared group based on the suggestion",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating the shared group based on the suggestion",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating the shared group based on the suggestion",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering auto-grouping suggestions",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering auto-grouping suggestions",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reviewing auto-grouping suggestion",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reviewing auto-grouping suggestion",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reviewing auto-grouping suggestion",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reviewing auto-grouping suggestion",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reviewing auto-grouping suggestion > Editing the auto-grouping suggestion",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Sorting auto-grouping suggestions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Sorting auto-grouping suggestions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Sorting auto-grouping suggestions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Sorting auto-grouping suggestions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Sorting auto-grouping suggestions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/auto-grouping2",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Sorting auto-grouping suggestions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/clear-text-mobile",
+        "issueType": "segment-extra",
+        "sectionPath": "Limitations",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/clear-text-mobile",
+        "issueType": "segment-missing",
+        "sectionPath": "Limitations",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/coding-assistant",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Examples",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/coding-assistant",
+        "issueType": "segment-extra",
+        "sectionPath": "Examples",
+        "segmentKind": "details-summary",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/coding-assistant",
+        "issueType": "segment-extra",
+        "sectionPath": "Examples",
+        "segmentKind": "details-summary",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/coding-assistant",
+        "issueType": "segment-extra",
+        "sectionPath": "Examples",
+        "segmentKind": "details-summary",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/coding-assistant",
+        "issueType": "segment-extra",
+        "sectionPath": "Examples",
+        "segmentKind": "details-summary",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/coding-assistant",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/coding-assistant",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/coding-assistant",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/coding-assistant",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/coding-assistant",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/coding-assistant",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/coding-assistant",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Getting Cookies > Getting Cookies using the Get Cookie step",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-missing",
+        "sectionPath": "Getting Cookies > Getting Cookies using the Get Cookie step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Getting Cookies > Getting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Getting Cookies > Getting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Getting Cookies > Getting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Getting Cookies > Getting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Getting Cookies > Getting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Getting Cookies > Getting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Getting Cookies > Getting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Getting Cookies > Getting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Getting Cookies > Getting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Getting Cookies > Getting Cookies using the Get Cookie step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Getting Cookies > Getting Cookies using the Get Cookie step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Getting Cookies > Getting Cookies using the Get Cookie step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using a Configuration File",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using a Configuration File",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using a custom JS (JavaScript) step",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Set Cookie step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Set Cookie step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Set Cookie step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Set Cookie step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Set Cookie step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Set Cookie step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Set Cookie step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Set Cookie step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Set Cookie step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Set Cookie step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Set Cookie step",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Setup step – “Test Data” property",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Setup step – “Test Data” property",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Setup step – “Test Data” property",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Setup step – “Test Data” property",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/cookies",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies > Setting Cookies using the Setup step – “Test Data” property",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/custom-action-step-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/custom-action-step-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/custom-action-step-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/custom-action-step-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Custom Action (mobile) Step to your Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/custom-action-step-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Custom Action (mobile) Step to your Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/custom-action-step-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Custom Action (mobile) Step to your Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/custom-action-step-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Custom Action (mobile) Step to your Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/custom-action-step-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported Appium methods on VMG",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/data-driven-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Cookies",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/data-driven-testing/configuring-a-data-driven-test-from-the-visual-editor",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/data-driven-testing/configuring-a-data-driven-test-from-the-visual-editor",
+        "issueType": "segment-extra",
+        "sectionPath": "Adding test data by uploading a CSV/Excel file",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/data-driven-testing/configuring-a-data-driven-test-from-the-visual-editor",
+        "issueType": "segment-missing",
+        "sectionPath": "Adding test data by uploading a CSV/Excel file",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/data-driven-testing/configuring-a-data-driven-test-from-the-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/data-driven-testing/configuring-a-data-driven-test-from-the-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding test data by uploading a CSV/Excel file",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/data-driven-testing/configuring-data-driven-tests-using-data-from-an-external-source",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/data-driven-testing/configuring-data-driven-tests-using-the-config-file",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test level - adding an overrideTestData object",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/deep-link-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/deep-link-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Deep Link Step to your Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/deep-link-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Deep Link Step to your Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/deep-link-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Deep Link Step to your Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/deep-link-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Deep Link Step to your Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/deep-link-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Deep Link Step to your Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/deep-link-mobile/hide-keyboard-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/error-suffix-customization",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/extract-sms-message",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/extract-sms-message",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Parameters - Packages and JavaScript used in this example:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/extract-text",
+        "issueType": "segment-extra",
+        "sectionPath": "Add Extract Value Step to a Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/extract-text",
+        "issueType": "segment-missing",
+        "sectionPath": "Add Extract Value Step to a Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/group-context",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting a context for a group",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/group-context",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting a context for a group > Selecting the largest element in the DOM",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/handling-ui-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/handling-ui-actions/drag-drop-step",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Modify the \"Drop\" Target",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/handling-ui-actions/drag-drop-step",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Use Native events",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/handling-ui-actions/drag-drop-step",
+        "issueType": "segment-extra",
+        "sectionPath": "Modify the \"Drop\" Target",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/handling-ui-actions/drag-drop-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Use Native events",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/handling-ui-actions/drag-drop-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Use Native events",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/handling-ui-actions/scroll",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Fine Tuning Scroll Steps > Adjusting a Scroll to Element Step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/handling-ui-actions/scroll",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Fine Tuning Scroll Steps > Using Dynamic Scroll",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Creating Hooks via the Config File",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "/docs/configuration-file-parameters#defining-parameters-in-a-configuration-file",
+          "/docs/configuration-file-run-hooks"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Common usage examples for hooks > Before and after each step hook usage examples:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Configuration List screen",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Configuration List screen",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Configuration List screen",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Configuration List screen",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Configuration List screen",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Configuration List screen",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Configuration List screen",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Configuration List screen",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Configuration List screen",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Configuration List screen",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Configuration List screen",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Default Configuration setting",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Default Configuration setting",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Default Configuration setting",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Default Configuration setting",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Default Configuration setting",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Default Configuration setting",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Default Configuration setting",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Default Configuration setting",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Properties panel",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Properties panel",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Properties panel",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Properties panel",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Properties panel",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Properties panel",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Properties panel",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Creating Hooks Via the Test Configuration > Creating hooks via the Properties panel",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Test Configuration Hooks Run Parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Before/After Hooks > Test Configuration Hooks Run Parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Hooks via the Config File",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating Hooks via the Config File",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Hooks Visualizations",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Hooks Visualizations > Viewing before/after each step hooks",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Hooks Visualizations > Viewing before/after each step hooks",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Hooks Visualizations > Viewing before/after each step hooks",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Hooks Visualizations > Viewing before/after test hooks",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Hooks Visualizations > Viewing before/after test hooks",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Hooks Visualizations > Viewing errors related to hooks",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-extra",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-missing",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-missing",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-missing",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-missing",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-missing",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-missing",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-missing",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-missing",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Manually adding the Add keyboard shortcut step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Manually adding the Add keyboard shortcut step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Manually adding the Add keyboard shortcut step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Manually adding the Add keyboard shortcut step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/keyboard-shortcut-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported keyboard shortcuts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/loops",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using the Loop Iterator Parameter",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/loops",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using the Loop Iterator Parameter > Example 2",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/loops",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using the Loop Iterator Parameter > Example 2",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/loops",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using the Loop Iterator Parameter > Example 2",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Predefined (out of the box) parameters > Testim Iterator Parameter",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "/docs/loops#using-the-loop-iterator-parameter"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Predefined (out of the box) parameters > Base URL Parameter",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/configuration-file-parameters",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution level - placing parameters in the return section",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/configuration-file-parameters",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution level - placing parameters in the return section",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/exports-parameters",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Exporting a parameter",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/hidden-parameters",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/hidden-parameters",
+        "issueType": "segment-extra",
+        "sectionPath": "Run a test with hidden parameters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/hidden-parameters",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/hidden-parameters",
+        "issueType": "segment-missing",
+        "sectionPath": "Run a test with hidden parameters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/hidden-parameters",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Add a hidden parameter",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/hidden-parameters",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Edit or delete a hidden parameter",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/parameter-override-rules",
+        "issueType": "segment-extra",
+        "sectionPath": "The overriding Rules > Before the test begins:",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/parameter-override-rules",
+        "issueType": "segment-missing",
+        "sectionPath": "The overriding Rules > Before the test begins:",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/parameter-override-rules",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "/docs/exports-parameters",
+          "/docs/index",
+          "/docs/running-tests/configuration-file-run-hooks",
+          "http://testim.io"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/parameter-override-rules",
+        "issueType": "segment-token-gap",
+        "sectionPath": "The overriding Rules > Before the test begins:",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": [
+          "/docs/running-tests/configuration-file-run-hooks"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/parameter-override-rules",
+        "issueType": "segment-untranslated",
+        "sectionPath": "The overriding Rules > Usage",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/parameter-override-rules",
+        "issueType": "segment-untranslated",
+        "sectionPath": "The overriding Rules > Usage",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/parameters-for-groups",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assigning Parameters to Steps in a Group",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/parameters-for-groups",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assigning Parameters to Steps in a Group",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/parameters-for-groups",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reusing the Group with the Parameters",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/parameters-in-custom-javascript-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using the parameter in the step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/passing-parameters-from-excel-file",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/passing-parameters-from-excel-file",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/passing-parameters-from-excel-file",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/parameters/passing-parameters-from-excel-file",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assign a test data file to your test > Convert your existing test data to a test data file",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assign a test data file to your test > Convert your existing test data to a test data file",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assign a test data file to your test > Convert your existing test data to a test data file",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assign a test data file to your test > Convert your existing test data to a test data file",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assign a test data file to your test > Convert your existing test data to a test data file",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assign a test data file to your test > Reuse a test data file",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assign a test data file to your test > Reuse a test data file",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assign a test data file to your test > Reuse a test data file",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assign a test data file to your test > Reuse a test data file",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to use Test Data in Testim",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to use Test Data in Testim",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Manage your test data file",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Override default test data with scheduler",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Override default test data with scheduler",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Override default test data with scheduler",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Override default test data with scheduler",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Restore deleted test data files",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Upload your test data file",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/reusable-test-data",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Upload your test data file",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce APEX Action Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce APEX Action Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce APEX Action Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce APEX Action Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce APEX Action Step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce APEX Action Step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce APEX Action Step > Using parameters",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce APEX Action Step > Using parameters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce APEX Action Step > Using parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce APEX Action Step > Using parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce APEX Action Step > Using parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Salesforce APEX Action Example > Validating a new account",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the APEX Action Result Log",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-apex-action-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the APEX Action Result Log",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce Auto-Login Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce Auto-Login Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce Auto-Login Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce Auto-Login Step > Using parameters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce Auto-Login Step > Using parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce Auto-Login Step > Using parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Salesforce Auto-Login Step > Using parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "MFA Authentication",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up MFA",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up MFA",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up MFA",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up MFA",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up MFA",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up MFA",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up MFA",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up MFA",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up MFA",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/salesforce-auto-login-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up MFA",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/set-geolocation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/accessibility-validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/accessibility-validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate page accessibility step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/accessibility-validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate page accessibility step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/accessibility-validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate page accessibility step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/accessibility-validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate page accessibility step",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/accessibility-validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate page accessibility step",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/accessibility-validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the page accessibility results",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/accessibility-validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the page accessibility results",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/accessibility-validations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the page accessibility results",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-extra",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-missing",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-missing",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a CLI step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a CLI step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a CLI step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a CLI step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a CLI step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a CLI step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a CLI step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a CLI step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a CLI step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a CLI step > CLI step examples",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-cli-validations-and-actions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Capturing Request and Response Body",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Capturing Request and Response Body",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Capturing Request and Response Body > Adding the request/response body to the add network validation step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Capturing Request and Response Body > Adding the request/response body to the add network validation step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Network Validation",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Network Validation",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Network Validation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Network Validation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Network Validation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Network Validation",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Network Validation",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Network Validation",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Network Validation",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Network Validation",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Network Validation",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/checkbox-and-radio-button-validation",
+        "issueType": "segment-missing",
+        "sectionPath": "Adding a Validate checkbox/radio button step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/checkbox-and-radio-button-validation",
+        "issueType": "segment-missing",
+        "sectionPath": "Modifying a Validate checkbox/radio button step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/checkbox-and-radio-button-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/checkbox-and-radio-button-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate checkbox/radio button step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/checkbox-and-radio-button-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Modifying a Validate checkbox/radio button step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/css-property-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Modifying a Validate CSS property step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code",
+        "issueType": "segment-missing",
+        "sectionPath": "Adding an Add custom validation step or an Add custom action step > Custom validation and action examples > Navigating to a different website (Custom action)",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an Add custom validation step or an Add custom action step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an Add custom validation step or an Add custom action step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an Add custom validation step or an Add custom action step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an Add custom validation step or an Add custom action step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an Add custom validation step or an Add custom action step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an Add custom validation step or an Add custom action step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an Add custom validation step or an Add custom action step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an Add custom validation step or an Add custom action step",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an Add custom validation step or an Add custom action step > Custom validation and action examples > Asynchronous Validation via Promise (Custom validation)",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an Add custom validation step or an Add custom action step > Custom validation and action examples > Navigating to a different website (Custom action)",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "When to run outside of the browser (in Node.js)",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/custom-code-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "When to run within the browser",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/element-accessibility-validation",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Adding a Validate element accessibility step",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/element-accessibility-validation",
+        "issueType": "segment-extra",
+        "sectionPath": "Adding a Validate element accessibility step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/element-accessibility-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/element-accessibility-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/element-accessibility-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate element accessibility step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/element-accessibility-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate element accessibility step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/element-accessibility-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate element accessibility step",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/element-accessibility-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate element accessibility step",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/element-accessibility-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the element accessibility results",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/element-accessibility-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the element accessibility results",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/element-accessibility-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the element accessibility results",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validate Email Step using the Codeless Option",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validate Email Step using the Codeless Option",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validate Email Step using the Codeless Option",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validate Email Step using the Codeless Option",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validate Email Step using the Codeless Option",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validate Email Step using the Codeless Option",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validate Email Step using the Codeless Option",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validate Email Step using the Codeless Option",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validate Email Step using the Codeless Option",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validation Email Step using the Coded Option",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validation Email Step using the Coded Option",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validation Email Step using the Coded Option",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validation Email Step using the Coded Option",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validation Email Step using the Coded Option",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validation Email Step using the Coded Option > Coded email validation examples > Validate links in body",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Validate Email Step > Creating a Validation Email Step using the Coded Option > Coded email validation examples > Validate sign-up subject line",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Option A - Creating a permanent email address > Using the permanent email in the relevant steps of the test",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Option B - Generating a temporary email address > Adding the Generate Email Address step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Sending emails to the appropriate Testim inbox in advance > Using a Run API Action step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/email-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Sending emails to the appropriate Testim inbox in advance > Using a Run API Action step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/file-upload-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/file-upload-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a file upload step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/file-upload-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a file upload step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/file-upload-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a file upload step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/file-upload-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/file-upload-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/html-attribute-validation",
+        "issueType": "segment-missing",
+        "sectionPath": "Modifying a Validate HTML attribute step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/html-attribute-validation",
+        "issueType": "segment-missing",
+        "sectionPath": "Modifying a Validate HTML attribute step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/html-attribute-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate HTML attribute step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/html-attribute-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Modifying a Validate HTML attribute step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/html-attribute-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Modifying a Validate HTML attribute step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mongodb-validation",
+        "issueType": "segment-missing",
+        "sectionPath": "Parameters - Packages and JavaScript used in this example:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mongodb-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mongodb-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Parameters - Packages and JavaScript used in this example:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mongodb-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Parameters - Packages and JavaScript used in this example:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mongodb-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Parameters - Packages and JavaScript used in this example:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mongodb-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Parameters - Packages and JavaScript used in this example:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mongodb-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Parameters - Packages and JavaScript used in this example:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mysql-validation",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Parameters - Packages and JavaScript used in this example:",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mysql-validation",
+        "issueType": "segment-missing",
+        "sectionPath": "Parameters - Packages and JavaScript used in this example:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mysql-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mysql-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mysql-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Parameters - Packages and JavaScript used in this example:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mysql-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Parameters - Packages and JavaScript used in this example:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/mysql-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Parameters - Packages and JavaScript used in this example:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-missing",
+        "sectionPath": "Visual Validation Parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "/docs/integrations/visual-validation",
+          "/docs/integrations/visual-validation/lambdatest_integration"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying step-level visual validation settings",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying step-level visual validation settings",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying step-level visual validation settings",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying step-level visual validation settings",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying test-level visual validation settings in the Editor",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying test-level visual validation settings in the Editor",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying test-level visual validation settings in the Editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying test-level visual validation settings in the Editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying test-level visual validation settings in the Editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying visual validation settings in the test Configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying visual validation settings in the test Configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying visual validation settings in the test Configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying visual validation settings in the test Configuration",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying visual validation settings in the test Configuration",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying visual validation settings in the test Configuration",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/pixel-validation-and-pixel-wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Visual Validation Parameters > Modifying visual validation settings in the test Configuration",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Validate download examples > PDF files",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-extra",
+        "sectionPath": "Validate download examples > PDF files",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-extra",
+        "sectionPath": "Validate download examples > PDF files",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-missing",
+        "sectionPath": "Validate download examples > PDF files",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Adding a Validate download step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": [
+          "30000ms"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate download step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate download step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate download step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate download step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate download step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate download step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate download step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate download step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate download step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Prerequisites",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validate download examples > CSV files",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validate download examples > Image files",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validate download examples > MS Excel files",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validate download examples > MS PowerPoint files",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validate download examples > MS PowerPoint files",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validate download examples > MS Word files",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validate download examples > MS Word files",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validate download examples > PDF files",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validate download examples > PDF files",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validate download examples > PDF files",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-download",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validate download examples > PDF files",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-attribute",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate Element Attribute step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-attribute",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate Element Attribute step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-attribute",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate Element Attribute step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-attribute",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate Element Attribute step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-attribute",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate Element Attribute step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-attribute",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate Element Attribute step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-attribute",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Modifying a Validate element attribute step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-not-visible",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-not-visible",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate element not visible step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using a parameter > Parameter only",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-extra",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using a parameter",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-extra",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using a parameter > Parameter only",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-missing",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using a parameter",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-missing",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using a parameter > Parameter only",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-missing",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using a parameter > Parameter only",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-missing",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using a parameter > Parameter only",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using a parameter > Parameter only",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": [
+          "/docs/advanced-editing/data-driven-testing"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using Regular Expression (Regex) > Multiple Options (OR) with Parameters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using Regular Expression (Regex) > Multiple Options (OR) with Parameters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using Regular Expression (Regex) > Not Equal Validation",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using Regular Expression (Regex) > Not Equal Validation",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using a parameter > Parameter only",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using a parameter > Parameter only",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using a parameter > Parameter only",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-text",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Advanced text validation (Mobile & Web) > Using a parameter > Parameter only",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-visible",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-visible",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate element visible step (Mobile)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-visible",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Validate element visible step (Web)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-element-visualization",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-full-page-visualization",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-full-page-visualization",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-viewport-visualization",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/validate-viewport-visualization",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/wait-for-element-visualization",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/wait-for-element-visualization",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/wait-for-element-visualization",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/wait-for-element-visualization",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "https://applitools.com/"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/wait-for-element-visualization",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/validations/wait-for-element-visualization",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/wait-for",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Wait for element text (Web)",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/wait-for",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Wait for element text (Mobile)",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/wait-for",
+        "issueType": "segment-missing",
+        "sectionPath": "Wait for element text (Mobile)",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/wait-for",
+        "issueType": "segment-missing",
+        "sectionPath": "Wait for element text (Web)",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Custom Wait for (Web)",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Custom Wait for (Web)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Custom Wait for (Web)",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Wait for Download (Web)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Wait for element not visible (Web) > Wait for element not visible delay",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Wait for element text (Mobile)",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Wait for element visible (Mobile)",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "advanced-editing/wait-for",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Wait for element visible (Web)",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/debug-helper-panels",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Breakpoint Manager Helper Panel > Delete Breakpoints",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/debug-helper-panels",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Breakpoint Manager Helper Panel > Navigate to a Breakpoint Location within the Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/debug-helper-panels",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Console Log Helper Panel > Filtering Console Logs",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/js-code-debugging",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/js-code-debugging",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Debugging the JS Code in a supported step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/js-code-debugging",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Debugging the JS Code in a supported step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/js-code-debugging",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Debugging the JS Code in a supported step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/js-code-debugging",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Debugging the JS Code in a supported step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/js-code-debugging",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Debugging the JS Code in a supported step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/js-code-debugging",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Debugging the JS Code in a supported step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/js-code-debugging",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Debugging the JS Code in a supported step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/js-code-debugging",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Debugging the JS Code in a supported step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/js-code-debugging",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Debugging the JS Code in a supported step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/recording-additional-steps-to-fix-bugs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Start recording",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/recording-additional-steps-to-fix-bugs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Start recording at this position",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "debugging-tests/recording-additional-steps-to-fix-bugs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Start recording at this position",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "device-management/view-local-connected-mobile-devices",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "device-management/view-local-connected-mobile-devices",
+        "issueType": "segment-untranslated",
+        "sectionPath": "View Connected Local Devices > Copying the device UDID",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-missing",
+        "sectionPath": "Configuring a Custom Condition > Try it yourself",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-missing",
+        "sectionPath": "Configuring an Element Condition > Try it yourself",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-missing",
+        "sectionPath": "Configuring an Element Text Condition > Try it yourself",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring a Custom Condition",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring a Custom Condition",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring a Custom Condition",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring a Custom Condition",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring a Custom Condition",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring a Custom Condition",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring a Custom Condition > Try it yourself",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring a Never Run Step Condition",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring an Element Condition",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring an Element Condition > Try it yourself",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring an Element Text Condition",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring an Element Text Condition > Try it yourself",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions/advanced-conditions-settings",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions/advanced-conditions-settings",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions/advanced-conditions-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions/advanced-conditions-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions/advanced-conditions-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions/advanced-conditions-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions/advanced-conditions-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/conditions/advanced-conditions-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Copy & Paste Steps > Pasting a step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Deleting Steps > Deleting an individual step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Deleting Steps > Deleting multiple steps",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Record Additional Steps > Recording additional steps between existing steps",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-a-steps-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Properties Configuration",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-a-steps-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Properties Configuration",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-a-steps-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Properties Configuration",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-a-steps-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Properties Configuration",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-a-steps-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Properties Configuration",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-a-steps-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Properties Configuration",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Improving the Target Element",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Improving the Target Element",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reassigning the Target Element",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reassigning the Target Element",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing Smart Locators",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing Smart Locators > Auto Improved Locators",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": [
+          "/docs/editing-tests/editing-your-tests/editing-target-element-properties"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": [
+          "/docs/editing-tests/editing-your-tests/editing-target-element-properties"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Machine learning mode > Setting the Threshold level in Machine learning mode and Vision Locate",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Machine learning mode > Viewing the locators in the Machine learning mode",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Machine learning mode > Viewing the locators in the Machine learning mode",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reassigning the Target Element",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing Locators",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing Locators > Editing Locators",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/editing-your-tests/editing-target-element-properties-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing Locators > Editing Locators",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-date",
+        "issueType": "segment-missing",
+        "sectionPath": "Adding a Generate Date step > Generate Date properties",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-date",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Adding a Generate Date step > Generate Date properties",
+        "segmentKind": "table-cell",
+        "missingTokens": [
+          "test.Suite"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-date",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Generate Date step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-date",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Generate Date step > Generate Date properties",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-date",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Generate Date step > Generate Date properties",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-date",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a Generate Date step > Generate Date properties",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/generating-a-random-value",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/groups",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/groups",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Group",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/groups",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Group",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/groups",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Modifying Groups",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/groups",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Modifying Groups",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/groups",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Specifying Group Properties (optional)",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/groups",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Specifying Group Properties (optional)",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/groups/auto-complete",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Auto complete settings",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/groups/auto-complete",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using the auto-complete feature",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/groups/auto-grouping",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/groups/auto-grouping",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/groups/auto-grouping",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/search-within-a-test",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Understanding the search results > Search limitations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": [
+          "-variable"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/search-within-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/search-within-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/search-within-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/search-within-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/search-within-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/search-within-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Understanding the search results",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/search-within-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Understanding the search results",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/shareable-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Actions",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/shareable-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Actions",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/shareable-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a New Shared Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/shareable-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a New Shared Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/shareable-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Turning an Existing Step into a Shared Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/shareable-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validations",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/shareable-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validations",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/shareable-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validations",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/shareable-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Wait for",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/shareable-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Wait for",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "editing-tests/steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Automatically Recorded Steps",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-codeless-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding Validation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-codeless-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding Validation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-codeless-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding Validation",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-codeless-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording the Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-codeless-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording the Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-codeless-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording the Test",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-codeless-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording the Test",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-codeless-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Tutorial Use Case",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Running a Mobile Test",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-extra",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Running a Mobile Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial!",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Before we begin",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Before we begin",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Recording a Mobile Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Recording a Mobile Test > Supported Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Recording a Mobile Test > Supported Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Running a Mobile Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-mobile-test-in-testim-visual-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Welcome to Testim's mobile testing tutorial! > Running a Mobile Test > Run Mobile Test in Testim Editor",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/setting-up-your-account",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Signing Up",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "guides/generate-random-data-with-js",
+        "issueType": "segment-token-gap",
+        "sectionPath": "How to assign Random Data to a step?",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": [
+          "step.This"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "guides/generate-random-data-with-js",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "guides/generate-random-data-with-js",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to assign Random Data to a step?",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "guides/keyboard-shortcuts",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "guides/keyboard-shortcuts",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "guides/keyboard-shortcuts",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "guides/keyboard-shortcuts",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "guides/keyboard-shortcuts",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "guides/keyboard-shortcuts",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "guides/mobile-web-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to author a mobile web test",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "guides/mobile-web-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Known Limitations",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Bitbucket integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Bitbucket integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Bitbucket integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Bitbucket integration",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting Bitbucket integration",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Bitbucket with Testim",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Bitbucket with Testim > New branch example",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Bitbucket with Testim > New branch example",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Bitbucket with Testim > New branch example",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Bitbucket with Testim > Pull Request and Merge",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Bitbucket with Testim > Pull Request and Merge",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Bitbucket with Testim > Pull Request and Merge",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bitbucket-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Bitbucket with Testim > Pull Request and Merge",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bug-tracker-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bug-tracker-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bug-tracker-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bug-tracker-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bug-tracker-settings",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bug-tracker-settings/connecting-testim-to-github",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bug-tracker-settings/connecting-testim-to-github",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bug-tracker-settings/connecting-testim-to-github",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/bug-tracker-settings/connecting-testim-to-github",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/dedicated-run-tunnel",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/dedicated-run-tunnel",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Additional use cases > Example using Testim CLI with a tunnel",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/dedicated-run-tunnel",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Additional use cases > Example using Testim CLI with a tunnel",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/dedicated-run-tunnel",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to use it",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/dedicated-run-tunnel",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to use it",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/github-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-extra",
+        "sectionPath": "Adding a grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-missing",
+        "sectionPath": "Adding a grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a grid",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Grid configurations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Grid configurations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Grid configurations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Grid configurations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Grid configurations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Grid configurations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Grid configurations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > Running from the editor (Mobile)",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > Running from the editor (Web)",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Mobile Testing Grids",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Mobile Testing Grids",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Web Testing Grids",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Web Testing Grids",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Web Testing Grids",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Web Testing Grids",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-missing",
+        "sectionPath": "How to add a Browserstack grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Browserstack grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Browserstack grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Browserstack grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Browserstack grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Browserstack grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the editor",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the editor",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the editor",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-1",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-missing",
+        "sectionPath": "How to add a LambdaTest grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a LambdaTest grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a LambdaTest grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a LambdaTest grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a LambdaTest grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a LambdaTest grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the editor",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the editor",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/browserstack-integration-copy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Add custom capabilities to a test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Add custom capabilities to a test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Add custom capabilities to a test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Available capabilities",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create custom capabilities",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create custom capabilities",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Schedule tests with custom capabilities",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Schedule tests with custom capabilities",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Schedule tests with custom capabilities",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Use custom capabilities with CLI",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Use custom capabilities with CLI",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Use custom capabilities with CLI",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-capabilities",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Use custom capabilities with CLI",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-grid",
+        "issueType": "segment-missing",
+        "sectionPath": "How to add a Custom Grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Custom Grid",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Custom Grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Custom Grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Custom Grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Custom Grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the editor",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/custom-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/headspin-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "How to add a HeadSpin grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/headspin-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a HeadSpin grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/headspin-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a HeadSpin grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/headspin-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to obtain the HeadSpin API Token",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/headspin-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to obtain the HeadSpin API Token",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-missing",
+        "sectionPath": "Override rules for a capability (mobile)",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": [
+          "--sauce-options"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Browserstack",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "--browserstack-options"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-token-gap",
+        "sectionPath": "SauceLabs",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "--sauce-options"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Browserstack",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Browserstack",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Browserstack",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Browserstack",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Browserstack",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Override rules for a capability (mobile)",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Override rules for a capability (mobile)",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Override rules for a capability (mobile)",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-browserstack-options",
+        "issueType": "segment-untranslated",
+        "sectionPath": "SauceLabs",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "How to add a Saucelabs grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Saucelabs grid",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Saucelabs grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Saucelabs grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Saucelabs grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to add a Saucelabs grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the Editor",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the Editor",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the Editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/saucelabs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to run on the grid > From the Editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/tricentis-device-cloud",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/tricentis-device-cloud",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Tricentis Device Cloud",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/tricentis-device-cloud",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Tricentis Device Cloud",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/tricentis-device-cloud",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Tricentis Device Cloud",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/tricentis-device-cloud",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Tricentis Device Cloud",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "/docs/mobile-apps/mobile-apps"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the CLI",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the CLI",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the CLI",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the CLI",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the CLI",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the Editor",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the Editor",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the Editor",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the scheduler",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the scheduler",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the scheduler",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the test plan",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the test plan",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Changing the app when recorded from device > From the test plan",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Running the test remotely",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Running the test remotely",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Running the test remotely",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Run Tests on Virtual Mobile Grid > Running the test remotely",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Start a Free Virtual Mobile Grid Trial",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/grid-management/virtual-mobile-grid",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to Start a Free Virtual Mobile Grid Trial",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Start now!",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Start now!",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Start now!",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/autorabit-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/autorabit-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/autorabit-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/autorabit-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/autorabit-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/autorabit-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/autorabit-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/autorabit-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/autorabit-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/bamboo-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps: > 1. Create a New plan in Bamboo:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/bamboo-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps: > 3. Add run Testim CLI task:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/bamboo-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps: > 4. Add collect test results task",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/bamboo-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps: > 4. Add collect test results task",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/circle-ci-integration",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "YAML File",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/circle-ci-integration",
+        "issueType": "segment-extra",
+        "sectionPath": "YAML File",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/circle-ci-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "YAML File",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/copado-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/copado-integration",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": [
+          "https://editor.swagger.io/?url=https://raw.githubusercontent.com/testimio/public-openapi/main/api.yaml"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/copado-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/copado-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/copado-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/copado-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/copado-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/copado-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/copado-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/copado-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/copado-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Pausing Copado deployment until test is complete or based on test result",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/copado-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Pausing Copado deployment until test is complete or based on test result",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/gearset-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/gearset-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/gearset-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/gearset-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/gearset-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/gearset-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/github-action-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/jenkins-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Now, just follow these steps: > Windows:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/jenkins-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/jenkins-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps: > Linux:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/jenkins-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps: > Windows:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/jenkins-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps: > Windows:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/jenkins-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps: > Windows:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/jenkins-integration-using-docker",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/jenkins-integration-using-docker",
+        "issueType": "segment-missing",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/jenkins-integration-using-docker",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/jenkins-integration-using-docker",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "segment-extra",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "segment-extra",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/vsts-and-tfs-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Now, just follow these steps:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/integrations-overview",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/qtest-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Setting qTest integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/qtest-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Connecting a test in Testim to a qTest test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/qtest-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running a test and viewing the Testim test results in qTest",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/qtest-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running a test and viewing the Testim test results in qTest",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/qtest-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting qTest integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/testrail-integration",
+        "issueType": "segment-extra",
+        "sectionPath": "Setting TestRail integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/testrail-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Setting TestRail integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/testrail-integration",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Note:",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "http://testim.io/"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/testrail-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/testrail-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Connecting a test in Testim to a TestRail test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/testrail-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Connecting a test in Testim to a TestRail test",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/testrail-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Note:",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/testrail-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting TestRail integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Setting up TTM for Jira Integration",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Running a test and viewing the Testim test results in TTM for Jira > Upon Testim test run execution end",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Running a test and viewing the Testim test results in TTM for Jira > Upon Testim test run execution end",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Setting up TTM for Jira Integration",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira > How to Know if a Test is Already Mapped to TTM for Jira",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira > How to Know if a Test is Already Mapped to TTM for Jira",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira > Unmap a Test Already Mapped to TTM for Jira",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Bulk Create & Map Test Cases to TTM for Jira > Unmap a Test Already Mapped to TTM for Jira",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Manually Map a test in Testim to TTM for Jira",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Manually Map a test in Testim to TTM for Jira",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running a test and viewing the Testim test results in TTM for Jira",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running a test and viewing the Testim test results in TTM for Jira",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running a test and viewing the Testim test results in TTM for Jira > Upon Testim test run execution end",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running a test and viewing the Testim test results in TTM for Jira > Upon Testim test run execution end",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running a test and viewing the Testim test results in TTM for Jira > Upon Testim test run execution end",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running a test and viewing the Testim test results in TTM for Jira > Upon Testim test run execution end",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up TTM for Jira Integration",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up TTM for Jira Integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up TTM for Jira Integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up TTM for Jira Integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up TTM for Jira Integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up TTM for Jira Integration",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up TTM for Jira Integration",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up TTM for Jira Integration",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "What is TTM for Jira?",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "What is TTM for Jira?",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "What is TTM for Jira?",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "What is TTM for Jira?",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Why do I need a TTM for Jira integration?",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Why do I need a TTM for Jira integration?",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/ttm-for-jira-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Why do I need a TTM for Jira integration?",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Setting up Xray integration",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Running a test and viewing the Testim test results in Xray",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-extra",
+        "sectionPath": "Running a test and viewing the Testim test results in Xray",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-extra",
+        "sectionPath": "Setting up Xray integration",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Running a test and viewing the Testim test results in Xray",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Setting up Xray integration",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Map a test in Testim to an Xray test case",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Map a test in Testim to an Xray test case",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running a test and viewing the Testim test results in Xray",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running a test and viewing the Testim test results in Xray",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running a test and viewing the Testim test results in Xray",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up Xray integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up Xray integration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up Xray integration",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up Xray integration",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "What is Xray?",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/test-management-integrations/xray-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Why do I need Xray integration?",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up Applitools integration > Step 1: Create an API key in Applitools Eyes",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up Applitools integration > Step 2: Configure Applitools settings in Testim",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Setting up Applitools integration > Step 2: Configure Applitools settings in Testim",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/lambdatest_integration",
+        "issueType": "segment-extra",
+        "sectionPath": "Before you start",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/lambdatest_integration",
+        "issueType": "segment-extra",
+        "sectionPath": "Before you start",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/lambdatest_integration",
+        "issueType": "segment-extra",
+        "sectionPath": "Before you start",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/lambdatest_integration",
+        "issueType": "segment-extra",
+        "sectionPath": "Before you start",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/lambdatest_integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Before you start",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/lambdatest_integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Before you start",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/lambdatest_integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Before you start",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/lambdatest_integration",
+        "issueType": "segment-missing",
+        "sectionPath": "Before you start",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/lambdatest_integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/lambdatest_integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Integrate LambdaTest SmartUI",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/lambdatest_integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Integrate LambdaTest SmartUI",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/override-applitools-app-name",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Archive > End of Support for IE 11 and Edge",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Archive > Enhanced Mode for Testim Mobile",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Archive > Integration with Tricentis Test Management (TTM) for Jira",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Archive > Test Plans in Scheduler",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Archive > Testim Mobile - Execute Driver Script step",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Archive > Testim Startup Promotion",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Archive > Tricentis Device Cloud integration with Testim Mobile",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Archive > Tricentis Test Management for Jira integration - Bulk Create and Map Tests",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Fasten Your Seatbelts! Optimized Process for Web Test Recordings",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Hidden Parameters have moved to Resources!",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Sealights test stage integration",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "http://testim.io"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/enhanced-mode-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/enhanced-mode-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/enhanced-mode-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Enhanced mode advantages",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/enhanced-mode-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Enhanced mode advantages",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/enhanced-mode-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Enhanced mode advantages",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/enhanced-mode-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "FAQ > Can I apply Enhanced mode on previously recorded tests?",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/enhanced-mode-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "FAQ > Can I select another mode for my test (not Enhanced mode)?",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/enhanced-mode-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "FAQ > Can I use Enhanced mode on other grids (not just VMG)?",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/enhanced-mode-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to use the Enhanced mode in Testim",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/enhanced-mode-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to use the Enhanced mode in Testim",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/enhanced-mode-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to use the Enhanced mode in Testim",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/help-ai-assistant",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/help-ai-assistant",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/help-ai-assistant",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/testim-automate",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execute your tests",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/testim-automate",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execute your tests",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/testim-automate",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Smart Locators - where a lot of the magic of Testim's AI happens",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/use-ai-in-with-testim/ai-data-usage-policy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/use-ai-in-with-testim/ai-data-usage-policy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Affected Components",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/use-ai-in-with-testim/ai-data-usage-policy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Customer Data Usage",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/use-ai-in-with-testim/ai-data-usage-policy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Opting in/out > Opting in:",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/use-ai-in-with-testim/ai-data-usage-policy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Opting in/out > Opting in:",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "overview/testim-overview/use-ai-in-with-testim/ai-data-usage-policy",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Terms of Use",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 1 - Create a New Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 2 - Setting the Base URL > Changing the Default URL",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 3 – Setting the Test Configuration > Adjusting the Test Configuration",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 3 – Setting the Test Configuration > Choose a different Test Configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 3 – Setting the Test Configuration > Choose a different Test Configuration",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 3 – Setting the Test Configuration > Test Configuration Parameters",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 3 – Setting the Test Configuration > Test Configuration Parameters",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 3 – Setting the Test Configuration > Test Configuration Parameters",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 3 – Setting the Test Configuration > Test Configuration Parameters",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 3 – Setting the Test Configuration > Test Configuration Parameters",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 3 – Setting the Test Configuration > Test Configuration Parameters",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 3 – Setting the Test Configuration > Test Configuration Parameters",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 3 – Setting the Test Configuration > Test Configuration Parameters",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 4 - Recording the test",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 4 - Recording the test > Pausing/Restarting a recording",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 4 - Recording the test > Pausing/Restarting a recording",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 5 - Saving a Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test/multi-windows-recording",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Allow pop-ups through Chrome settings:",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/how-to-record-a-test/multi-windows-recording",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Allow pop-ups through the address bar (while the test is running)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test",
+        "issueType": "segment-extra",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-extra",
+        "sectionPath": "Install Tricentis Mobile Agent on your Local Computer > Installing and Starting Tricentis Mobile Agent on Linux",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-missing",
+        "sectionPath": "Install Tricentis Mobile Agent on your Local Computer > Installing and Starting Tricentis Mobile Agent on Linux",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configure your Device > Prepare your iOS device > Configure Tricentis Mobile Agent iOS Artifacts",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configure your Device > Prepare your iOS device > Configure Tricentis Mobile Agent iOS Artifacts",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configure your Device > Prepare your iOS device > Configure Tricentis Mobile Agent iOS Artifacts",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configure your Device > Prepare your iOS device > Configure Tricentis Mobile Agent iOS Artifacts",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configure your Device > Prepare your iOS device > Enable iOS simulator",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configure your Device > Prepare your iOS device > Enable iOS simulator",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configure your Device > Prepare your iOS device > Enable iOS simulator",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configure your Device > Prepare your iOS device > Enable iOS simulator",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configure your Device > Prepare your iOS device > Get Apple team ID",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configure your Device > Prepare your iOS device > Install iTunes",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configure your Device > Prepare your iOS device > Prerequisites",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configure your Device > Prepare your iOS device > Upload iOS images",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Install Tricentis Mobile Agent on your Local Computer > Installing and Starting Tricentis Mobile Agent on Linux",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Install Tricentis Mobile Agent on your Local Computer > Installing and Starting Tricentis Mobile Agent on Linux",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Install Tricentis Mobile Agent on your Local Computer > Installing and Starting Tricentis Mobile Agent on Linux",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Install Tricentis Mobile Agent on your Local Computer > Installing and Starting Tricentis Mobile Agent on Linux",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Install Tricentis Mobile Agent on your Local Computer > Installing and Starting Tricentis Mobile Agent on Mac",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Install Tricentis Mobile Agent on your Local Computer > Installing and Starting Tricentis Mobile Agent on Windows",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Troubleshooting > UI Automator crash on Android devices",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Troubleshooting > UI Automator crash on Android devices",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Troubleshooting > WebDriverAgent (WDA) Errors",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Troubleshooting > WebDriverAgent (WDA) Errors",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Troubleshooting > iOS Simulators not Detected",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/how-to-prepare-an-ipa-for-mobile-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Build .ipa Files for Physical Devices using Xcode",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/how-to-prepare-an-ipa-for-mobile-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Build .ipa Files for Physical Devices using Xcode",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/how-to-prepare-an-ipa-for-mobile-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Build .ipa Files for Physical Devices using Xcode",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/how-to-prepare-an-ipa-for-mobile-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Build .ipa Files for Physical Devices using Xcode",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/how-to-prepare-an-ipa-for-mobile-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Build .ipa Files for Physical Devices using Xcode",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/how-to-prepare-an-ipa-for-mobile-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Build .ipa Files for Physical Devices using Xcode",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/how-to-prepare-an-ipa-for-mobile-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Build .ipa files for Virtual Devices using XCode",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/how-to-prepare-an-ipa-for-mobile-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Build .ipa files for Virtual Devices using XCode",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/how-to-prepare-an-ipa-for-mobile-testing",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Build .ipa files for Virtual Devices using XCode",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Device and Mobile Application Information",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Device and Mobile Application Information",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Device and Mobile Application Information",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Device and Mobile Application Information",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Device and Mobile Application Information > Change Mobile App Used for the Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Device and Mobile Application Information > Change Mobile App Used for the Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Mobile Test Action Panel",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Mobile Test Action Panel",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-editor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Mobile Test Action Panel",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-mirroring-toolbar",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-mirroring-toolbar",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-mirroring-toolbar",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/mobile-test-mirroring-toolbar",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 2 - Connect a Device > Connecting a physical Android device",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 2 - Connect a Device > Connecting a physical iOS device",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 2 - Connect a Device > Connecting a physical iOS device",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 2 - Connect a Device > Connecting a physical iOS device",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 2 - Connect a Device > Connecting a physical iOS device",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 2 - Connect a Device > Connecting a physical iOS device",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 2 - Connect a Device > Connecting a physical iOS device",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 2 - Connect a Device > Connecting a virtual Android device",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 2 - Connect a Device > Connecting a virtual iOS device",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 2 - Connect a Device > Connecting a virtual iOS device",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 2 - Connect a Device > Connecting a virtual iOS device",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 4 - Record the test",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 4 - Record the test",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 4 - Record the test",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 4 - Record the test",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 4 - Record the test > Supported Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 6 - Add additional steps and edit the properties > Supported Predefined Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 6 - Add additional steps and edit the properties > Supported Predefined Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 6 - Add additional steps and edit the properties > Supported Predefined Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 6 - Add additional steps and edit the properties > Supported Predefined Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 6 - Add additional steps and edit the properties > Supported Predefined Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Step 6 - Add additional steps and edit the properties > Supported Predefined Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-extra",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-extra",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-extra",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "/docs/mobile-apps/mobile-apps"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding additional steps and edit the properties",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Before we begin",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Modes",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Modes",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recording a Mobile Test",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported Predefined Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported Predefined Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported Predefined Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-vmg-mobile-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Supported Predefined Mobile Actions",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/setting-the-test-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/setting-the-test-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/setting-the-test-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/setting-the-test-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/setting-the-test-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/setting-the-test-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/setting-the-test-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/vision-locate",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/vision-locate",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/vision-locate",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Vision Locate",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/vision-locate",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Vision Locate",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/vision-locate",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Vision Locate > Test playback",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/vision-locate",
+        "issueType": "segment-untranslated",
+        "sectionPath": "When should you use Vision Locate?",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution Details Screen > Execution Test List",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution Details Screen > Execution Test List",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution Details Screen > Execution Test List",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution Details Screen > Execution Test List",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution Details Screen > Execution Test List",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution Operations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution Operations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution Operations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution Operations > Advanced Filters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution Operations > Export Execution List",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution Operations > Filter by Run Date",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Execution Runs Graph > Hide/Show Execution Runs Graph",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Executions List",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Executions List > Execution Name Conventions",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Executions List > Execution Name Conventions",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Operations > Rerun Test Directly from Execution Details Screen (Web)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/execution-runs-screen",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Operations > Tag a Test Failure",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Tagging a test failure from the test result screen",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "segment-missing",
+        "sectionPath": "Tagging a test failure from the test result screen",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a bug report for the failed test run",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a bug report for the failed test run",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a bug report for the failed test run",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Suggested failure tags",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Tagging a test failure from the test result screen",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Tagging a test failure from the test result screen",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Tagging a test failure from the test result screen",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Tagging a test failure from the test result screen",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Tagging a test failure from the test result screen",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Tagging multiple test failures from the Test Runs screen",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/tag-remote-runs-failures",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Tagging multiple test failures from the Test Runs screen",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing Overall Test Results",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing Overall Test Results",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing Overall Test Results",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing Overall Test Results",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/debug-console-errors-access-dom",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Debug by seeing the failed step DOM",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/debug-console-errors-access-dom",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Debug console errors and network",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/debug-console-errors-access-dom",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Debug using Chrome Console",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/network-logs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the network activity",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/network-logs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the network logs at the step level > Viewing HTTP headers",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/network-logs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the network logs at the test level",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/network-logs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the network logs at the test level",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/why-did-my-test-fail",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Common Troubleshooting Steps",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/why-did-my-test-fail",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Failure Types > 1. Element not visible",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/why-did-my-test-fail",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Failure Types > 1. Element not visible",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/why-did-my-test-fail",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Failure Types > 13. API Step Failed",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/why-did-my-test-fail",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Failure Types > 2. Element not Found",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/why-did-my-test-fail",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Failure Types > 7. Browser Type is not Supported",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/why-did-my-test-fail",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Failure Types > 8. Page is not Available",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-results/why-did-my-test-fail",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Warning Types > 1. Could not resize to view-port size",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-run-pdf-report",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Generating the Test Report from the Test screen",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-run-pdf-report",
+        "issueType": "segment-extra",
+        "sectionPath": "Generating the Test Report from the Test screen",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-runs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-runs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Download to CSV",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-runs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-runs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filters > Advanced filters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-runs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filters > Advanced filters",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-runs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to access the Test Runs screen",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-runs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to access the Test Runs screen",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-runs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Tag test failure",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-runs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Runs Details",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "results/test-runs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Runs Details",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/base-url",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Overriding the Base URL when running the test > Overriding the base URL in a Navigation Step",
+        "segmentKind": "callout-body",
+        "missingTokens": [
+          "https://demo.testim.io/checkout"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/base-url",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Overriding the Base URL when running the test",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/base-url",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using the Base URL Out-of-the-box Parameter > Using the Base URL parameter in a Navigation Step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Config Hooks > Predefined properties in Config Hooks > Using the beforeTest hook to get a list of labels in runtime",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks",
+        "issueType": "segment-extra",
+        "sectionPath": "Config Hooks > Global exports parameters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks",
+        "issueType": "segment-extra",
+        "sectionPath": "Config Hooks > Predefined properties in Config Hooks > Using the beforeTest hook to get a list of labels in runtime",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks",
+        "issueType": "segment-missing",
+        "sectionPath": "Config Hooks > Global exports parameters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Config Hooks > Predefined properties in Config Hooks",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Config Hooks > Predefined properties in Config Hooks > Using the beforeTest hook to get a list of labels in runtime",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Syntax",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks/predefined-properties-in-config-file-hooks",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "After Test Predefined Properties",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks/predefined-properties-in-config-file-hooks",
+        "issueType": "segment-extra",
+        "sectionPath": "After Test Predefined Properties",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks/predefined-properties-in-config-file-hooks",
+        "issueType": "segment-missing",
+        "sectionPath": "After Test Predefined Properties",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/configuration-file-run-hooks/predefined-properties-in-config-file-hooks",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/mock-network-responses",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Overview",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/mock-network-responses",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Overview",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/mock-network-responses/mocking-all-the-network-traffic-using-a-har-file",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/mock-network-responses/mocking-all-the-network-traffic-using-a-har-file",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/mock-network-responses/mocking-all-the-network-traffic-using-a-har-file",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/running-tests-on-multiple-browsers",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/running-tests-overview",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/running-tests-overview",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/running-tests-overview",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests through the CLI (web & mobile) > Running mobile tests through the CLI > Running mobile tests locally through the CLI",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/running-tests-overview",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests through the CLI (web & mobile) > Running mobile tests through the CLI > Running mobile tests locally through the CLI",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/running-tests-overview",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Tests through the CLI (web & mobile) > Running web tests through the CLI > Running web tests remotely through the CLI",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/running-tests-overview",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running a single or multiple tests through the Test List on Testim UI (web only)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/scheduler",
+        "issueType": "segment-extra",
+        "sectionPath": "Creating a scheduled test run",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/scheduler",
+        "issueType": "segment-missing",
+        "sectionPath": "Creating a scheduled test run",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/scheduler",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Advanced scheduler options",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/scheduler",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a scheduled test run",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/scheduler",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Integrating Scheduler with Slack",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/scheduler-mobile",
+        "issueType": "segment-extra",
+        "sectionPath": "Creating a scheduled test run",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/scheduler-mobile",
+        "issueType": "segment-missing",
+        "sectionPath": "Creating a scheduled test run",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/scheduler-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a scheduled test run",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/scheduler-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Integrating Scheduler with Slack",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/schedulers-notification-via-webhook",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/schedulers-notification-via-webhook",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Webhook format",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/the-command-line-cli",
+        "issueType": "segment-untranslated",
+        "sectionPath": "All CLI Parameters > Grid Name",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/the-command-line-cli",
+        "issueType": "segment-untranslated",
+        "sectionPath": "All CLI Parameters > Sealights Integration",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/the-command-line-cli",
+        "issueType": "segment-untranslated",
+        "sectionPath": "All CLI Parameters > Sealights Integration > Sealights buildSessionId",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/the-command-line-cli",
+        "issueType": "segment-untranslated",
+        "sectionPath": "All CLI Parameters > Sealights Integration > Sealights labId",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/the-command-line-cli",
+        "issueType": "segment-untranslated",
+        "sectionPath": "All CLI Parameters > Test Plan (by name)",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/the-command-line-cli",
+        "issueType": "segment-untranslated",
+        "sectionPath": "All CLI Parameters > intersect-with flag",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/the-command-line-cli",
+        "issueType": "segment-untranslated",
+        "sectionPath": "All CLI Parameters > intersect-with flag",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/the-command-line-cli",
+        "issueType": "segment-untranslated",
+        "sectionPath": "All CLI Parameters > intersect-with-operand",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/the-command-line-cli",
+        "issueType": "segment-untranslated",
+        "sectionPath": "CLI Installation > Additional common parameters",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/the-command-line-cli",
+        "issueType": "segment-untranslated",
+        "sectionPath": "CLI Installation > Basic CLI command",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "running-tests/the-command-line-cli/allow-chrome-browser-to-use-microphone",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "--chrome-extra-args",
+          "/docs/index"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/best-practice-variable-naming-convention-for-easy-cleanup",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "CI integrations June 2023",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "CI integrations June 2023",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "CPQ Quote Line Editor step July 2023",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Sign-in with Salesforce May 2023",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/changelog",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Tricentis Test Management for Jira Integration June 2023",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-persona-and-add-users",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a persona and associating it with a Salesforce user",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-persona-and-add-users",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a persona and associating it with a Salesforce user",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-persona-and-add-users",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a persona and associating it with a Salesforce user",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-persona-and-add-users",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a persona and associating it with a Salesforce user",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-persona-and-add-users",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a persona and associating it with a Salesforce user",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test",
+        "issueType": "segment-extra",
+        "sectionPath": "Recording Steps",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Salesforce test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Salesforce test",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Salesforce test",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Salesforce test",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Salesforce test",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "How to create prompts",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-extra",
+        "sectionPath": "Creating a new Salesforce test with Agentic Test Automation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-extra",
+        "sectionPath": "How to create prompts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-extra",
+        "sectionPath": "How to create prompts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-missing",
+        "sectionPath": "Creating a new Salesforce test with Agentic Test Automation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-missing",
+        "sectionPath": "How to create prompts",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a new Salesforce test with Agentic Test Automation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to create prompts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to create prompts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to create prompts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to create prompts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to create prompts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How to create prompts",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-and-merge-branches-from-different-test-environments",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a branch",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/create-and-merge-branches-from-different-test-environments",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Merging a Branch",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/faq",
+        "issueType": "segment-untranslated",
+        "sectionPath": "How can I clean-up/delete the records created during a test?",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/record-tests-with-salesforce",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Validating Values",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps",
+        "issueType": "segment-extra",
+        "sectionPath": "Common operations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps",
+        "issueType": "segment-missing",
+        "sectionPath": "Common operations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "API Operations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps",
+        "issueType": "segment-untranslated",
+        "sectionPath": "CPQ Operations",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-document-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Before you begin",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-document-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring the Content validation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-document-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring the Key Value extraction",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-document-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring the Key Value extraction",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-document-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring the Key Value extraction",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-document-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring the Key Value extraction",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-document-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring the Key Value extraction",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-document-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring the Key Value validation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-document-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring the Key Value validation",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-document-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring the Key Value validation",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-document-validation",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring the Table extraction",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-apex-action",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Exporting Values",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": [
+          "/docs/exports-parameters#exporting-a-parameter"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-apex-action",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-apex-action",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding an Execute APEX Action Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-apex-action",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Exporting Values",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-apex-action",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Passing parameters",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-apex-action",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Salesforce APEX Action Example",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-create",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-create",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-create",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": [
+          "-this"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-create",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-edit",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-edit",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-edit",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": [
+          "-this"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-edit",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-edit",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-loginas",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-loginas",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-loginas",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-loginas",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-loginas",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-logout",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-quickactions",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Creating a Quick Actions Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": [
+          "-this"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-quickactions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-quickactions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Quick Actions Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-quotelineeditor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-quotelineeditor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-quotelineeditor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-quotelineeditor",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Creating a new related list object (Create)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": [
+          "-this"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a new related list object (Create)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a new related list object (Create)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a new related list object (Create)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Verifying a related list object (Verify)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Verifying a related list object (Verify)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Verifying a related list object (Verify)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Verifying a related list object (Verify)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing a related list object (View)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing a related list object (View)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-relatedlistaction",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing a related list object (View)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-salesforce-flows",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Creating a Flow Screen Completion Step",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-salesforce-flows",
+        "issueType": "segment-extra",
+        "sectionPath": "Creating a Flow Screen Completion Step",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-salesforce-flows",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Creating a Flow Screen Completion Step",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "/docs/salesforce-testing/record-tests-with-salesforce"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-salesforce-flows",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Flow Screen Completion Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-validate",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-validate",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-validate",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": [
+          "-this"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-validate",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-validate",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-verifypicklistoptions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Verify Picklist Options Step",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/setting-mfa-for-salesforce",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/setting-mfa-for-salesforce",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/troubleshoot",
+        "issueType": "segment-extra",
+        "sectionPath": "Scheduled test executions on the Grid are failing",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/troubleshoot",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Cannot find a record in Salesforce",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/troubleshoot",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Concurrent Salesforce test executions are failing because a user gets logged out",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/troubleshoot",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Fields are not present in a Salesforce Step",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/troubleshoot",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Scheduled test executions on the Grid are failing",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/troubleshoot",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Scheduled test executions on the Grid are failing",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/troubleshoot",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Scheduled test executions on the Grid are failing due to need for verification code",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/troubleshoot",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Unable to connect to your Salesforce environment",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/troubleshoot",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Unable to connect to your Salesforce environment",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/troubleshoot",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Unable to connect to your Salesforce environment",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Configuring SSO for your deployment",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Ensuring SSO is enabled",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/azure-ad-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/okta-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/sso-integration/onelogin-sso-integration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "security/testim-grid-ips",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/bug-reporting",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Connecting the bug report to the bug tracker",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "Adding a New Configuration",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Adding a New Configuration",
+        "segmentKind": "callout-body",
+        "missingTokens": [
+          "https://www.browserstack.com/docs/app-automate/appium/dynamic-device-allocation"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a New Configuration",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a New Configuration",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a New Configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a New Configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a New Configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a New Configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a New Configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a New Configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a New Configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Adding a New Configuration",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Checking available devices for a specific configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Cloning, renaming, modifying and deleting test configurations > Cloning a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Cloning, renaming, modifying and deleting test configurations > Deleting a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Cloning, renaming, modifying and deleting test configurations > Modifying a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Cloning, renaming, modifying and deleting test configurations > Renaming a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using a Mobile Configuration to Execute a Test",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/configuration-library-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using a Mobile Configuration to Execute a Test",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/dependencies-and-ordering-of-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running Order",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/locators-auto-improve",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/locators-auto-improve",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Allowing Auto Improve on a Master Read Only Branch",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/locators-auto-improve",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering the Test Library",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/locators-auto-improve",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering the Test Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/locators-auto-improve",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering the Test Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/locators-auto-improve",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering the Test Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/locators-auto-improve",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering the Test Library",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/locators-auto-improve",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Locators Panel",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/locators-auto-improve",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Revision History Panel",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/revisions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Automated revisions following a Locator’s auto-improve process",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/revisions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Automated revisions following a Locator’s auto-improve process",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/revisions",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the test revisions",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-missing",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Creating a new test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-missing",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Modifying a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-missing",
+        "sectionPath": "Creating and modifying test configurations in the Test Editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Cloning a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Creating a new test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Creating a new test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Creating a new test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Creating a new test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Creating a new test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Creating a new test configuration",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Creating a new test configuration",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Deleting a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Modifying a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Modifying a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Modifying a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Modifying a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Modifying a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Configuration Library > Renaming a test configuration",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Test Editor",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Test Editor",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Test Editor",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Test Editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Test Editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Test Editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating and modifying test configurations in the Test Editor",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering the Configuration Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering the Configuration Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering the Configuration Library",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "View Existing Configurations",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "View Existing Configurations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-configuration",
+        "issueType": "segment-untranslated",
+        "sectionPath": "View Existing Configurations",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-steps-library",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Shared Steps Library > Exporting to CSV",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-steps-library",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Shared Steps Library > Filtering the Shared Steps Library",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-steps-library",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Shared Steps Library > Filtering the Shared Steps Library",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-steps-library",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Shared Steps Library > Filtering the Shared Steps Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-steps-library",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Shared Steps Library > Filtering the Shared Steps Library",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/shared-steps-library",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Shared Steps Library > Hiding shared steps from the list",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-extra",
+        "sectionPath": "Viewing the Test Library > Search text box",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-missing",
+        "sectionPath": "Viewing the Test Library",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-missing",
+        "sectionPath": "Viewing the Test Library > Search text box",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-order-mismatch",
+        "sectionPath": "Viewing the Test Library > Search text box",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Changing Tests' Configuration (Web)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Exporting to CSV",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Exporting to CSV",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Filtering the Test Library",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Filtering the Test Library",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Filtering the Test Library",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Filtering the Test Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Filtering the Test Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Filtering the Test Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Filtering the Test Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Filtering the Test Library",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Filtering the Test Library",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Running Tests (Web)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Running Tests (Web)",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Running Tests (Web)",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Running Tests (Web)",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Search text box",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the Test Library > Search text box",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list/cloning-tests",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "What happens after cloning",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list/cloning-tests",
+        "issueType": "segment-extra",
+        "sectionPath": "What happens after cloning",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list/cloning-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list/cloning-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "What happens after cloning",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list/cloning-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "What happens after cloning",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list/cloning-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "What happens after cloning",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list/cloning-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "What happens after cloning",
+        "segmentKind": "table-cell",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list/managing-tests-and-folders",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Applying labels to tests",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list/managing-tests-and-folders",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Cloning tests",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list/managing-tests-and-folders",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a new folder",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list/managing-tests-and-folders",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Moving tests/folders to folders",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-list/managing-tests-and-folders",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Moving tests/folders to folders",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Web Test Plan",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Web Test Plan",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Web Test Plan",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Web Test Plan",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Web Test Plan",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Web Test Plan",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Mobile Test Plan",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Mobile Test Plan",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Mobile Test Plan",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Mobile Test Plan",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Mobile Test Plan",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Mobile Test Plan",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a New Mobile Test Plan",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-plans-mobile",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running your Test Plan",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-suites",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Create a new test suite",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "test-management/test-suites",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Re-Order tests in a test suite",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-extension/testim-extension-capture-screenshot",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Capturing the screenshot and annotating it",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-extension/testim-extension-create-automated-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating the automated test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-extension/testim-extension-create-automated-test",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating the automated test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-labs/link-directly-to-a-shared-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-labs/link-directly-to-a-shared-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-labs/link-directly-to-a-shared-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Directly Accessing Shared Steps/Groups",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-labs/link-directly-to-a-shared-step",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Directly Accessing Shared Steps/Groups",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-labs/test-flow-view",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-labs/test-flow-view",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-labs/test-flow-view",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-labs/test-flow-view",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-labs/test-flow-view",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-labs/test-flow-view",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Flow View Controls",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-labs/testim-labs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testim-labs/testim-labs",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/audit-log",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the audit log",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assigned to Me",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Assigned to Me",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Duplication Level",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Duplication Level",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Pull Requests",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Pull Requests",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Recent Activity",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs > Filtering the Results",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs > Filtering the Results",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs > Filtering the Results",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs > Filtering the Results",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs > Filtering the Results",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs > Filtering the Results",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs > Remote Runs Pane - Assigned to me",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs > Remote Runs Pane - Assigned to me",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Remote Execution Runs > Remote Runs Pane - Assigned to me",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Test Overview",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-extra",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-extra",
+        "sectionPath": "Testim’s Activity",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-missing",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-missing",
+        "sectionPath": "Testim’s Activity",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Company-level Report > Filtering the Company-level Report",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Company-level Report > Filtering the Company-level Report",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering the Results",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering the Results",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering the Results",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering the Results",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Tests Run Results",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Tests Run Results",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/reports",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Where Can You Improve?",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/team-productivity",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Team productivity report",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/team-productivity",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Team productivity report > Access team productivity report",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/flaky-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Changing flaky tests status",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/flaky-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Find your flaky tests",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/flaky-tests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Find your flaky tests",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/test-owner",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/test-owner",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Changing the Test Owner > Changing the Test Owner in the Editor",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/test-owner",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Changing the Test Owner > Changing the Test Owner in the Test Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/test-owner",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Changing the Test Owner > Changing the Test Owner in the Test Library",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/test-owner",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering Test Library and Suite Runs by Test Owner > Filtering Suite Runs",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/test-owner",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering Test Library and Suite Runs by Test Owner > Filtering Test Library",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/test-owner",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering Test Library and Suite Runs by Test Owner > Filtering Test Library",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/test-owner",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering Test Library and Suite Runs by Test Owner > Filtering Test Library",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/test-owner",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering Test Library and Suite Runs by Test Owner > Filtering Test Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/test-owner",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Filtering Test Library and Suite Runs by Test Owner > Filtering Test Library",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-management/test-status",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Viewing the test status",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-overview",
+        "issueType": "segment-untranslated",
+        "sectionPath": "TestOps - Scale testing with control, management, and insights",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/merging-branches",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Deleting the source branch when merging",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/merging-branches",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Merge cherry-pick",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/merging-branches",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Resolving all conflicts automatically without comparing",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/merging-branches",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Resolving conflicts between shared steps",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/merging-branches",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Resolving conflicts between shared steps",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/merging-branches",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Resolving conflicts between shared steps",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/merging-branches",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Resolving conflicts between tests",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/merging-branches",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Resolving conflicts between tests",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/merging-branches",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Resolving conflicts between tests",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/pull-requests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Pull Request",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/pull-requests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Pull Request > Issuing a Pull Request",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/pull-requests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Creating a Pull Request > Issuing a Pull Request",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/pull-requests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Resubmitting a Pull Request",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/pull-requests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Resubmitting a Pull Request",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/pull-requests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reviewing a Pull Request",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/pull-requests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reviewing a Pull Request",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/pull-requests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reviewing a Pull Request",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/pull-requests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reviewing a Pull Request",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/pull-requests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reviewing a Pull Request",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/pull-requests",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Reviewing a Pull Request",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/read-only",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Branch as read-only behavior > Auto-Improve feature on read-only branches",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/read-only",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Enabling the branch read-only mode",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/testops-version-control/version-control-branches",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Using Branches",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/turbo-mode",
+        "issueType": "segment-untranslated",
+        "sectionPath": "",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/turbo-mode",
+        "issueType": "segment-untranslated",
+        "sectionPath": "Running in turbo-mode",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      }
+    ],
+    "artifactCandidates": [
+      {
+        "slug": "editing-tests/conditions/advanced-conditions-settings",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": [
+          "/docs/index"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-codeless-test",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Recording the Test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": [
+          "http://google.com"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "getting-started/creating-your-first-codeless-test",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Recording the Test",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "http://google.com"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "integrations/visual-validation/visual_validation_index",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": [
+          "/docs/index"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "recording-tests/recording-a-mobile-test/recording-a-local-mobile-test",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Step 4 - Record the test",
+        "segmentKind": "ordered-list-item",
+        "missingTokens": [
+          "/docs/index"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "salesforce-testing/salesforce-steps/sfdc-step-login",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "/docs/index"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "testops/insights/dashboard",
+        "issueType": "segment-token-gap",
+        "sectionPath": "",
+        "segmentKind": "paragraph",
+        "missingTokens": [
+          "/docs/index"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      }
+    ],
+    "normalizerCandidates": [
+      {
+        "slug": "running-tests/scheduler",
+        "issueType": "segment-token-gap",
+        "sectionPath": "Creating a scheduled test run",
+        "segmentKind": "unordered-list-item",
+        "missingTokens": [
+          "https://help.testim.io/v2.0/docs/scheduler#integrating-scheduler-with-slack"
+        ],
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      }
+    ],
+    "intentionalDivergenceCandidates": [
+      {
+        "slug": "administration/api-access",
+        "issueType": "section-structure-mismatch",
+        "sectionPath": "API keys management",
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/api-access",
+        "issueType": "segment-extra",
+        "sectionPath": "API keys management",
+        "segmentKind": "callout-body",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      },
+      {
+        "slug": "administration/api-access",
+        "issueType": "segment-missing",
+        "sectionPath": "API keys management",
+        "segmentKind": "paragraph",
+        "missingTokens": null,
+        "inconclusiveCategory": null,
+        "inconclusiveReason": null
+      }
+    ],
+    "advisoryResidual": [
+      {
+        "slug": "advanced-editing/validations/add-network-validation",
+        "issueType": "segment-inconclusive",
+        "sectionPath": null,
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": "tokenless-near-tie",
+        "inconclusiveReason": "Tokenless adjacent sections \"Network Validation > Network Validation Examples > Validate all the image requests\" and \"Network Validation > Network Validation Examples > Validate a single request\" cannot rule out a body swap (current=2.00, swap=2.00)"
+      },
+      {
+        "slug": "integrations/bug-tracker-settings/connecting-testim-to-jira",
+        "issueType": "segment-inconclusive",
+        "sectionPath": null,
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": "heading-count-mismatch",
+        "inconclusiveReason": "Heading count mismatch: EN has 0 headings, JA has 2"
+      },
+      {
+        "slug": "integrations/bug-tracker-settings/connecting-testim-to-slack",
+        "issueType": "segment-inconclusive",
+        "sectionPath": null,
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": "heading-count-mismatch",
+        "inconclusiveReason": "Heading count mismatch: EN has 0 headings, JA has 2"
+      },
+      {
+        "slug": "integrations/bug-tracker-settings/connecting-testim-to-trello",
+        "issueType": "segment-inconclusive",
+        "sectionPath": null,
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": "heading-count-mismatch",
+        "inconclusiveReason": "Heading count mismatch: EN has 0 headings, JA has 2"
+      },
+      {
+        "slug": "integrations/integrate-testim-to-your-ci/codeship-integration",
+        "issueType": "segment-inconclusive",
+        "sectionPath": null,
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": "heading-count-mismatch",
+        "inconclusiveReason": "Heading count mismatch: EN has 2 headings, JA has 3"
+      },
+      {
+        "slug": "integrations/sealights-integration",
+        "issueType": "segment-inconclusive",
+        "sectionPath": null,
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": "heading-count-mismatch",
+        "inconclusiveReason": "Heading count mismatch: EN has 15 headings, JA has 8"
+      },
+      {
+        "slug": "overview/changelog",
+        "issueType": "segment-inconclusive",
+        "sectionPath": null,
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": "tokenless-near-tie",
+        "inconclusiveReason": "Tokenless adjacent sections \"Archive > Exporting a Testim test as code for Playwright\" and \"Archive > Cloning tests\" cannot rule out a body swap (current=2.81, swap=2.81)"
+      },
+      {
+        "slug": "running-tests/scheduler",
+        "issueType": "segment-inconclusive",
+        "sectionPath": null,
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": "tokenless-near-tie",
+        "inconclusiveReason": "Tokenless adjacent sections \"Modify your scheduled test suites > Activate or Pause\" and \"Modify your scheduled test suites > Edit\" cannot rule out a body swap (current=1.34, swap=1.35)"
+      },
+      {
+        "slug": "running-tests/scheduler-mobile",
+        "issueType": "segment-inconclusive",
+        "sectionPath": null,
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": "tokenless-near-tie",
+        "inconclusiveReason": "Tokenless adjacent sections \"Modify your scheduled test suites > Activate or Pause\" and \"Modify your scheduled test suites > Edit\" cannot rule out a body swap (current=1.34, swap=1.35)"
+      },
+      {
+        "slug": "salesforce-testing/changelog",
+        "issueType": "segment-inconclusive",
+        "sectionPath": null,
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": "tokenless-near-tie",
+        "inconclusiveReason": "Tokenless adjacent sections \"Switch between users with Login As step May 2023\" and \"Permission validation step May 2023\" cannot rule out a body swap (current=1.18, swap=1.17)"
+      },
+      {
+        "slug": "test-management/revisions",
+        "issueType": "segment-inconclusive",
+        "sectionPath": null,
+        "segmentKind": null,
+        "missingTokens": null,
+        "inconclusiveCategory": "tokenless-near-tie",
+        "inconclusiveReason": "Tokenless adjacent sections \"Accessing a previous revision\" and \"Reverting to a previous revision\" cannot rule out a body swap (current=1.17, swap=1.17)"
+      }
+    ]
+  },
+  "summary": {
+    "reportableActiveFiles": null,
+    "baselinedIssues": null,
+    "advisoryQueueIssues": null,
+    "auditSignalIssues": null
+  },
+  "snapshotDiff": {
+    "changed": null,
+    "added": null,
+    "removed": null
+  }
+}

--- a/docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.md
+++ b/docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.md
@@ -1,0 +1,162 @@
+# Parity Phase 4 Residual Inventory (5-bucket)
+
+Task 4.1 で `parity-baseline.json` を 5 bucket に分離した実測結果。
+Task 4.2 (artifact registry) / Task 4.3 (URL normalizer) / Task 4.4 (HTML extractor allow list) / Task 4.5 (翻訳修正) への入力分配に用いる。
+
+本ファイルは機械生成 (`scripts/phase4/render_residual_inventory.mjs`)。末尾の「分配方針」節のみ手動追記。
+
+## 1. 概要
+
+- baseline entries 合計: **1873**
+
+### issueType 別件数
+
+| issueType | count |
+| --- | --- |
+| section-structure-mismatch | 56 |
+| segment-extra | 87 |
+| segment-inconclusive | 11 |
+| segment-missing | 107 |
+| segment-order-mismatch | 1 |
+| segment-token-gap | 40 |
+| segment-untranslated | 1571 |
+
+### bucket 別件数
+
+| bucket | count |
+| --- | --- |
+| actionable | 1851 |
+| artifactCandidates | 7 |
+| normalizerCandidates | 1 |
+| intentionalDivergenceCandidates | 3 |
+| advisoryResidual | 11 |
+
+## 2. bucket 別 entry 一覧
+
+### actionable (1851 件)
+
+| slug | issueType | sectionPath | segmentKind | missingTokens | inconclusiveCategory | inconclusiveReason |
+| --- | --- | --- | --- | --- | --- | --- |
+| administration/copilot-license-management | segment-untranslated | Assigning seats to users | ordered-list-item |  |  |  |
+| administration/copilot-license-management | segment-untranslated | Assigning seats to users | paragraph |  |  |  |
+| administration/copilot-license-management | segment-untranslated | Viewing current Copilot license allocation | ordered-list-item |  |  |  |
+| administration/copilot-license-management | segment-untranslated | Viewing current Copilot license allocation | ordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-extra | Using Encrypted Credentials in Tests > Adding encrypted credentials to Param File > Making the Param File compatible with encrypted credentials | ordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-missing | Using Encrypted Credentials in Tests > Adding encrypted credentials to Param File > Making the Param File compatible with encrypted credentials | ordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-token-gap | Running test with encrypted credentials summary > Running tests with encrypted credentials in the Test Data | unordered-list-item | /tests/run |  |  |
+| administration/encrypted-credentials | segment-untranslated |  | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Configuring the Encrypted Credentials > Creating an Encrypted Credential | ordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Configuring the Encrypted Credentials > Creating an Encrypted Credential | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | How encrypted credentials are used in test runs | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running Tests with Encrypted Credentials > API Runs | callout-body |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running Tests with Encrypted Credentials > API Runs | ordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running Tests with Encrypted Credentials > API Runs | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running Tests with Encrypted Credentials > API Runs | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running Tests with Encrypted Credentials > API Runs | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running Tests with Encrypted Credentials > CLI Runs | callout-body |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running Tests with Encrypted Credentials > CLI Runs | ordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running Tests with Encrypted Credentials > CLI Runs | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running Tests with Encrypted Credentials > CLI Runs | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running Tests with Encrypted Credentials > Scheduler Runs | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running test with encrypted credentials summary | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running test with encrypted credentials summary > Running tests with encrypted credentials in the Test Data | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running test with encrypted credentials summary > Running tests with encrypted credentials in the Test Data | unordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running test with encrypted credentials summary > Running tests with encrypted credentials in the Test Data | unordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Running test with encrypted credentials summary > Running tests with encrypted credentials in the Test Data | unordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Using Encrypted Credentials in Tests | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Using Encrypted Credentials in Tests > Adding encrypted credentials to Config File | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Using Encrypted Credentials in Tests > Adding encrypted credentials to Config File > Encrypted credentials syntax | unordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Using Encrypted Credentials in Tests > Adding encrypted credentials to Param File > Encrypted credentials syntax | unordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Using Encrypted Credentials in Tests > Adding encrypted credentials to Param File > Making the Param File compatible with encrypted credentials | ordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Using Encrypted Credentials in Tests > Adding encrypted credentials to Test Data | paragraph |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Using Encrypted Credentials in Tests > Adding encrypted credentials to Test Data > Encrypted credentials syntax | unordered-list-item |  |  |  |
+| administration/encrypted-credentials | segment-untranslated | Viewing Test Runs with Encrypted Credentials | paragraph |  |  |  |
+| administration/project-and-user-management | segment-untranslated |  | paragraph |  |  |  |
+| administration/project-and-user-management | segment-untranslated |  | unordered-list-item |  |  |  |
+| administration/project-and-user-management | segment-untranslated | View Company Teammates > Changing/Adding Company Owner and Project Owners | ordered-list-item |  |  |  |
+| administration/project-and-user-management | segment-untranslated | View Company Teammates > Remove Company Owner | ordered-list-item |  |  |  |
+| administration/project-and-user-management | segment-untranslated | View Company Teammates > Removing Company Teammates | ordered-list-item |  |  |  |
+| administration/project-settings | section-structure-mismatch | General Settings > Project Name |  |  |  |  |
+| administration/project-settings | section-structure-mismatch | General Settings > Default Base URL |  |  |  |  |
+| administration/project-settings | section-structure-mismatch | General Settings > Hidden Parameters |  |  |  |  |
+| administration/project-settings | segment-missing | General Settings > Default Base URL | paragraph |  |  |  |
+| administration/project-settings | segment-missing | General Settings > Hidden Parameters | paragraph |  |  |  |
+| administration/project-settings | segment-missing | General Settings > Project Name | paragraph |  |  |  |
+| administration/project-settings | segment-untranslated | General Settings > Allow auto-complete suggestions | ordered-list-item |  |  |  |
+| administration/project-settings | segment-untranslated | General Settings > Default Base URL | ordered-list-item |  |  |  |
+| administration/project-settings | segment-untranslated | General Settings > Default Base URL | ordered-list-item |  |  |  |
+| administration/project-settings | segment-untranslated | General Settings > Default Test Configuration | ordered-list-item |  |  |  |
+| administration/project-settings | segment-untranslated | General Settings > Hidden Parameters | ordered-list-item |  |  |  |
+
+先頭 50 件のみ表示。全 1851 件は JSON を参照。
+
+### artifactCandidates (7 件)
+
+| slug | issueType | sectionPath | segmentKind | missingTokens | inconclusiveCategory | inconclusiveReason |
+| --- | --- | --- | --- | --- | --- | --- |
+| editing-tests/conditions/advanced-conditions-settings | segment-token-gap |  | ordered-list-item | /docs/index |  |  |
+| getting-started/creating-your-first-codeless-test | segment-token-gap | Recording the Test | ordered-list-item | http://google.com |  |  |
+| getting-started/creating-your-first-codeless-test | segment-token-gap | Recording the Test | paragraph | http://google.com |  |  |
+| integrations/visual-validation/visual_validation_index | segment-token-gap |  | unordered-list-item | /docs/index |  |  |
+| recording-tests/recording-a-mobile-test/recording-a-local-mobile-test | segment-token-gap | Step 4 - Record the test | ordered-list-item | /docs/index |  |  |
+| salesforce-testing/salesforce-steps/sfdc-step-login | segment-token-gap |  | paragraph | /docs/index |  |  |
+| testops/insights/dashboard | segment-token-gap |  | paragraph | /docs/index |  |  |
+
+### normalizerCandidates (1 件)
+
+| slug | issueType | sectionPath | segmentKind | missingTokens | inconclusiveCategory | inconclusiveReason |
+| --- | --- | --- | --- | --- | --- | --- |
+| running-tests/scheduler | segment-token-gap | Creating a scheduled test run | unordered-list-item | https://help.testim.io/v2.0/docs/scheduler#integrating-scheduler-with-slack |  |  |
+
+### intentionalDivergenceCandidates (3 件)
+
+| slug | issueType | sectionPath | segmentKind | missingTokens | inconclusiveCategory | inconclusiveReason |
+| --- | --- | --- | --- | --- | --- | --- |
+| administration/api-access | section-structure-mismatch | API keys management |  |  |  |  |
+| administration/api-access | segment-extra | API keys management | callout-body |  |  |  |
+| administration/api-access | segment-missing | API keys management | paragraph |  |  |  |
+
+### advisoryResidual (11 件)
+
+| slug | issueType | sectionPath | segmentKind | missingTokens | inconclusiveCategory | inconclusiveReason |
+| --- | --- | --- | --- | --- | --- | --- |
+| advanced-editing/validations/add-network-validation | segment-inconclusive |  |  |  | tokenless-near-tie | Tokenless adjacent sections "Network Validation > Network Validation Examples > Validate all the image requests" and "Network Validation > Network Validation Examples > Validate a single request" cannot rule out a body swap (current=2.00, swap=2.00) |
+| integrations/bug-tracker-settings/connecting-testim-to-jira | segment-inconclusive |  |  |  | heading-count-mismatch | Heading count mismatch: EN has 0 headings, JA has 2 |
+| integrations/bug-tracker-settings/connecting-testim-to-slack | segment-inconclusive |  |  |  | heading-count-mismatch | Heading count mismatch: EN has 0 headings, JA has 2 |
+| integrations/bug-tracker-settings/connecting-testim-to-trello | segment-inconclusive |  |  |  | heading-count-mismatch | Heading count mismatch: EN has 0 headings, JA has 2 |
+| integrations/integrate-testim-to-your-ci/codeship-integration | segment-inconclusive |  |  |  | heading-count-mismatch | Heading count mismatch: EN has 2 headings, JA has 3 |
+| integrations/sealights-integration | segment-inconclusive |  |  |  | heading-count-mismatch | Heading count mismatch: EN has 15 headings, JA has 8 |
+| overview/changelog | segment-inconclusive |  |  |  | tokenless-near-tie | Tokenless adjacent sections "Archive > Exporting a Testim test as code for Playwright" and "Archive > Cloning tests" cannot rule out a body swap (current=2.81, swap=2.81) |
+| running-tests/scheduler | segment-inconclusive |  |  |  | tokenless-near-tie | Tokenless adjacent sections "Modify your scheduled test suites > Activate or Pause" and "Modify your scheduled test suites > Edit" cannot rule out a body swap (current=1.34, swap=1.35) |
+| running-tests/scheduler-mobile | segment-inconclusive |  |  |  | tokenless-near-tie | Tokenless adjacent sections "Modify your scheduled test suites > Activate or Pause" and "Modify your scheduled test suites > Edit" cannot rule out a body swap (current=1.34, swap=1.35) |
+| salesforce-testing/changelog | segment-inconclusive |  |  |  | tokenless-near-tie | Tokenless adjacent sections "Switch between users with Login As step May 2023" and "Permission validation step May 2023" cannot rule out a body swap (current=1.18, swap=1.17) |
+| test-management/revisions | segment-inconclusive |  |  |  | tokenless-near-tie | Tokenless adjacent sections "Accessing a previous revision" and "Reverting to a previous revision" cannot rule out a body swap (current=1.17, swap=1.17) |
+
+## 3. summary counters
+
+`parity-check-status.json` から転記 (未生成の場合 `n/a`)。
+
+| counter | value |
+| --- | --- |
+| reportableActiveFiles | n/a |
+| baselinedIssues | n/a |
+| advisoryQueueIssues | n/a |
+| auditSignalIssues | n/a |
+
+## 4. snapshotDiff
+
+`snapshot-diff-status.json` から転記 (未生成の場合 `n/a`)。
+
+| metric | value |
+| --- | --- |
+| changed | n/a |
+| added | n/a |
+| removed | n/a |
+
+## 分配方針 (Task 4.2–4.5 への振り分け)
+
+- `artifactCandidates` → Task 4.2 registry の初期 entries に登録 (slug list 固定)
+- `normalizerCandidates` → Task 4.3 で normalizer 修正
+- `intentionalDivergenceCandidates` → Task 4.4 の slug allow list に追加
+- `actionable` → Task 4.5 で翻訳修正
+- `advisoryResidual` → Task 4.5 で全件解消 (翻訳 / alignment 改善 / artifact 昇格いずれか)

--- a/scripts/__tests__/check_source_parity.test.mjs
+++ b/scripts/__tests__/check_source_parity.test.mjs
@@ -774,3 +774,30 @@ describe('gate exit code contract (snapshotUnusable* は gate を変えない)',
     assert.equal(computeExitCode(summary, null), 1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase 4: parity-check-status.json の debug.artifactCoverage 出力契約
+//
+// alignSegments の slug-scope artifact 抑止 hit は runtime aggregator で
+// 集計され、status.debug.artifactCoverage に snapshot として emit される。
+// ---------------------------------------------------------------------------
+
+describe('parity-check-status.json — debug.artifactCoverage emit (Phase 4)', () => {
+  it('status.debug.artifactCoverage has runtime aggregate shape', async () => {
+    const { default: main } = await import('../check_source_parity.mjs');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'parity-artifact-'));
+    const outputPath = path.join(tmp, 'parity-check-status.json');
+    try {
+      await main({ outputPath });
+      const status = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+      const ac = status.debug?.artifactCoverage;
+      assert.ok(ac, 'debug.artifactCoverage should exist');
+      assert.equal(typeof ac.registryEntries, 'number');
+      assert.equal(typeof ac.matchedHits, 'number');
+      assert.ok(typeof ac.bySlug === 'object' && ac.bySlug !== null);
+      assert.ok(typeof ac.byToken === 'object' && ac.byToken !== null);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -2303,6 +2303,26 @@ describe('§1 cleanup — validateParityCheckStatus', () => {
     delete v.schemaVersion;
     assert.throws(() => validateParityCheckStatus(v), /unsupported schemaVersion/);
   });
+
+  // Phase 4: debug.artifactCoverage は runtime 側で emit されるが、
+  // validator / detection 側は gate-sensitive でないため passthrough として
+  // 受け入れる (Spec Invariant 3: debug.* は baseline / ack / gate と独立)。
+  it('passes through debug.artifactCoverage without rejecting', () => {
+    const v = validParityStatus();
+    v.debug = {
+      artifactCoverage: {
+        registryEntries: 2,
+        matchedHits: 3,
+        bySlug: { 'a/b': 2, 'c/d': 1 },
+        byToken: { '/docs/index': 2, 'http://google.com': 1 },
+      },
+    };
+    // validator が debug.* を rejection 対象にしないこと (passthrough 契約)
+    assert.doesNotThrow(() => validateParityCheckStatus(v));
+    // field は input をそのまま保持している (mutation 禁止の確認)
+    assert.equal(v.debug.artifactCoverage.matchedHits, 3);
+    assert.equal(v.debug.artifactCoverage.byToken['/docs/index'], 2);
+  });
 });
 
 describe('§1 cleanup — validateActionableReport', () => {

--- a/scripts/__tests__/parity_artifact_registry.test.mjs
+++ b/scripts/__tests__/parity_artifact_registry.test.mjs
@@ -1,0 +1,106 @@
+// scripts/__tests__/parity_artifact_registry.test.mjs
+/**
+ * parity_artifact_registry の shape / empty-safe / inventory-driven exclusion /
+ * runtime coverage aggregator を検証する。
+ *
+ * registry は EN-side artifact を (slug, token) で管理する slug-scope token
+ * 抑止機構で、Phase 4 の alignSegments({slug, coverage}) から呼び出される。
+ */
+import { before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+let isArtifactExcluded;
+let registryEntries;
+let createArtifactCoverage;
+
+before(async () => {
+  ({
+    isArtifactExcluded,
+    registryEntries,
+    createArtifactCoverage,
+  } = await import('../lib/parity_artifact_registry.mjs'));
+});
+
+// ---------------------------------------------------------------------------
+// shape / empty-safe
+// ---------------------------------------------------------------------------
+
+describe('parity_artifact_registry (shape / empty-safe)', () => {
+  it('isArtifactExcluded returns false for unregistered (slug, token)', () => {
+    assert.equal(
+      isArtifactExcluded({ slug: 'nonexistent/slug', token: 'nonexistent-token' }),
+      false,
+    );
+  });
+
+  it('registry entries have required shape (slugs non-empty, token string, dated)', () => {
+    for (const e of registryEntries()) {
+      assert.ok(Array.isArray(e.slugs) && e.slugs.length > 0, 'slugs must be non-empty array');
+      assert.ok(typeof e.token === 'string' && e.token.length > 0, 'token must be non-empty string');
+      assert.ok(/^\d{4}-\d{2}-\d{2}$/.test(e.addedAt), 'addedAt must be YYYY-MM-DD');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runtime coverage aggregator
+// ---------------------------------------------------------------------------
+
+describe('createArtifactCoverage', () => {
+  it('starts empty and records hits per (slug, token)', () => {
+    const c = createArtifactCoverage();
+    const s0 = c.snapshot();
+    assert.equal(s0.matchedHits, 0);
+    c.record({ slug: 'a', token: '/docs/index', reason: 'en-unresolvable' });
+    c.record({ slug: 'a', token: '/docs/index', reason: 'en-unresolvable' });
+    c.record({ slug: 'b', token: 'http://google.com', reason: 'en-demo' });
+    const s = c.snapshot();
+    assert.equal(s.matchedHits, 3);
+    assert.equal(s.bySlug.a, 2);
+    assert.equal(s.bySlug.b, 1);
+    assert.equal(s.byToken['/docs/index'], 2);
+    assert.equal(s.byToken['http://google.com'], 1);
+    assert.equal(typeof s.registryEntries, 'number');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inventory-driven exclusion (Task 4.1 inventory 2026-04-15 時点)
+// ---------------------------------------------------------------------------
+
+describe('parity_artifact_registry (inventory-driven exclusion)', () => {
+  it('excludes http://google.com for creating-your-first-codeless-test (EN demo link artifact)', () => {
+    assert.equal(
+      isArtifactExcluded({
+        slug: 'getting-started/creating-your-first-codeless-test',
+        token: 'http://google.com',
+      }),
+      true,
+    );
+    assert.equal(
+      isArtifactExcluded({ slug: 'editing-tests/steps', token: 'http://google.com' }),
+      false,
+    );
+  });
+
+  it('excludes /docs/index for registered slugs (5 slugs in inventory)', () => {
+    const registered = [
+      'editing-tests/conditions/advanced-conditions-settings',
+      'integrations/visual-validation/visual_validation_index',
+      'recording-tests/recording-a-mobile-test/recording-a-local-mobile-test',
+      'salesforce-testing/salesforce-steps/sfdc-step-login',
+      'testops/insights/dashboard',
+    ];
+    for (const slug of registered) {
+      assert.equal(
+        isArtifactExcluded({ slug, token: '/docs/index' }),
+        true,
+        `expected ${slug} to be excluded for /docs/index`,
+      );
+    }
+    assert.equal(
+      isArtifactExcluded({ slug: 'unregistered/slug', token: '/docs/index' }),
+      false,
+    );
+  });
+});

--- a/scripts/__tests__/parity_normalize.test.mjs
+++ b/scripts/__tests__/parity_normalize.test.mjs
@@ -142,3 +142,26 @@ describe('normalizeUrlForParity — passthrough cases', () => {
     assert.equal(normalizeUrlForParity('--project-id'), '--project-id');
   });
 });
+
+describe('normalizeUrlForParity — help.testim.io symmetry (Phase 4 Task 4.3)', () => {
+  it('normalizes help.testim.io URL with fragment symmetrically', () => {
+    assert.equal(
+      normalizeUrlForParity('https://help.testim.io/docs/api-access#api-access'),
+      normalizeUrlForParity('/docs/api-access#api-access'),
+    );
+  });
+
+  it('preserves fragment on /docs path', () => {
+    assert.equal(
+      normalizeUrlForParity('https://help.testim.io/docs/index#top'),
+      '/docs/index#top',
+    );
+  });
+
+  it('drops trailing slash differences', () => {
+    assert.equal(
+      normalizeUrlForParity('https://help.testim.io/docs/api-access/'),
+      normalizeUrlForParity('/docs/api-access'),
+    );
+  });
+});

--- a/scripts/__tests__/parity_normalize.test.mjs
+++ b/scripts/__tests__/parity_normalize.test.mjs
@@ -165,3 +165,48 @@ describe('normalizeUrlForParity — help.testim.io symmetry (Phase 4 Task 4.3)',
     );
   });
 });
+
+describe('normalizeUrlForParity — /docs canonical form (PR A feedback P2)', () => {
+  it('drops trailing slash on bare /docs path', () => {
+    assert.equal(
+      normalizeUrlForParity('/docs/api-access/'),
+      '/docs/api-access',
+    );
+  });
+
+  it('drops query string on bare /docs path', () => {
+    assert.equal(
+      normalizeUrlForParity('/docs/api-access?x=1'),
+      '/docs/api-access',
+    );
+  });
+
+  it('drops query string on help.testim.io URL', () => {
+    assert.equal(
+      normalizeUrlForParity('https://help.testim.io/docs/api-access?x=1'),
+      '/docs/api-access',
+    );
+  });
+
+  it('drops query while preserving fragment', () => {
+    assert.equal(
+      normalizeUrlForParity('https://help.testim.io/docs/api-access?x=1#frag'),
+      '/docs/api-access#frag',
+    );
+  });
+
+  it('help.testim.io + query + trailing slash ↔ bare /docs symmetric', () => {
+    assert.equal(
+      normalizeUrlForParity('https://help.testim.io/docs/api-access/?ref=x#top'),
+      normalizeUrlForParity('/docs/api-access#top'),
+    );
+  });
+
+  it('strips help.testim.io prefix even for non-/docs paths (e.g. /v2.0/docs/...)', () => {
+    // Stage B5 で別途処理する想定。ここでは少なくとも prefix strip の対称性を確保する。
+    assert.equal(
+      normalizeUrlForParity('https://help.testim.io/v2.0/docs/scheduler#x'),
+      '/v2.0/docs/scheduler#x',
+    );
+  });
+});

--- a/scripts/__tests__/parity_normalize.test.mjs
+++ b/scripts/__tests__/parity_normalize.test.mjs
@@ -202,11 +202,12 @@ describe('normalizeUrlForParity — /docs canonical form (PR A feedback P2)', ()
     );
   });
 
-  it('strips help.testim.io prefix even for non-/docs paths (e.g. /v2.0/docs/...)', () => {
-    // Stage B5 で別途処理する想定。ここでは少なくとも prefix strip の対称性を確保する。
+  it('passes through non-/docs help.testim.io paths unchanged (Stage B5 scope)', () => {
+    // /v2.0/docs/... 等の versioned path は PR A canonical form の範囲外。
+    // 既存の baseline 凍結を崩さないよう URL 不変で返す (Stage B5 で別途処理)。
     assert.equal(
       normalizeUrlForParity('https://help.testim.io/v2.0/docs/scheduler#x'),
-      '/v2.0/docs/scheduler#x',
+      'https://help.testim.io/v2.0/docs/scheduler#x',
     );
   });
 });

--- a/scripts/__tests__/phase2_baseline.test.mjs
+++ b/scripts/__tests__/phase2_baseline.test.mjs
@@ -1,0 +1,67 @@
+// scripts/__tests__/phase2_baseline.test.mjs
+/**
+ * Phase 2 baseline util — enSideArtifact 分類契約が Phase 4 registry 一本化後も
+ * 維持されていることの regression test。
+ *
+ * Context: Phase 4 で runtime registry に一本化した際、`categorizeToken` が
+ * legacy typo tokens (`-variable`, `-this`, `step.This`) を静かに `cliFlag` /
+ * `other` に落としていたため、enumerate_token_gaps 出力の分類が気付かれず
+ * 変わっていた。Phase 4 registry (slug-scope) と phase2 の token-only 分類を
+ * 意図的に分けて保持する契約を pin する。
+ */
+
+import { before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+let categorizeToken;
+
+before(async () => {
+  ({ categorizeToken } = await import('../phase2/lib/baseline.mjs'));
+});
+
+describe('categorizeToken — Phase 2 legacy typo tokens (enSideArtifact 互換)', () => {
+  it('classifies -variable as enSideArtifact', () => {
+    assert.equal(categorizeToken('-variable'), 'enSideArtifact');
+  });
+  it('classifies -this as enSideArtifact', () => {
+    assert.equal(categorizeToken('-this'), 'enSideArtifact');
+  });
+  it('classifies step.This as enSideArtifact', () => {
+    assert.equal(categorizeToken('step.This'), 'enSideArtifact');
+  });
+});
+
+describe('categorizeToken — Phase 4 registry tokens', () => {
+  it('classifies /docs/index as enSideArtifact (registry token)', () => {
+    assert.equal(categorizeToken('/docs/index'), 'enSideArtifact');
+  });
+  it('classifies http://google.com as enSideArtifact (registry token)', () => {
+    assert.equal(categorizeToken('http://google.com'), 'enSideArtifact');
+  });
+});
+
+describe('categorizeToken — 他 category (回帰防止)', () => {
+  it('classifies --project-id as cliFlag', () => {
+    assert.equal(categorizeToken('--project-id'), 'cliFlag');
+  });
+  it('classifies -f as cliFlag', () => {
+    assert.equal(categorizeToken('-f'), 'cliFlag');
+  });
+  it('classifies /docs/api-access as internalLink', () => {
+    assert.equal(categorizeToken('/docs/api-access'), 'internalLink');
+  });
+  it('classifies 1000ms as numericOrUnit', () => {
+    assert.equal(categorizeToken('1000ms'), 'numericOrUnit');
+  });
+  it('classifies https://example.com as externalUrl', () => {
+    assert.equal(categorizeToken('https://example.com'), 'externalUrl');
+  });
+  it('classifies unknown token as other', () => {
+    assert.equal(categorizeToken('Ctrl+S'), 'other');
+  });
+  it('returns other for empty / null / undefined', () => {
+    assert.equal(categorizeToken(''), 'other');
+    assert.equal(categorizeToken(null), 'other');
+    assert.equal(categorizeToken(undefined), 'other');
+  });
+});

--- a/scripts/__tests__/source_parity_align.test.mjs
+++ b/scripts/__tests__/source_parity_align.test.mjs
@@ -23,10 +23,12 @@ import assert from 'node:assert/strict';
 
 let alignSegments;
 let createSegment;
+let createArtifactCoverage;
 
 before(async () => {
   ({ alignSegments } = await import('../lib/source_parity_align.mjs'));
   ({ createSegment } = await import('../lib/source_parity_segments_shared.mjs'));
+  ({ createArtifactCoverage } = await import('../lib/parity_artifact_registry.mjs'));
 });
 
 // ---------------------------------------------------------------------------
@@ -55,7 +57,7 @@ function diffsByType(diffs) {
 
 describe('alignSegments — empty / identical inputs', () => {
   it('returns no diffs for two empty sequences', () => {
-    const result = alignSegments([], []);
+    const result = alignSegments([], [], { slug: 'test/fixture' });
     assert.deepEqual(result.diffs, []);
     assert.equal(result.sectionsAligned, 1); // preface only
   });
@@ -73,7 +75,7 @@ describe('alignSegments — empty / identical inputs', () => {
       makeSeg('セットアップ', 'unordered-list-item', 0, 'JA 箇条書き 1'),
       makeSeg('セットアップ', 'unordered-list-item', 1, 'JA 箇条書き 2'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     assert.deepEqual(result.diffs, []);
   });
 
@@ -88,7 +90,7 @@ describe('alignSegments — empty / identical inputs', () => {
       makeHeading('セットアップ', 0, 'セットアップ'),
       makeSeg('セットアップ', 'paragraph', 0, '本文段落'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const grouped = diffsByType(result.diffs);
     assert.equal(grouped['segment-missing'], 1, 'preface paragraph missing');
     const missing = result.diffs.find((d) => d.type === 'segment-missing');
@@ -115,7 +117,7 @@ describe('alignSegments — segment-missing', () => {
       // 2 番目の段落を削除
       makeSeg('セットアップ', 'paragraph', 1, '段落 3'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const missingDiffs = result.diffs.filter((d) => d.type === 'segment-missing');
     assert.equal(missingDiffs.length, 1, 'exactly one segment-missing — no LCS cascade');
     assert.equal(missingDiffs[0].segmentKind, 'paragraph');
@@ -133,7 +135,7 @@ describe('alignSegments — segment-missing', () => {
       makeSeg('セットアップ', 'unordered-list-item', 0, '箇条 1'),
       makeSeg('セットアップ', 'unordered-list-item', 1, '箇条 3'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     assert.equal(result.diffs.length, 1);
     assert.equal(result.diffs[0].type, 'segment-missing');
     assert.equal(result.diffs[0].segmentKind, 'unordered-list-item');
@@ -151,7 +153,7 @@ describe('alignSegments — segment-missing', () => {
       makeSeg('手順', 'ordered-list-item', 0, '手順 1'),
       makeSeg('手順', 'ordered-list-item', 1, '手順 3'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     assert.equal(result.diffs.length, 1);
     assert.equal(result.diffs[0].type, 'segment-missing');
   });
@@ -168,7 +170,7 @@ describe('alignSegments — segment-missing', () => {
       makeSeg('セットアップ', 'callout-body', 0, 'JA callout 文 A'),
       // 2 番目の callout body 段落が JA で欠落
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const missingDiffs = result.diffs.filter((d) => d.type === 'segment-missing');
     assert.equal(missingDiffs.length, 1);
     assert.equal(missingDiffs[0].segmentKind, 'callout-body');
@@ -189,7 +191,7 @@ describe('alignSegments — segment-missing', () => {
       makeSeg('引数', 'table-cell', 2, '`--token`'),
       // 4th cell deleted
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const missingDiffs = result.diffs.filter((d) => d.type === 'segment-missing');
     assert.ok(missingDiffs.length >= 1, 'at least one segment-missing emitted');
     assert.equal(missingDiffs[0].segmentKind, 'table-cell');
@@ -214,7 +216,7 @@ describe('alignSegments — segment-extra', () => {
       makeSeg('セットアップ', 'paragraph', 1, '余分な段落'),
       makeSeg('セットアップ', 'paragraph', 2, '段落 2'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const extraDiffs = result.diffs.filter((d) => d.type === 'segment-extra');
     assert.equal(extraDiffs.length, 1);
     assert.equal(extraDiffs[0].segmentKind, 'paragraph');
@@ -235,7 +237,7 @@ describe('alignSegments — segment-untranslated', () => {
       makeHeading('セットアップ', 0, 'セットアップ'),
       makeSeg('セットアップ', 'paragraph', 0, 'Click on the Settings button to begin.'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const untranslated = result.diffs.filter((d) => d.type === 'segment-untranslated');
     assert.equal(untranslated.length, 1);
     assert.equal(untranslated[0].segmentKind, 'paragraph');
@@ -250,7 +252,7 @@ describe('alignSegments — segment-untranslated', () => {
       makeHeading('セットアップ', 0, 'セットアップ'),
       makeSeg('セットアップ', 'paragraph', 0, '設定ボタンをクリックして開始します。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const untranslated = result.diffs.filter((d) => d.type === 'segment-untranslated');
     assert.equal(untranslated.length, 0);
   });
@@ -264,7 +266,7 @@ describe('alignSegments — segment-untranslated', () => {
       makeHeading('CLI', 0, 'CLI'),
       makeSeg('CLI', 'paragraph', 0, '`--proxy` フラグは URL を受け取ります。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const untranslated = result.diffs.filter((d) => d.type === 'segment-untranslated');
     assert.equal(untranslated.length, 0);
   });
@@ -285,7 +287,7 @@ describe('alignSegments — segment-token-gap', () => {
       // The token `--proxy` was dropped from the JA paragraph
       makeSeg('CLI', 'paragraph', 0, 'HTTP プロキシを使うには起動します。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const gaps = result.diffs.filter((d) => d.type === 'segment-token-gap');
     assert.equal(gaps.length, 1);
     assert.ok(Array.isArray(gaps[0].missingTokens));
@@ -301,7 +303,7 @@ describe('alignSegments — segment-token-gap', () => {
       makeHeading('CLI', 0, 'CLI'),
       makeSeg('CLI', 'paragraph', 0, '`--proxy` を指定して HTTP プロキシを使用します。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const gaps = result.diffs.filter((d) => d.type === 'segment-token-gap');
     assert.equal(gaps.length, 0);
   });
@@ -328,7 +330,7 @@ describe('alignSegments — section anchoring', () => {
       makeHeading('実行', 0, '実行'),
       makeSeg('実行', 'paragraph', 0, '実行段落 1'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const missingDiffs = result.diffs.filter((d) => d.type === 'segment-missing');
     assert.equal(missingDiffs.length, 1);
     // sectionPath は EN 側 (削除された segment は EN にしか存在しない)。
@@ -364,7 +366,7 @@ describe('alignSegments — section anchoring', () => {
       makeHeading('Cセクション', 0, 'Cセクション'),
       makeSeg('Cセクション', 'paragraph', 0, '`--cflag` を C1 で使用します。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     // section A にだけ diff が出て、B / C に cascade しないことを確認する。
     const missingDiffs = result.diffs.filter((d) => d.type === 'segment-missing');
     assert.equal(missingDiffs.length, 1, 'no cascade — exactly one missing diff');
@@ -407,7 +409,7 @@ describe('alignSegments — heading count mismatch', () => {
       makeSeg('A-ja', 'paragraph', 0, 'a-ja'),
       // B heading + body missing entirely
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     assert.equal(result.inconclusive, true);
     assert.match(result.inconclusiveReason, /heading/i);
   });
@@ -434,7 +436,7 @@ describe('alignSegments — position correctness on distinguishable content', ()
       makeSeg('セットアップ', 'paragraph', 0, 'JA 0: `token-alpha-0`'),
       makeSeg('セットアップ', 'paragraph', 1, 'JA 2: `token-alpha-2`'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const missing = result.diffs.filter((d) => d.type === 'segment-missing');
     assert.equal(missing.length, 1, 'exactly one missing diff');
     // The deleted EN paragraph is the second one (segmentIndex=1).
@@ -453,7 +455,7 @@ describe('alignSegments — position correctness on distinguishable content', ()
       makeSeg('セットアップ', 'paragraph', 0, 'JA 0: `token-beta-0`'),
       makeSeg('セットアップ', 'paragraph', 1, 'JA 1: `token-beta-1`'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const missing = result.diffs.filter((d) => d.type === 'segment-missing');
     assert.equal(missing.length, 1);
     assert.equal(missing[0].enSegmentIndex, 2, 'enSegmentIndex must point at the trailing paragraph');
@@ -467,7 +469,7 @@ describe('alignSegments — position correctness on distinguishable content', ()
       makeSeg('セットアップ', 'paragraph', 0, 'JA 1: `token-gamma-1`'),
       makeSeg('セットアップ', 'paragraph', 1, 'JA 2: `token-gamma-2`'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const missing = result.diffs.filter((d) => d.type === 'segment-missing');
     assert.equal(missing.length, 1);
     assert.equal(missing[0].enSegmentIndex, 0, 'enSegmentIndex must point at the leading paragraph');
@@ -491,7 +493,7 @@ describe('alignSegments — position correctness on distinguishable content', ()
       makeSeg('Setup', 'paragraph', 0, 'Alpha paragraph.'),
       makeSeg('Setup', 'paragraph', 1, 'Gamma paragraph.'),
     ];
-    const middle = alignSegments(en, jaMiddleMissing);
+    const middle = alignSegments(en, jaMiddleMissing, { slug: 'test/fixture' });
     const middleMissing = middle.diffs.filter((d) => d.type === 'segment-missing');
     assert.equal(middleMissing.length, 1);
     assert.equal(middleMissing[0].enSegmentIndex, 1);
@@ -523,7 +525,7 @@ describe('alignSegments — section content validation', () => {
       // body sourced from Setup
       makeSeg('実行', 'paragraph', 0, '`--proxy` と `--token` を設定します。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const shifted = result.diffs.filter((d) => d.type === 'segment-shifted');
     // At least the Setup section must be flagged as mis-aligned.
     assert.ok(shifted.length >= 1, 'at least one segment-shifted diff expected');
@@ -542,7 +544,7 @@ describe('alignSegments — section content validation', () => {
       makeHeading('セットアップ', 0, 'セットアップ'),
       makeSeg('セットアップ', 'paragraph', 0, '`--proxy` を使用して設定します。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const shifted = result.diffs.filter((d) => d.type === 'segment-shifted');
     assert.equal(shifted.length, 0);
   });
@@ -567,7 +569,7 @@ describe('alignSegments — segment-shifted only fires with token destination ev
       makeHeading('CLI', 0, 'CLI'),
       makeSeg('CLI', 'paragraph', 0, '`--token` を指定して認証します。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const types = result.diffs.map((d) => d.type);
     assert.ok(
       !types.includes('segment-shifted'),
@@ -598,7 +600,7 @@ describe('alignSegments — segment-shifted only fires with token destination ev
       makeSeg('Bセクション', 'paragraph', 0, '極短ベータ 1。'),
       makeSeg('Bセクション', 'paragraph', 1, '極短ベータ 2。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const shifted = result.diffs.filter((d) => d.type === 'segment-shifted');
     assert.equal(
       shifted.length,
@@ -630,7 +632,7 @@ describe('alignSegments — segment-shifted only fires with token destination ev
       makeSeg('Bセクション', 'paragraph', 0, 'これはより長い A1 段落で、重要な詳細を含んでいます。'),
       makeSeg('Bセクション', 'paragraph', 1, 'これは A2 段落も長く、物事を詳しく説明しています。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const shifted = result.diffs.filter((d) => d.type === 'segment-shifted');
     assert.equal(result.inconclusive, false);
     assert.equal(shifted.length, 0, 'no exact shift diff should be emitted');
@@ -656,7 +658,7 @@ describe('alignSegments — segment-shifted only fires with token destination ev
       makeSeg('Bセクション', 'paragraph', 0, 'アルファ 1 の段落です。'),
       makeSeg('Bセクション', 'paragraph', 1, 'アルファ 2 の段落です。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     assert.equal(result.diffs.length, 0);
     assert.equal(result.inconclusive, true, 'uniform tokenless swap must not be silent green');
     assert.match(result.inconclusiveReason, /cannot rule out a body swap/i);
@@ -680,7 +682,7 @@ describe('alignSegments — segment-shifted only fires with token destination ev
       makeSeg('B-ja', 'paragraph', 0, 'ベータ 1 の段落です。'),
       makeSeg('B-ja', 'paragraph', 1, 'ベータ 2 の段落です。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     assert.equal(result.diffs.length, 0);
     assert.equal(result.inconclusive, true);
   });
@@ -706,7 +708,7 @@ describe('alignSegments — segment-shifted only fires with token destination ev
       makeHeading('C-ja', 0, 'C-ja'),
       makeSeg('C-ja', 'paragraph', 0, 'ここで使います。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     assert.equal(result.inconclusive, true, 'A/B pair should still mark the page inconclusive');
     const gaps = result.diffs.filter((d) => d.type === 'segment-token-gap');
     assert.equal(gaps.length, 1, 'exact diff in section C must be preserved');
@@ -730,7 +732,7 @@ describe('alignSegments — segment-shifted only fires with token destination ev
       makeHeading('B', 0, 'B'),
       makeSeg('B', 'paragraph', 0, '`--beta` を B で使います。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const shifted = result.diffs.filter((d) => d.type === 'segment-shifted');
     assert.equal(shifted.length, 0, 'no destination section → no shift');
   });
@@ -751,7 +753,7 @@ describe('alignSegments — segment-shifted only fires with token destination ev
       makeHeading('実行', 0, '実行'),
       makeSeg('実行', 'paragraph', 0, '`--proxy` を設定します。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const shifted = result.diffs.filter((d) => d.type === 'segment-shifted');
     assert.ok(shifted.length >= 1, 'symmetric token swap must surface as segment-shifted');
     assert.ok(shifted.every((d) => d.confidence === 'high'));
@@ -780,7 +782,7 @@ describe('alignSegments — tokenless cross-language paragraph identification', 
       makeSeg('セットアップ', 'paragraph', 0, 'アルファ段落です。'),
       makeSeg('セットアップ', 'paragraph', 1, 'ガンマ段落です。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const missing = result.diffs.filter((d) => d.type === 'segment-missing');
     assert.equal(missing.length, 1);
     assert.equal(missing[0].enSegmentIndex, 1, 'middle paragraph must be the gap');
@@ -804,7 +806,7 @@ describe('alignSegments — tokenless cross-language paragraph identification', 
       makeSeg('セットアップ', 'paragraph', 1, 'Beta paragraph.'),
       // Gamma deleted
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const missing = result.diffs.filter((d) => d.type === 'segment-missing');
     assert.equal(missing.length, 1);
     assert.equal(missing[0].enSegmentIndex, 2, 'trailing paragraph must be the gap');
@@ -823,7 +825,7 @@ describe('alignSegments — tokenless cross-language paragraph identification', 
       makeSeg('セットアップ', 'paragraph', 0, 'Beta paragraph.'),
       makeSeg('セットアップ', 'paragraph', 1, 'Gamma paragraph.'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const missing = result.diffs.filter((d) => d.type === 'segment-missing');
     assert.equal(missing.length, 1);
     assert.equal(missing[0].enSegmentIndex, 0, 'leading paragraph must be the gap');
@@ -849,7 +851,7 @@ describe('alignSegments — tokenless cross-language paragraph identification', 
       makeSeg('セットアップ', 'paragraph', 0, 'ベータの段落です。'),
       makeSeg('セットアップ', 'paragraph', 1, 'ガンマの段落です。'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const missing = result.diffs.filter((d) => d.type === 'segment-missing');
     // Structural detection still fires — exactly one paragraph is missing.
     assert.equal(missing.length, 1, 'one missing diff must be emitted');
@@ -876,8 +878,8 @@ describe('alignSegments — determinism', () => {
       makeSeg('セットアップ', 'paragraph', 0, 'p1-ja'),
       makeSeg('セットアップ', 'paragraph', 1, 'p3-ja'),
     ];
-    const a = alignSegments(en, ja);
-    const b = alignSegments(en, ja);
+    const a = alignSegments(en, ja, { slug: 'test/fixture' });
+    const b = alignSegments(en, ja, { slug: 'test/fixture' });
     assert.deepEqual(a, b);
   });
 
@@ -886,7 +888,7 @@ describe('alignSegments — determinism', () => {
     const ja = [makeHeading('A-ja', 0, 'A-ja')];
     const enClone = JSON.parse(JSON.stringify(en));
     const jaClone = JSON.parse(JSON.stringify(ja));
-    alignSegments(en, ja);
+    alignSegments(en, ja, { slug: 'test/fixture' });
     assert.deepEqual(en, enClone);
     assert.deepEqual(ja, jaClone);
   });
@@ -906,7 +908,7 @@ describe('alignSegments — inconclusiveCategory enum', () => {
       makeHeading('セットアップ', 0, 'セットアップ'),
       makeSeg('セットアップ', 'paragraph', 0, '本文段落'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     assert.equal(result.inconclusive, false);
     assert.equal(result.inconclusiveCategory, null);
     assert.equal(result.inconclusiveMeta, null);
@@ -922,7 +924,7 @@ describe('alignSegments — inconclusiveCategory enum', () => {
       makeHeading('セットアップ', 0, 'セットアップ'),
       makeSeg('セットアップ', 'paragraph', 0, '本文'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     assert.equal(result.inconclusive, true);
     assert.equal(result.inconclusiveCategory, 'heading-count-mismatch');
     assert.equal(result.inconclusiveMeta, null);
@@ -947,7 +949,7 @@ describe('alignSegments — inconclusiveCategory enum', () => {
       makeHeading('セクション B', 0, 'セクション B'),
       makeSeg('セクション B', 'paragraph', 0, '1 番目の本文文章 ほぼ同じ長さ'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     if (result.inconclusive) {
       assert.equal(result.inconclusiveCategory, 'tokenless-near-tie');
       assert.match(result.inconclusiveReason, /tokenless adjacent sections/i);
@@ -988,7 +990,7 @@ describe('alignSegments — structure comparator integration', () => {
       makeHeading('概要', 0, '概要'),
       makeSeg('概要', 'paragraph', 0, 'alpha, beta, gamma を段落に畳んだ翻訳'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const structureDiffs = result.diffs.filter(
       (d) => d.type === 'section-structure-mismatch',
     );
@@ -1012,7 +1014,7 @@ describe('alignSegments — structure comparator integration', () => {
       makeHeading('概要', 0, '概要'),
       makeSeg('概要', 'paragraph', 0, 'alpha, beta, gamma を段落に畳んだ翻訳'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const grouped = diffsByType(result.diffs);
     assert.equal(
       grouped['section-structure-mismatch'],
@@ -1041,7 +1043,7 @@ describe('alignSegments — structure comparator integration', () => {
       makeHeading('セクション 2', 0, 'セクション 2'),
       makeSeg('セクション 2', 'paragraph', 0, '綺麗な翻訳 `key`'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const structureDiffs = result.diffs.filter(
       (d) => d.type === 'section-structure-mismatch' || d.type === 'segment-order-mismatch',
     );
@@ -1060,7 +1062,7 @@ describe('alignSegments — structure comparator integration', () => {
       makeSeg('概要', 'unordered-list-item', 0, '- 箇条書き `token-b`'),
       makeSeg('概要', 'paragraph', 0, '段落 `token-a`'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const structureDiffs = result.diffs.filter((d) => d.type === 'segment-order-mismatch');
     assert.equal(structureDiffs.length, 1);
     assert.equal(structureDiffs[0].structureCategory, 'kind-sequence');
@@ -1077,7 +1079,7 @@ describe('alignSegments — structure comparator integration', () => {
       makeSeg('概要', 'paragraph', 0, '`beta-token` の段落'),
       makeSeg('概要', 'paragraph', 1, '`alpha-token` の段落'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const structureDiffs = result.diffs.filter((d) => d.type === 'segment-order-mismatch');
     assert.equal(structureDiffs.length, 1);
     assert.equal(structureDiffs[0].structureCategory, 'content-order');
@@ -1097,7 +1099,7 @@ describe('alignSegments — structure comparator integration', () => {
       makeSeg('概要', 'paragraph', 0, 'JA 段落 A `token-a`'),
       makeSeg('概要', 'paragraph', 1, 'JA 段落 C `token-c`'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const grouped = diffsByType(result.diffs);
     assert.equal(
       grouped['section-structure-mismatch'],
@@ -1132,7 +1134,7 @@ describe('alignSegments — structure comparator integration', () => {
       makeSeg('セクション B', 'paragraph', 0, 'JA A 段落 `alpha-token` と `alpha-flag`'),
       makeSeg('セクション B', 'unordered-list-item', 0, '- A 箇条書き `alpha-extra`'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const grouped = diffsByType(result.diffs);
     assert.ok(
       (grouped['segment-shifted'] ?? 0) > 0,
@@ -1171,7 +1173,7 @@ describe('alignSegments — structure comparator integration', () => {
       // Section B はローカルに callout を平文に畳んだ (cross-kind drift)
       makeSeg('セクション B', 'paragraph', 0, 'JA B 注意と段落を畳んだ翻訳 `local-token` `local-flag`'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const grouped = diffsByType(result.diffs);
     // Section B の cross-kind drift は structure-mismatch として残る。
     // (Section A は shift 判定が出るかどうかは alignSection の token
@@ -1197,7 +1199,7 @@ describe('alignSegments — structure comparator integration', () => {
       makeHeading('概要', 0, '概要'),
       makeSeg('概要', 'paragraph', 0, '注意 `warn` と段落 `flag` を畳んだ翻訳'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const issues = parityDiffsToIssues(result.diffs);
 
     const structureIssue = issues.find((i) => i.type === 'section-structure-mismatch');
@@ -1246,7 +1248,7 @@ describe('alignSegments — structure comparator integration', () => {
       makeSeg('概要', 'paragraph', 0, '`beta` の段落'),
       makeSeg('概要', 'paragraph', 1, '`alpha` の段落'),
     ];
-    const result = alignSegments(en, ja);
+    const result = alignSegments(en, ja, { slug: 'test/fixture' });
     const issues = parityDiffsToIssues(result.diffs);
     const issue = issues.find((i) => i.type === 'segment-order-mismatch');
     assert.ok(issue);
@@ -1291,7 +1293,7 @@ describe('alignSegments — glossary_mask 統合 (Phase 0)', () => {
         rawText: 'Test Editor を開いて開始します。',
       }),
     ];
-    const result = alignSegments(enSegs, jaSegs);
+    const result = alignSegments(enSegs, jaSegs, { slug: 'test/fixture' });
     const untranslatedDiffs = result.diffs.filter(
       (d) => d.type === 'segment-untranslated',
     );
@@ -1331,7 +1333,7 @@ describe('alignSegments — glossary_mask 統合 (Phase 0)', () => {
         rawText: 'Open Test Editor to start recording tests.',
       }),
     ];
-    const result = alignSegments(enSegs, jaSegs);
+    const result = alignSegments(enSegs, jaSegs, { slug: 'test/fixture' });
     const untranslatedDiffs = result.diffs.filter(
       (d) => d.type === 'segment-untranslated',
     );
@@ -1339,5 +1341,77 @@ describe('alignSegments — glossary_mask 統合 (Phase 0)', () => {
       untranslatedDiffs.length >= 1,
       '英語 prose が残る場合は untranslated として emit するべき',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 4: options.slug safety guard + artifact registry suppression
+// ---------------------------------------------------------------------------
+
+describe('alignSegments — options.slug / artifact registry integration (Phase 4)', () => {
+  it('throws when slug option is missing (safety guard)', () => {
+    const en = [makeHeading('Setup', 0, 'Setup'), makeSeg('Setup', 'paragraph', 0, 'body')];
+    const ja = [makeHeading('セットアップ', 0, 'セットアップ'), makeSeg('セットアップ', 'paragraph', 0, '本文')];
+    assert.throws(() => alignSegments(en, ja), /slug option is required/);
+    assert.throws(() => alignSegments(en, ja, {}), /slug option is required/);
+  });
+
+  it('suppresses segment-token-gap via artifact registry and records coverage', () => {
+    // EN 側に /docs/index リンクを持ち、JA には無い fixture を作る。
+    // registry 登録済 slug で呼ぶと token-gap が 1 件も出ない。coverage には 1 hit。
+    const en = [
+      makeHeading('Overview', 0, 'Overview'),
+      makeSeg(
+        'Overview',
+        'paragraph',
+        0,
+        'See the [index page](/docs/index) for details.',
+      ),
+    ];
+    const ja = [
+      makeHeading('概要', 0, '概要'),
+      makeSeg('概要', 'paragraph', 0, '詳細は index ページを参照してください。'),
+    ];
+    const registeredSlug = 'testops/insights/dashboard'; // registry 登録済
+    const coverage = createArtifactCoverage();
+    const result = alignSegments(en, ja, { slug: registeredSlug, coverage });
+    const tokenGaps = result.diffs.filter((d) => d.type === 'segment-token-gap');
+    assert.equal(
+      tokenGaps.length,
+      0,
+      `registry 登録済 slug + token では token-gap が 0 件になるべき (実際: ${tokenGaps.length})`,
+    );
+    const snap = coverage.snapshot();
+    assert.ok(snap.matchedHits >= 1, 'coverage に 1 hit 以上記録されるべき');
+    assert.equal(snap.byToken['/docs/index'], snap.matchedHits);
+    assert.equal(snap.bySlug[registeredSlug], snap.matchedHits);
+  });
+
+  it('does not suppress segment-token-gap for unregistered slugs', () => {
+    // 同じ fixture を registry 非登録 slug で呼ぶと通常通り token-gap が出る。
+    const en = [
+      makeHeading('Overview', 0, 'Overview'),
+      makeSeg(
+        'Overview',
+        'paragraph',
+        0,
+        'See the [index page](/docs/index) for details.',
+      ),
+    ];
+    const ja = [
+      makeHeading('概要', 0, '概要'),
+      makeSeg('概要', 'paragraph', 0, '詳細は index ページを参照してください。'),
+    ];
+    const coverage = createArtifactCoverage();
+    const result = alignSegments(en, ja, {
+      slug: 'unregistered/slug-should-not-match',
+      coverage,
+    });
+    const tokenGaps = result.diffs.filter((d) => d.type === 'segment-token-gap');
+    assert.ok(
+      tokenGaps.length >= 1,
+      `未登録 slug では token-gap が emit されるべき (実際: ${tokenGaps.length})`,
+    );
+    assert.equal(coverage.snapshot().matchedHits, 0);
   });
 });

--- a/scripts/__tests__/source_parity_align_runtime.test.mjs
+++ b/scripts/__tests__/source_parity_align_runtime.test.mjs
@@ -71,7 +71,7 @@ describe('parityDiffsToIssues', () => {
     const jaMd = '## セットアップ\n\nプロキシを設定します。\n';
     const enSegs = extractSegmentsFromHtml(enHtml);
     const jaSegs = extractSegmentsFromMarkdown(jaMd);
-    const alignment = alignSegments(enSegs, jaSegs);
+    const alignment = alignSegments(enSegs, jaSegs, { slug: 'test/fixture' });
     const issues = parityDiffsToIssues(alignment.diffs);
     assert.ok(issues.length > 0, 'expected at least one diff (token-gap on --proxy)');
     for (const issue of issues) {
@@ -89,7 +89,7 @@ describe('parityDiffsToIssues', () => {
     const jaMd = '## CLI\n\nHTTP プロキシを使うときに指定します。\n';
     const enSegs = extractSegmentsFromHtml(enHtml);
     const jaSegs = extractSegmentsFromMarkdown(jaMd);
-    const alignment = alignSegments(enSegs, jaSegs);
+    const alignment = alignSegments(enSegs, jaSegs, { slug: 'test/fixture' });
     const issues = parityDiffsToIssues(alignment.diffs);
     const tokenGap = issues.find((i) => i.type === 'segment-token-gap');
     assert.ok(tokenGap, 'expected a segment-token-gap diff');

--- a/scripts/__tests__/source_parity_baseline_recall.test.mjs
+++ b/scripts/__tests__/source_parity_baseline_recall.test.mjs
@@ -103,7 +103,7 @@ describe('baseline does not absorb new mutations', () => {
       const enSegments = extractSegmentsFromHtml(html);
       const jaOriginal = readJaMarkdown(slug);
       const jaSegmentsOriginal = extractSegmentsFromMarkdown(jaOriginal);
-      const baselineAlignment = alignSegments(enSegments, jaSegmentsOriginal);
+      const baselineAlignment = alignSegments(enSegments, jaSegmentsOriginal, { slug });
 
       if (baselineAlignment.inconclusive) continue;
 
@@ -116,7 +116,7 @@ describe('baseline does not absorb new mutations', () => {
         if (mutation === null) continue;
 
         const jaSegmentsMutated = extractSegmentsFromMarkdown(mutation.mutated);
-        const mutatedAlignment = alignSegments(enSegments, jaSegmentsMutated);
+        const mutatedAlignment = alignSegments(enSegments, jaSegmentsMutated, { slug });
         if (mutatedAlignment.inconclusive) continue;
 
         const mutatedIssues = parityDiffsToIssues(mutatedAlignment.diffs);

--- a/scripts/__tests__/source_parity_clean_page_fixtures.test.mjs
+++ b/scripts/__tests__/source_parity_clean_page_fixtures.test.mjs
@@ -65,7 +65,7 @@ function runStructureComparator(slug) {
   const jaBody = extractJaBody(jaMd);
   const enSegments = extractSegmentsFromHtml(rawEnHtml);
   const jaSegments = extractSegmentsFromMarkdown(jaBody);
-  const alignment = alignSegments(enSegments, jaSegments);
+  const alignment = alignSegments(enSegments, jaSegments, { slug });
   const issues = parityDiffsToIssues(alignment.diffs);
   const structureIssues = issues.filter(
     (i) => i.type === 'section-structure-mismatch' || i.type === 'segment-order-mismatch',

--- a/scripts/__tests__/source_parity_recall.test.mjs
+++ b/scripts/__tests__/source_parity_recall.test.mjs
@@ -394,7 +394,7 @@ function analyzePage(slug) {
   const enSegments = extractSegmentsFromHtml(html);
   const jaSegmentsOriginal = extractSegmentsFromMarkdown(jaOriginal);
 
-  const baselineResult = alignSegments(enSegments, jaSegmentsOriginal);
+  const baselineResult = alignSegments(enSegments, jaSegmentsOriginal, { slug });
 
   const mutations = {};
   for (const [type, fn] of Object.entries(MUTATION_TYPES)) {
@@ -404,7 +404,7 @@ function analyzePage(slug) {
       continue;
     }
     const jaSegmentsMutated = extractSegmentsFromMarkdown(mutation.mutated);
-    const mutatedResult = alignSegments(enSegments, jaSegmentsMutated);
+    const mutatedResult = alignSegments(enSegments, jaSegmentsMutated, { slug });
 
     const affected = findAffectedSegment(
       jaSegmentsOriginal,

--- a/scripts/__tests__/source_parity_segments_en.test.mjs
+++ b/scripts/__tests__/source_parity_segments_en.test.mjs
@@ -416,10 +416,13 @@ describe('extractSegmentsFromHtml — shape invariants', () => {
 // ---------------------------------------------------------------------------
 
 describe('preprocessHtml callout normalization', () => {
-  it('exports CALLOUT_NORMALIZATION_SLUGS as a frozen Set with administration/api-access', () => {
+  it('exports CALLOUT_NORMALIZATION_SLUGS as a Set containing administration/api-access', () => {
+    // NOTE: Object.freeze(new Set(...)) は内部 slot (add/delete/clear) を
+    // 防がないため Object.isFrozen では「単一 truth」を保証できない。allow list
+    // の書き換えを検知したい場合は下記 size assertion を更新すること。
     assert.ok(CALLOUT_NORMALIZATION_SLUGS instanceof Set);
     assert.ok(CALLOUT_NORMALIZATION_SLUGS.has('administration/api-access'));
-    assert.ok(Object.isFrozen(CALLOUT_NORMALIZATION_SLUGS));
+    assert.equal(CALLOUT_NORMALIZATION_SLUGS.size, 1);
   });
 
   it('rewrites short warning-like <blockquote> to <div class="callout-note"> for allowed slug', () => {

--- a/scripts/__tests__/source_parity_segments_en.test.mjs
+++ b/scripts/__tests__/source_parity_segments_en.test.mjs
@@ -486,6 +486,20 @@ describe('preprocessHtml callout normalization', () => {
     assert.match(out, /<div class="callout-note">/);
     assert.doesNotMatch(out, /<blockquote>/);
   });
+
+  it('does NOT rewrite <blockquote> without <p> wrapper even for allowed slug (walkCalloutBody drops text nodes)', () => {
+    // bare-text blockquote を callout-note に書き換えると walkCalloutBody が
+    // text node を emit しないため content が消失する。変換対象外にして
+    // 元の <blockquote> を残すことで、extractor の通常経路で paragraph 扱いに
+    // フォールバックする。
+    const html = '<blockquote>Warning text</blockquote>';
+    const out = preprocessHtml(html, {
+      slug: 'administration/api-access',
+      calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS,
+    });
+    assert.match(out, /<blockquote>/);
+    assert.doesNotMatch(out, /<div class="callout-note">/);
+  });
 });
 
 describe('extractSegmentsFromHtml emits callout-body after normalization', () => {

--- a/scripts/__tests__/source_parity_segments_en.test.mjs
+++ b/scripts/__tests__/source_parity_segments_en.test.mjs
@@ -8,9 +8,12 @@ import { before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 let extractSegmentsFromHtml;
+let preprocessHtml;
+let CALLOUT_NORMALIZATION_SLUGS;
 
 before(async () => {
-  ({ extractSegmentsFromHtml } = await import('../lib/source_parity_segments_en.mjs'));
+  ({ extractSegmentsFromHtml, preprocessHtml, CALLOUT_NORMALIZATION_SLUGS } =
+    await import('../lib/source_parity_segments_en.mjs'));
 });
 
 function byKind(segments, kind) {
@@ -405,5 +408,112 @@ describe('extractSegmentsFromHtml — shape invariants', () => {
   it('handles empty input', () => {
     assert.deepEqual(extractSegmentsFromHtml(''), []);
     assert.deepEqual(extractSegmentsFromHtml('   \n\t  '), []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// preprocessHtml — slug-scoped <blockquote> → callout-note 正規化
+// ---------------------------------------------------------------------------
+
+describe('preprocessHtml callout normalization', () => {
+  it('exports CALLOUT_NORMALIZATION_SLUGS as a frozen Set with administration/api-access', () => {
+    assert.ok(CALLOUT_NORMALIZATION_SLUGS instanceof Set);
+    assert.ok(CALLOUT_NORMALIZATION_SLUGS.has('administration/api-access'));
+    assert.ok(Object.isFrozen(CALLOUT_NORMALIZATION_SLUGS));
+  });
+
+  it('rewrites short warning-like <blockquote> to <div class="callout-note"> for allowed slug', () => {
+    const html =
+      '<blockquote><p><strong>Note</strong>: Keep your API key safe.</p></blockquote>';
+    const out = preprocessHtml(html, {
+      slug: 'administration/api-access',
+      calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS,
+    });
+    assert.match(out, /<div class="callout-note">/);
+    assert.doesNotMatch(out, /<blockquote>/);
+  });
+
+  it('does NOT rewrite when slug is not allowed', () => {
+    const html = '<blockquote><p><strong>Note</strong>: Keep.</p></blockquote>';
+    const out = preprocessHtml(html, {
+      slug: 'editing-tests/steps',
+      calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS,
+    });
+    assert.match(out, /<blockquote>/);
+  });
+
+  it('does NOT rewrite when options omitted (backward compat)', () => {
+    const html = '<blockquote><p><strong>Note</strong>: Keep.</p></blockquote>';
+    const out = preprocessHtml(html);
+    assert.match(out, /<blockquote>/);
+  });
+
+  it('does NOT rewrite long (>3 paragraph) blockquote', () => {
+    const html = [
+      '<blockquote>',
+      '<p>Note: a</p>',
+      '<p>b</p>',
+      '<p>c</p>',
+      '<p>d</p>',
+      '</blockquote>',
+    ].join('');
+    const out = preprocessHtml(html, {
+      slug: 'administration/api-access',
+      calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS,
+    });
+    assert.match(out, /<blockquote>/);
+  });
+
+  it('does NOT rewrite blockquote without warning-like leading token', () => {
+    const html = '<blockquote><p>This is a quotation.</p></blockquote>';
+    const out = preprocessHtml(html, {
+      slug: 'administration/api-access',
+      calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS,
+    });
+    assert.match(out, /<blockquote>/);
+  });
+
+  it('rewrites blockquote starting with Warning (no delimiter) as api-access-style', () => {
+    const html =
+      '<blockquote><p>Warning This action cannot be undone.</p></blockquote>';
+    const out = preprocessHtml(html, {
+      slug: 'administration/api-access',
+      calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS,
+    });
+    assert.match(out, /<div class="callout-note">/);
+    assert.doesNotMatch(out, /<blockquote>/);
+  });
+});
+
+describe('extractSegmentsFromHtml emits callout-body after normalization', () => {
+  it('emits segmentKind=callout-body for allowed slug + warning-like short blockquote', () => {
+    const html =
+      '<h2>Heading</h2><blockquote><p><strong>Warning</strong>: drop zone</p></blockquote>';
+    const segments = extractSegmentsFromHtml(html, {
+      slug: 'administration/api-access',
+      calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS,
+    });
+    const kinds = segments.map((s) => s.segmentKind);
+    assert.ok(kinds.includes('callout-body'));
+    assert.ok(!kinds.includes('paragraph') || kinds.indexOf('callout-body') !== -1);
+  });
+
+  it('does NOT emit callout-body for disallowed slug (stays paragraph fallback)', () => {
+    const html =
+      '<h2>Heading</h2><blockquote><p><strong>Warning</strong>: drop zone</p></blockquote>';
+    const segments = extractSegmentsFromHtml(html, {
+      slug: 'editing-tests/steps',
+      calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS,
+    });
+    const kinds = segments.map((s) => s.segmentKind);
+    assert.ok(!kinds.includes('callout-body'));
+  });
+
+  it('legacy 1-arg call still works (backward compat, no normalization)', () => {
+    const html = '<h2>H</h2><blockquote><p>Warning: x</p></blockquote>';
+    const segments = extractSegmentsFromHtml(html);
+    assert.ok(Array.isArray(segments));
+    const kinds = segments.map((s) => s.segmentKind);
+    assert.ok(!kinds.includes('callout-body'));
   });
 });

--- a/scripts/__tests__/source_parity_source_usability_fixtures.test.mjs
+++ b/scripts/__tests__/source_parity_source_usability_fixtures.test.mjs
@@ -201,7 +201,9 @@ describe('detectSourceUsability fixture: advanced-editing/coding-assistant', () 
 
     // extractError がない場合のみ alignSegments を検証する
     if (!extractError) {
-      const alignment = alignSegments(enSegments, jaSegments);
+      const alignment = alignSegments(enSegments, jaSegments, {
+        slug: 'advanced-editing/coding-assistant',
+      });
       const issues = parityDiffsToIssues(alignment.diffs);
       // source-unusable は出ない
       const sourceUnusable = issues.filter(i => i.type === 'source-unusable');

--- a/scripts/__tests__/source_parity_structure_fixtures.test.mjs
+++ b/scripts/__tests__/source_parity_structure_fixtures.test.mjs
@@ -52,7 +52,7 @@ function runStructureComparator(slug) {
 
   const enSegments = extractSegmentsFromHtml(rawEnHtml);
   const jaSegments = extractSegmentsFromMarkdown(jaBody);
-  const alignment = alignSegments(enSegments, jaSegments);
+  const alignment = alignSegments(enSegments, jaSegments, { slug });
   const issues = parityDiffsToIssues(alignment.diffs);
   const structureIssues = issues.filter(
     (i) => i.type === 'section-structure-mismatch' || i.type === 'segment-order-mismatch',

--- a/scripts/check_source_parity.mjs
+++ b/scripts/check_source_parity.mjs
@@ -48,6 +48,7 @@ import { convertEnHtmlToMd, preprocessEnHtml } from './lib/turndown.mjs';
 import { checkPageCoverage, checkSinglePageSnapshot } from './lib/source_parity_page_coverage.mjs';
 import { buildRunScope, validateRunLinkage } from './lib/source_sync_health.mjs';
 import { createMaskCoverage, maskSegmentText } from './lib/parity_glossary_mask.mjs';
+import { createArtifactCoverage } from './lib/parity_artifact_registry.mjs';
 export { buildRunScope };
 
 const SNAPSHOTS_DIR = path.join(ROOT_DIR, 'snapshots', 'en', 'content');
@@ -376,6 +377,10 @@ export async function checkSourceParity({
   // debug.maskCoverage: per-segment mask 結果を収集する。
   const maskCoverage = createMaskCoverage();
 
+  // debug.artifactCoverage: alignSegments の slug-scope artifact 抑止 hit を
+  // 集計する run 単位 aggregator。Phase 4 で新設。
+  const artifactCoverage = createArtifactCoverage();
+
   for (const filePath of allFiles) {
     const fileSlug = filePathToSlug(filePath);
     if (resolvedSlug && fileSlug !== resolvedSlug) {
@@ -499,7 +504,10 @@ export async function checkSourceParity({
           // (image order, callout nesting, table shape) を併走させる。
           let alignment;
           try {
-            alignment = alignSegments(enSegments, jaSegments);
+            alignment = alignSegments(enSegments, jaSegments, {
+              slug: fileSlug,
+              coverage: artifactCoverage,
+            });
           } catch (e) {
             console.error(
               `alignSegments failed for ${fileSlug}: ${e.message}. Falling back to coarse parity.`,
@@ -732,6 +740,7 @@ export async function checkSourceParity({
     advisoryQueue,
     debug: {
       maskCoverage: maskCoverage.toJSON(),
+      artifactCoverage: artifactCoverage.snapshot(),
     },
   };
 

--- a/scripts/check_source_parity.mjs
+++ b/scripts/check_source_parity.mjs
@@ -28,6 +28,7 @@ import {
   parityDiffsToIssues,
   summarizeParityResults,
 } from './lib/source_parity.mjs';
+import { CALLOUT_NORMALIZATION_SLUGS } from './lib/source_parity_segments_en.mjs';
 import {
   isAdvisoryOnlyParityIssue,
   isValidAcknowledgedIssue,
@@ -455,7 +456,10 @@ export async function checkSourceParity({
         let jaSegments = [];
         let extractError = null;
         try {
-          enSegments = extractSegmentsFromHtml(rawEnHtml);
+          enSegments = extractSegmentsFromHtml(rawEnHtml, {
+            slug: fileSlug,
+            calloutAllowSlugs: CALLOUT_NORMALIZATION_SLUGS,
+          });
           jaSegments = extractSegmentsFromMarkdown(doc.body);
         } catch (e) {
           extractError = e;

--- a/scripts/lib/parity_artifact_registry.mjs
+++ b/scripts/lib/parity_artifact_registry.mjs
@@ -1,0 +1,134 @@
+// scripts/lib/parity_artifact_registry.mjs
+/**
+ * EN-side artifact registry (slug-scope, token) + runtime coverage aggregator.
+ *
+ * Phase 4 で alignSegments の `segment-token-gap` 抑止に使う slug-scope token
+ * registry。「EN ページ固有の artifact (self-index link, demo placeholder link
+ * 等) を、JA 側で修復不能なまま検出に上げ続けない」という Phase 2 の観測結果を
+ * runtime 側へ持ち込むための静的データと、その抑止 hit を集計する coverage
+ * aggregator を提供する。
+ *
+ * 契約:
+ *   - registry は凍結された配列。entry 単位で `slugs[]` と `token` を持ち、
+ *     `(slug, token)` の直接照合で抑止を判定する。グロブ / regex は使わない。
+ *   - `isArtifactExcluded({ slug, token })` は副作用ゼロの純粋関数。
+ *   - `createArtifactCoverage()` は run 単位で 1 個だけ生成し、抑止 hit を
+ *     record する stateful aggregator。`snapshot()` で per-slug / per-token
+ *     カウンタと registry entry 数を返す。`NOOP_COVERAGE` は test / 呼び出し
+ *     側で coverage 集計が不要なときのデフォルト。
+ *
+ * Spec: docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md
+ *
+ * @module parity_artifact_registry
+ */
+
+/**
+ * 初期 entries。Task 4.1 inventory (2026-04-15) に基づく。
+ * inventory: docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.json
+ */
+export const ARTIFACT_REGISTRY = Object.freeze([
+  Object.freeze({
+    slugs: Object.freeze([
+      'editing-tests/conditions/advanced-conditions-settings',
+      'integrations/visual-validation/visual_validation_index',
+      'recording-tests/recording-a-mobile-test/recording-a-local-mobile-test',
+      'salesforce-testing/salesforce-steps/sfdc-step-login',
+      'testops/insights/dashboard',
+    ]),
+    token: '/docs/index',
+    reason: 'en-side-self-index-link-artifact',
+    note: 'EN ページ内 self-link (/docs/index) の artifact',
+    expectedIssueType: 'segment-token-gap',
+    addedAt: '2026-04-15',
+    linkedIssue: null,
+  }),
+  Object.freeze({
+    slugs: Object.freeze(['getting-started/creating-your-first-codeless-test']),
+    token: 'http://google.com',
+    reason: 'en-side-demo-link-artifact',
+    note: 'EN 側 demo.testim.io の例示用 <a href="http://google.com">',
+    expectedIssueType: 'segment-token-gap',
+    addedAt: '2026-04-15',
+    linkedIssue: null,
+  }),
+]);
+
+/**
+ * 指定した (slug, token) が registry に登録された artifact と一致するか。
+ * 純粋関数 — 入力を mutate しない。
+ *
+ * @param {{slug: string, token: string}} params
+ * @returns {boolean}
+ */
+export function isArtifactExcluded({ slug, token }) {
+  for (const entry of ARTIFACT_REGISTRY) {
+    if (!entry.slugs.includes(slug)) continue;
+    if (entry.token === token) return true;
+  }
+  return false;
+}
+
+/**
+ * registry の shallow copy を返す。呼び出し側で mutate しても registry 本体は
+ * 影響を受けない (配列コピーのみ。entry 自体は Object.freeze 済み)。
+ *
+ * @returns {ReadonlyArray<object>}
+ */
+export function registryEntries() {
+  return ARTIFACT_REGISTRY.slice();
+}
+
+/**
+ * runtime coverage aggregator。run 単位で 1 個生成し、artifact 抑止が発火した
+ * ときに record する。snapshot() で以下を返す:
+ *   - registryEntries: registry の entry 数
+ *   - matchedHits:     record 呼び出し回数 (= 抑止発火回数)
+ *   - bySlug:          { [slug]: count }
+ *   - byToken:         { [token]: count }
+ *
+ * @returns {{
+ *   record: (hit: {slug: string, token: string, reason?: string|null}) => void,
+ *   snapshot: () => {
+ *     registryEntries: number,
+ *     matchedHits: number,
+ *     bySlug: Record<string, number>,
+ *     byToken: Record<string, number>,
+ *   },
+ * }}
+ */
+export function createArtifactCoverage() {
+  const hits = [];
+  return {
+    record({ slug, token, reason }) {
+      hits.push({ slug, token, reason: reason ?? null });
+    },
+    snapshot() {
+      const bySlug = {};
+      const byToken = {};
+      for (const h of hits) {
+        bySlug[h.slug] = (bySlug[h.slug] ?? 0) + 1;
+        byToken[h.token] = (byToken[h.token] ?? 0) + 1;
+      }
+      return {
+        registryEntries: ARTIFACT_REGISTRY.length,
+        matchedHits: hits.length,
+        bySlug,
+        byToken,
+      };
+    },
+  };
+}
+
+/**
+ * coverage を集計したくない呼び出し側が使う no-op aggregator。
+ * snapshot() は常に空カウンタ + registry 件数だけを返す。
+ */
+export const NOOP_COVERAGE = Object.freeze({
+  record() {},
+  snapshot: () => ({
+    registryEntries: ARTIFACT_REGISTRY.length,
+    matchedHits: 0,
+    bySlug: {},
+    byToken: {},
+  }),
+});

--- a/scripts/lib/parity_normalize.mjs
+++ b/scripts/lib/parity_normalize.mjs
@@ -33,9 +33,11 @@ export function normalizeUrlForParity(url) {
     return `/docs/${path}${tricentisMatch[2] ?? ''}`;
   }
 
-  // help.testim.io prefix を常に剥がし、/docs/... path で canonicalize を適用する
-  // (query drop / trailing slash drop / fragment 保持)。help.testim.io 形式と
-  // bare /docs/... 形式が同一 canonical form に揃う。
+  // help.testim.io prefix を剥がし、剥がした結果が /docs/... path に match する
+  // ときのみ canonicalize を適用する (query drop / trailing slash drop /
+  // fragment 保持)。help.testim.io 形式と bare /docs/... 形式が同一 canonical
+  // form に揃う。/docs/ 以外 (例: /v2.0/docs/...) は Stage B5 scope のため、
+  // 既存挙動 (URL 不変) を保つ。
   const stripped = url.replace(HELP_TESTIM_PREFIX_RE, '');
   const docsMatch = stripped.match(DOCS_PATH_RE);
   if (docsMatch) {
@@ -43,8 +45,7 @@ export function normalizeUrlForParity(url) {
     return `${path}${fragment ?? ''}`;
   }
 
-  // /docs/ 以外 (例: /v2.0/docs/...) は prefix strip のみ適用 (Stage B5 で別途処理)。
-  return stripped;
+  return url;
 }
 
 export function canonicalizeDocsUrl(url) {

--- a/scripts/lib/parity_normalize.mjs
+++ b/scripts/lib/parity_normalize.mjs
@@ -8,7 +8,11 @@
  * @module parity_normalize
  */
 
-const HELP_TESTIM_RE = /^(?:https?:\/\/)?help\.testim\.io(\/docs\/[^\s)]+)/;
+// Matches help.testim.io URL (protocol optional), capturing:
+//   group 1: path starting with /docs/ (no fragment, no trailing slash preserved)
+//   group 2: optional #fragment
+const HELP_TESTIM_RE =
+  /^(?:https?:\/\/)?help\.testim\.io(\/docs\/[^\s)#]+?)\/?(#[^\s)]*)?$/;
 // Matches any path under /testim/content/ (canonical repo URL form: /{category}/{slug}.htm).
 // Legacy /Topics/Help/ URLs are also matched by this broader regex and produce their literal
 // path translation (e.g. Topics/Help/loops → /docs/Topics/Help/loops) since that URL form
@@ -20,7 +24,7 @@ export function normalizeUrlForParity(url) {
   if (typeof url !== 'string' || url.length === 0) return url;
 
   const helpMatch = url.match(HELP_TESTIM_RE);
-  if (helpMatch) return helpMatch[1];
+  if (helpMatch) return `${helpMatch[1]}${helpMatch[2] ?? ''}`;
 
   const tricentisMatch = url.match(TRICENTIS_DOCS_RE);
   if (tricentisMatch) {

--- a/scripts/lib/parity_normalize.mjs
+++ b/scripts/lib/parity_normalize.mjs
@@ -8,11 +8,13 @@
  * @module parity_normalize
  */
 
-// Matches help.testim.io URL (protocol optional), capturing:
-//   group 1: path starting with /docs/ (no fragment, no trailing slash preserved)
-//   group 2: optional #fragment
-const HELP_TESTIM_RE =
-  /^(?:https?:\/\/)?help\.testim\.io(\/docs\/[^\s)#]+?)\/?(#[^\s)]*)?$/;
+// help.testim.io の protocol + host prefix (path 以降は DOCS_PATH_RE で canonicalize)。
+const HELP_TESTIM_PREFIX_RE = /^(?:https?:\/\/)?help\.testim\.io/;
+// /docs/... path の canonical form を分解:
+//   group 1: path (trailing slash / ?query / #fragment を含まない)
+//   group 2: 任意の ?query (canonicalize で drop、保持しない)
+//   group 3: 任意の #fragment (保持)
+const DOCS_PATH_RE = /^(\/docs\/[^\s)?#]+?)\/?(\?[^\s)#]*)?(#[^\s)]*)?$/;
 // Matches any path under /testim/content/ (canonical repo URL form: /{category}/{slug}.htm).
 // Legacy /Topics/Help/ URLs are also matched by this broader regex and produce their literal
 // path translation (e.g. Topics/Help/loops → /docs/Topics/Help/loops) since that URL form
@@ -23,9 +25,7 @@ const TRICENTIS_DOCS_RE =
 export function normalizeUrlForParity(url) {
   if (typeof url !== 'string' || url.length === 0) return url;
 
-  const helpMatch = url.match(HELP_TESTIM_RE);
-  if (helpMatch) return `${helpMatch[1]}${helpMatch[2] ?? ''}`;
-
+  // tricentis.com/testim/content/*.htm → /docs/* は先に処理する (fragment 保持)。
   const tricentisMatch = url.match(TRICENTIS_DOCS_RE);
   if (tricentisMatch) {
     // Strip trailing /index so that /foo/index.htm → /docs/foo (directory root).
@@ -33,7 +33,18 @@ export function normalizeUrlForParity(url) {
     return `/docs/${path}${tricentisMatch[2] ?? ''}`;
   }
 
-  return url;
+  // help.testim.io prefix を常に剥がし、/docs/... path で canonicalize を適用する
+  // (query drop / trailing slash drop / fragment 保持)。help.testim.io 形式と
+  // bare /docs/... 形式が同一 canonical form に揃う。
+  const stripped = url.replace(HELP_TESTIM_PREFIX_RE, '');
+  const docsMatch = stripped.match(DOCS_PATH_RE);
+  if (docsMatch) {
+    const [, path, , fragment] = docsMatch;
+    return `${path}${fragment ?? ''}`;
+  }
+
+  // /docs/ 以外 (例: /v2.0/docs/...) は prefix strip のみ適用 (Stage B5 で別途処理)。
+  return stripped;
 }
 
 export function canonicalizeDocsUrl(url) {

--- a/scripts/lib/source_parity_align.mjs
+++ b/scripts/lib/source_parity_align.mjs
@@ -40,6 +40,7 @@ import {
 import { compareSectionStructure } from './source_parity_structure.mjs';
 import { classifySegment } from './parity_glossary_mask.mjs';
 import { normalizeSegmentTokens } from './parity_normalize.mjs';
+import { isArtifactExcluded, NOOP_COVERAGE } from './parity_artifact_registry.mjs';
 
 const GATE_KIND_SET = new Set(GATE_ELIGIBLE_KINDS);
 
@@ -496,9 +497,12 @@ function detectAmbiguousAdjacentTokenlessSwap(enSections, jaSections, diffs) {
  * @param {Section} enSection
  * @param {Section} jaSection
  * @param {{enSectionTokensList: Set<string>[], jaSectionTokensList: Set<string>[]}} crossSectionInfo
+ * @param {{slug: string, coverage: {record: Function, snapshot: Function}}} artifactCtx
+ *   slug-scope artifact 抑止に使う context。EN-side artifact registry の直接照合に
+ *   必要な slug と、抑止 hit を記録する runtime coverage aggregator を受け取る。
  * @returns {object[]}
  */
-function alignSection(enSection, jaSection, crossSectionInfo) {
+function alignSection(enSection, jaSection, crossSectionInfo, artifactCtx) {
   const diffs = [];
   const enBody = enSection.body;
   const jaBody = jaSection.body;
@@ -563,7 +567,18 @@ function alignSection(enSection, jaSection, crossSectionInfo) {
     const enTokens = normalizeSegmentTokens(enSeg.tokensInvariant ?? []);
     const missingTokens = [];
     for (const token of enTokens) {
-      if (!jaTokenSet.has(token)) missingTokens.push(token);
+      if (jaTokenSet.has(token)) continue;
+      // Phase 4: slug-scope EN-side artifact は registry で抑止し、
+      // 抑止 hit は runtime coverage aggregator に記録する。
+      if (isArtifactExcluded({ slug: artifactCtx.slug, token })) {
+        artifactCtx.coverage.record({
+          slug: artifactCtx.slug,
+          token,
+          reason: 'artifact-registry',
+        });
+        continue;
+      }
+      missingTokens.push(token);
     }
     if (missingTokens.length > 0) {
       diffs.push(diffTokenGap(enSection, enSeg, jaSeg, enIdx, jaIdx, missingTokens));
@@ -622,11 +637,24 @@ function alignSection(enSection, jaSection, crossSectionInfo) {
  * EN canonical segments と JA canonical segments を整列し、diff 一覧を返す。
  * 詳細な契約は module header を参照。
  *
+ * `options.slug` は EN-side artifact の slug-scope 抑止判定に使う (Phase 4)。
+ * 未指定だと `isArtifactExcluded` が effectively no-op になり、本来抑止される
+ * はずの token-gap が検出側に漏れるため必須とする。既存呼び出し (check_source_parity /
+ * test fixture) 全てがこの signature に揃っていることは Step 9 grep gate で担保する。
+ *
+ * `options.coverage` は抑止 hit の runtime aggregator。省略時は `NOOP_COVERAGE`。
+ *
  * @param {Segment[]} enSegments
  * @param {Segment[]} jaSegments
+ * @param {{slug: string, coverage?: {record: Function, snapshot: Function}}} [options]
  * @returns {AlignResult}
  */
-export function alignSegments(enSegments, jaSegments) {
+export function alignSegments(enSegments, jaSegments, options = {}) {
+  const { slug, coverage = NOOP_COVERAGE } = options;
+  if (typeof slug !== 'string' || slug.length === 0) {
+    throw new Error('alignSegments: slug option is required');
+  }
+
   const enFiltered = filterForAlignment(enSegments);
   const jaFiltered = filterForAlignment(jaSegments);
 
@@ -660,7 +688,10 @@ export function alignSegments(enSegments, jaSegments) {
     // 同じ section の structure diff は重複報告になるため抑止する。
     // shift していない section は structure diff と segment diff を併記し、
     // section レベルの要約と drill-down を両方残す。
-    const sectionDiffs = alignSection(enSections[i], jaSections[i], crossSectionInfo);
+    const sectionDiffs = alignSection(enSections[i], jaSections[i], crossSectionInfo, {
+      slug,
+      coverage,
+    });
     const hasShift = sectionDiffs.some((d) => d.type === 'segment-shifted');
 
     if (!hasShift) {

--- a/scripts/lib/source_parity_segments_en.mjs
+++ b/scripts/lib/source_parity_segments_en.mjs
@@ -57,21 +57,25 @@ const WARNING_LEAD_RE = /^\s*(?:<(?:strong|b)>\s*)?(note|warning|important|cauti
 const MAX_CALLOUT_PARAGRAPHS = 3;
 
 /**
- * blockquote 内側 HTML が callout-normalization の対象となる 2 条件 (短長 +
- * warning-like 先頭) を満たすかを判定する。
+ * blockquote 内側 HTML が callout-normalization の対象となる 3 条件を満たすかを
+ * 判定する。
  *
- * - **warning-like 判定:** 最初の段落の先頭が `(Note|Warning|Important|Caution|Tip|Danger)`
- *   で始まる (先頭 `<strong>` / `<b>` は許容、case-insensitive)。`<p>` が 1 つも
- *   ない場合は inner そのものを対象にする (fallback)。
+ * - **`<p>` 存在必須:** `<p>` が 1 つもない bare-text blockquote は対象外。
+ *   walkCalloutBody() は text node を emit しないため、書き換えると中身が
+ *   丸ごと消える。そのままの `<blockquote>` として残し、extractor の通常経路で
+ *   paragraph として処理させる。
+ * - **warning-like 判定:** 最初の `<p>` の先頭が
+ *   `(Note|Warning|Important|Caution|Tip|Danger)` で始まる (先頭 `<strong>` /
+ *   `<b>` は許容、case-insensitive)。
  * - **短長制約:** `<p>` 個数 ≤ MAX_CALLOUT_PARAGRAPHS (3)
  */
 function isWarningLikeBlockquote(innerHtml) {
   const paragraphs = Array.from(innerHtml.matchAll(BLOCKQUOTE_P_RE)).map(
     (m) => m[1],
   );
+  if (paragraphs.length === 0) return false;
   if (paragraphs.length > MAX_CALLOUT_PARAGRAPHS) return false;
-  const head = paragraphs.length > 0 ? paragraphs[0] : innerHtml;
-  return WARNING_LEAD_RE.test(head);
+  return WARNING_LEAD_RE.test(paragraphs[0]);
 }
 
 /**

--- a/scripts/lib/source_parity_segments_en.mjs
+++ b/scripts/lib/source_parity_segments_en.mjs
@@ -31,6 +31,66 @@ const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
 const SCRIPT_STYLE_RE = /<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi;
 const COL_TAG_RE = /<col\b[^>]*\/?>/gi;
 
+// ---------------------------------------------------------------------------
+// callout-normalization (slug 限定の intentional divergence 吸収層)
+// ---------------------------------------------------------------------------
+
+/**
+ * callout-normalization を適用する slug の single source of truth。
+ *
+ * allow list に含まれる slug では、EN snapshot に存在する warning-like な短い
+ * `<blockquote>` を `<div class="callout-note">` に書き換え、JA 側の
+ * `:::note` / `:::danger` 等 callout と kind-level parity を揃える。
+ *
+ * Phase 4 Task 4.1 inventory の `intentionalDivergenceCandidates` に基づく
+ * 初期値。slug の追加 / 削除は **本定数を先に更新** すること (docs に先に書かない)。
+ *
+ * 詳細: `docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md` §8。
+ */
+export const CALLOUT_NORMALIZATION_SLUGS = Object.freeze(
+  new Set(['administration/api-access']),
+);
+
+const BLOCKQUOTE_RE = /<blockquote\b[^>]*>([\s\S]*?)<\/blockquote>/gi;
+const BLOCKQUOTE_P_RE = /<p\b[^>]*>([\s\S]*?)<\/p>/gi;
+const WARNING_LEAD_RE = /^\s*(?:<(?:strong|b)>\s*)?(note|warning|important|caution|tip|danger)\b/i;
+const MAX_CALLOUT_PARAGRAPHS = 3;
+
+/**
+ * blockquote 内側 HTML が callout-normalization の対象となる 2 条件 (短長 +
+ * warning-like 先頭) を満たすかを判定する。
+ *
+ * - **warning-like 判定:** 最初の段落の先頭が `(Note|Warning|Important|Caution|Tip|Danger)`
+ *   で始まる (先頭 `<strong>` / `<b>` は許容、case-insensitive)。`<p>` が 1 つも
+ *   ない場合は inner そのものを対象にする (fallback)。
+ * - **短長制約:** `<p>` 個数 ≤ MAX_CALLOUT_PARAGRAPHS (3)
+ */
+function isWarningLikeBlockquote(innerHtml) {
+  const paragraphs = Array.from(innerHtml.matchAll(BLOCKQUOTE_P_RE)).map(
+    (m) => m[1],
+  );
+  if (paragraphs.length > MAX_CALLOUT_PARAGRAPHS) return false;
+  const head = paragraphs.length > 0 ? paragraphs[0] : innerHtml;
+  return WARNING_LEAD_RE.test(head);
+}
+
+/**
+ * slug allow list に含まれる場合のみ、warning-like な短い `<blockquote>` を
+ * `<div class="callout-note">` に書き換える。options なし / slug 未指定 /
+ * slug 非該当 / 判定不一致のときは元 HTML をそのまま返す (後方互換)。
+ */
+function normalizeCallouts(html, options) {
+  if (!options || typeof options !== 'object') return html;
+  const { slug, calloutAllowSlugs } = options;
+  if (typeof slug !== 'string' || slug.length === 0) return html;
+  if (!(calloutAllowSlugs instanceof Set)) return html;
+  if (!calloutAllowSlugs.has(slug)) return html;
+  return html.replace(BLOCKQUOTE_RE, (match, inner) => {
+    if (!isWarningLikeBlockquote(inner)) return match;
+    return `<div class="callout-note">${inner}</div>`;
+  });
+}
+
 /**
  * Preprocess raw MadCap Flare HTML by removing line-oriented noise and simple
  * self-contained structures that would otherwise produce spurious segments.
@@ -40,8 +100,16 @@ const COL_TAG_RE = /<col\b[^>]*\/?>/gi;
  * non-greedy match stops at the first `</div>`, corrupting the outer tree).
  * Instead the walker drops codeSnippet divs on traversal so nested structures
  * inside a callout are preserved correctly.
+ *
+ * @param {string} html                 raw MadCap Flare HTML
+ * @param {object} [options]            slug-scoped normalization controls
+ * @param {string} [options.slug]       page slug (e.g. `administration/api-access`)
+ * @param {Set<string>} [options.calloutAllowSlugs]
+ *   allow list of slugs for warning-like `<blockquote>` → `<div class="callout-note">`
+ *   rewriting. Usually `CALLOUT_NORMALIZATION_SLUGS`. When omitted or when slug
+ *   is not in the set, no normalization is applied (backward compat).
  */
-export function preprocessHtml(html) {
+export function preprocessHtml(html, options) {
   if (typeof html !== 'string' || html.length === 0) return '';
   let text = html;
   text = text.replace(HTML_COMMENT_RE, '');
@@ -50,6 +118,7 @@ export function preprocessHtml(html) {
   text = text.replace(ANCHOR_ONLY_RE, '');
   text = text.replace(THEAD_RE, '');
   text = text.replace(COL_TAG_RE, '');
+  text = normalizeCallouts(text, options);
   return text;
 }
 
@@ -589,17 +658,23 @@ function walkDetails(node, state) {
 /**
  * Extract canonical segments from an EN HTML snapshot.
  *
- * @param {string} html  raw MadCap Flare HTML
+ * @param {string} html                 raw MadCap Flare HTML
+ * @param {object} [options]            slug-scoped normalization controls
+ * @param {string} [options.slug]       page slug (forwarded to preprocessHtml)
+ * @param {Set<string>} [options.calloutAllowSlugs]
+ *   allow list of slugs whose warning-like `<blockquote>` are rewritten to
+ *   `<div class="callout-note">` before tokenization. Omitting options
+ *   preserves legacy behavior (no normalization).
  * @returns {import('./source_parity_segments_shared.mjs').Segment[]}
  */
-export function extractSegmentsFromHtml(html) {
+export function extractSegmentsFromHtml(html, options) {
   if (typeof html !== 'string') return [];
   const trimmed = html.trim();
   if (trimmed.length === 0) return [];
   // Reuse the existing turndown preprocessor so entity-encoded <details>
   // blocks and escaped callouts become real HTML before our own pass runs.
   const normalized = preprocessEnHtml(html);
-  const preprocessed = preprocessHtml(normalized);
+  const preprocessed = preprocessHtml(normalized, options);
   const tokens = tokenize(preprocessed);
   const tree = buildTree(tokens);
   const state = createWalkState();

--- a/scripts/phase2/lib/baseline.mjs
+++ b/scripts/phase2/lib/baseline.mjs
@@ -4,11 +4,10 @@
  * 目的:
  *   - `parity-baseline.json` の読み込みを一箇所にまとめる
  *   - REPO_ROOT を相対パスで解決する
- *   - 既知 EN-side artifact トークンを registry として共有
+ *   - 既知 EN-side artifact を Phase 4 registry 経由で参照する
  *
- * Phase 2.3 report で浮上した EN-side artifact は、ここに登録することで
- * enumerate script が直接修正候補から除外し `enSideArtifact` カテゴリへ回せる。
- * Phase 4 で parity checker 側の修正に使う registry の雛形でもある。
+ * Phase 4 で slug-scope の `parity_artifact_registry` に一本化したため、
+ * enSideArtifact 判定は registry に登録済みの token を参照する。
  *
  * @module scripts/phase2/lib/baseline
  */
@@ -16,6 +15,14 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+
+import {
+  ARTIFACT_REGISTRY,
+  NOOP_COVERAGE,
+  createArtifactCoverage,
+  isArtifactExcluded,
+  registryEntries,
+} from '../../lib/parity_artifact_registry.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -30,31 +37,28 @@ export function loadBaseline() {
   );
 }
 
-/**
- * 既知 EN-side artifact トークン。
- * Phase 2.3 (2026-04-14) で enumerate 時に skip 理由として記録したもの。
- * JA 側修正不能 / 要 EN 側修正 or parity normalizer 側修正。
- */
-export const EN_SIDE_ARTIFACT_TOKENS = new Set([
-  '-variable',   // "Generate email address -variable name" stray dash (EN typo, search-within-a-test)
-  '-this',       // "Verify -this action" stray dash (EN typo, sfdc-step-{create,edit,quickactions,relatedlistaction,validate})
-  'step.This',   // "step.This will create..." sentence boundary (EN typo, generate-random-data-with-js)
-  '/docs/index', // EN の index.htm self-referential / unresolvable link (6 slugs)
-]);
+// Phase 4: registry API を phase2 側から直接参照できるよう re-export。
+export {
+  ARTIFACT_REGISTRY,
+  NOOP_COVERAGE,
+  createArtifactCoverage,
+  isArtifactExcluded,
+  registryEntries,
+};
 
 /**
- * EN-side artifact で「href 値として」既知不正なもの。
- * missingTokens に現れる URL を判定するのに使う。
+ * Phase 4 registry に登録済みの EN-side artifact token 集合。
+ * (slug, token) 対応は失うが、カテゴリ分類では token 単位で見れば十分。
  */
-export const EN_SIDE_ARTIFACT_URLS = new Set([
-  'http://google.com', // demo.testim.io link text に対して誤 href (creating-your-first-codeless-test)
-]);
+const EN_SIDE_ARTIFACT_TOKENS_FROM_REGISTRY = new Set(
+  ARTIFACT_REGISTRY.map((e) => e.token),
+);
 
 /**
  * 単一トークンを category に分類する。
  *
  * Category:
- *   - enSideArtifact: EN 側 typo / 不正リンクで JA 側修正不能
+ *   - enSideArtifact: EN 側 typo / 不正リンクで JA 側修正不能 (registry 登録済)
  *   - cliFlag        : `--flag` / `-f` 形式の CLI フラグ
  *   - internalLink   : `/docs/...` 形式の内部リンク
  *   - numericOrUnit  : 数値 + 単位 (`1000ms`, `10MB` 等)
@@ -63,8 +67,7 @@ export const EN_SIDE_ARTIFACT_URLS = new Set([
  */
 export function categorizeToken(token) {
   if (!token) return 'other';
-  if (EN_SIDE_ARTIFACT_TOKENS.has(token)) return 'enSideArtifact';
-  if (EN_SIDE_ARTIFACT_URLS.has(token)) return 'enSideArtifact';
+  if (EN_SIDE_ARTIFACT_TOKENS_FROM_REGISTRY.has(token)) return 'enSideArtifact';
   if (token.startsWith('--') || /^-[a-zA-Z]/.test(token)) return 'cliFlag';
   if (token.startsWith('/docs/')) return 'internalLink';
   if (/^\d+(\.\d+)?(ms|sec|s|min|hr|px|em|rem|MB|GB|KB|%|x)$/i.test(token)) {

--- a/scripts/phase2/lib/baseline.mjs
+++ b/scripts/phase2/lib/baseline.mjs
@@ -47,27 +47,52 @@ export {
 };
 
 /**
- * Phase 4 registry に登録済みの EN-side artifact token 集合。
- * (slug, token) 対応は失うが、カテゴリ分類では token 単位で見れば十分。
+ * Phase 4 runtime registry に登録済みの EN-side artifact token 集合 (slug 非依存
+ * の集計用)。
  */
 const EN_SIDE_ARTIFACT_TOKENS_FROM_REGISTRY = new Set(
   ARTIFACT_REGISTRY.map((e) => e.token),
 );
 
 /**
+ * Phase 2 enumerate 時代から `enSideArtifact` として扱われてきた legacy typo 系
+ * token。Phase 4 runtime registry には載せない (実 runtime 影響が無く、slug-scope
+ * 化の恩恵が無いため) が、phase2 の分析 / remediation planning では引き続き
+ * artifact として扱えるよう互換保持する。
+ *
+ * 削除 / 変更する際は enumerate_token_gaps 出力の分類が静かに変わらないよう
+ * 同 PR で下流の受け手を更新すること。
+ */
+const PHASE2_LEGACY_TYPO_TOKENS = new Set([
+  '-variable',
+  '-this',
+  'step.This',
+]);
+
+/** phase2 `categorizeToken` の enSideArtifact 判定に使う union 集合。 */
+const EN_SIDE_ARTIFACT_TOKENS_FOR_CATEGORIZATION = new Set([
+  ...EN_SIDE_ARTIFACT_TOKENS_FROM_REGISTRY,
+  ...PHASE2_LEGACY_TYPO_TOKENS,
+]);
+
+/**
  * 単一トークンを category に分類する。
  *
  * Category:
- *   - enSideArtifact: EN 側 typo / 不正リンクで JA 側修正不能 (registry 登録済)
+ *   - enSideArtifact: EN 側 typo / 不正リンクで JA 側修正不能 (Phase 4 registry +
+ *                     phase2 legacy typo tokens の union)
  *   - cliFlag        : `--flag` / `-f` 形式の CLI フラグ
  *   - internalLink   : `/docs/...` 形式の内部リンク
  *   - numericOrUnit  : 数値 + 単位 (`1000ms`, `10MB` 等)
  *   - externalUrl    : `http(s)://...` 形式の外部 URL
  *   - other          : 上記に当てはまらないもの
+ *
+ * NOTE: runtime registry は slug-scope (`isArtifactExcluded({ slug, token })`)、
+ * phase2 分析は token のみを見るため、両者は意図的に別機能として保持する。
  */
 export function categorizeToken(token) {
   if (!token) return 'other';
-  if (EN_SIDE_ARTIFACT_TOKENS_FROM_REGISTRY.has(token)) return 'enSideArtifact';
+  if (EN_SIDE_ARTIFACT_TOKENS_FOR_CATEGORIZATION.has(token)) return 'enSideArtifact';
   if (token.startsWith('--') || /^-[a-zA-Z]/.test(token)) return 'cliFlag';
   if (token.startsWith('/docs/')) return 'internalLink';
   if (/^\d+(\.\d+)?(ms|sec|s|min|hr|px|em|rem|MB|GB|KB|%|x)$/i.test(token)) {

--- a/scripts/phase4/classify_residual.mjs
+++ b/scripts/phase4/classify_residual.mjs
@@ -1,0 +1,69 @@
+// scripts/phase4/classify_residual.mjs
+// Output: JSON to stdout
+import { readFileSync } from 'node:fs';
+
+// 本物の EN artifact (翻訳でも normalizer でも直らない)
+const ARTIFACT_TOKEN_MATCHERS = [
+  (t) => t === '/docs/index',
+  (t) => t === 'http://google.com',
+];
+// Task 4.3 の URL normalizer が正規化すべきもの
+const NORMALIZER_TOKEN_MATCHERS = [
+  (t) => typeof t === 'string' && /^https?:\/\/help\.testim\.io/.test(t),
+];
+// Task 4.4 の HTML extractor で正規化すべき intentional divergence 候補
+const INTENTIONAL_SLUGS = new Set(['administration/api-access']);
+
+function classify(entry) {
+  if (entry.issueType === 'segment-inconclusive') return 'advisoryResidual';
+  if (INTENTIONAL_SLUGS.has(entry.slug)) return 'intentionalDivergenceCandidates';
+  const tokens = entry.missingTokens ?? [];
+  if (tokens.length > 0) {
+    if (tokens.every(t => NORMALIZER_TOKEN_MATCHERS.some(f => f(t)))) return 'normalizerCandidates';
+    if (tokens.every(t => ARTIFACT_TOKEN_MATCHERS.some(f => f(t)))) return 'artifactCandidates';
+  }
+  return 'actionable';
+}
+
+function main() {
+  const baseline = JSON.parse(readFileSync('./parity-baseline.json', 'utf8'));
+  let status = null, snapDiff = null;
+  try { status = JSON.parse(readFileSync('./parity-check-status.json', 'utf8')); } catch {}
+  try { snapDiff = JSON.parse(readFileSync('./snapshot-diff-status.json', 'utf8')); } catch {}
+
+  const out = {
+    baseline: { total: baseline.entries.length, byIssueType: {} },
+    buckets: {
+      actionable: [],
+      artifactCandidates: [],
+      normalizerCandidates: [],
+      intentionalDivergenceCandidates: [],
+      advisoryResidual: [],
+    },
+    summary: {
+      reportableActiveFiles: status?.summary?.reportableActiveFiles ?? null,
+      baselinedIssues: status?.summary?.baselinedIssues ?? null,
+      advisoryQueueIssues: status?.summary?.advisoryQueueIssues ?? null,
+      auditSignalIssues: status?.summary?.auditSignalIssues ?? null,
+    },
+    snapshotDiff: {
+      changed: snapDiff?.summary?.changed ?? null,
+      added:   snapDiff?.summary?.added   ?? null,
+      removed: snapDiff?.summary?.removed ?? null,
+    },
+  };
+  for (const e of baseline.entries) {
+    out.baseline.byIssueType[e.issueType] = (out.baseline.byIssueType[e.issueType] ?? 0) + 1;
+    out.buckets[classify(e)].push({
+      slug: e.slug,
+      issueType: e.issueType,
+      sectionPath: e.sectionPath,
+      segmentKind: e.segmentKind,
+      missingTokens: e.missingTokens,
+      inconclusiveCategory: e.inconclusiveCategory,
+      inconclusiveReason: e.inconclusiveReason,
+    });
+  }
+  process.stdout.write(JSON.stringify(out, null, 2));
+}
+main();

--- a/scripts/phase4/classify_residual.mjs
+++ b/scripts/phase4/classify_residual.mjs
@@ -11,16 +11,33 @@ const ARTIFACT_TOKEN_MATCHERS = [
 const NORMALIZER_TOKEN_MATCHERS = [
   (t) => typeof t === 'string' && /^https?:\/\/help\.testim\.io/.test(t),
 ];
-// Task 4.4 の HTML extractor で正規化すべき intentional divergence 候補
+// Task 4.4 の HTML extractor で正規化すべき intentional divergence 候補 slug。
 const INTENTIONAL_SLUGS = new Set(['administration/api-access']);
+// intentional 候補として routing してよい issueType (callout 正規化で解消する
+// 3 パターン)。token-gap 等は除外して、slug 別の actionable / artifact / normalizer
+// 判定に fall through させる。
+const INTENTIONAL_CALLOUT_ISSUE_TYPES = new Set([
+  'section-structure-mismatch',
+  'segment-extra',
+  'segment-missing',
+]);
 
 function classify(entry) {
   if (entry.issueType === 'segment-inconclusive') return 'advisoryResidual';
-  if (INTENTIONAL_SLUGS.has(entry.slug)) return 'intentionalDivergenceCandidates';
-  const tokens = entry.missingTokens ?? [];
-  if (tokens.length > 0) {
-    if (tokens.every(t => NORMALIZER_TOKEN_MATCHERS.some(f => f(t)))) return 'normalizerCandidates';
-    if (tokens.every(t => ARTIFACT_TOKEN_MATCHERS.some(f => f(t)))) return 'artifactCandidates';
+  const missingTokens = entry.missingTokens ?? [];
+  // intentional bucket は「slug が allow list に入り、かつ callout 関連の
+  // issueType で、missingTokens が無い」という狭い条件にする。token gap は
+  // たとえ同 slug でも normalizer / artifact / actionable 判定に回す。
+  if (
+    INTENTIONAL_SLUGS.has(entry.slug) &&
+    INTENTIONAL_CALLOUT_ISSUE_TYPES.has(entry.issueType) &&
+    missingTokens.length === 0
+  ) {
+    return 'intentionalDivergenceCandidates';
+  }
+  if (missingTokens.length > 0) {
+    if (missingTokens.every(t => NORMALIZER_TOKEN_MATCHERS.some(f => f(t)))) return 'normalizerCandidates';
+    if (missingTokens.every(t => ARTIFACT_TOKEN_MATCHERS.some(f => f(t)))) return 'artifactCandidates';
   }
   return 'actionable';
 }

--- a/scripts/phase4/render_residual_inventory.mjs
+++ b/scripts/phase4/render_residual_inventory.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// scripts/phase4/render_residual_inventory.mjs
+// 入力: Task 4.1 で固定化した residual-inventory JSON (CLI arg 1)
+// 出力: stdout に Japanese markdown
+//
+// 出力構成:
+//   1. 概要 (合計 / byIssueType)
+//   2. 5 bucket 別 entry 表 (先頭 N 件 + 総数)
+//   3. summary counters
+//   4. snapshotDiff
+
+import { readFileSync } from 'node:fs';
+
+const HEAD_ROWS = 50; // 各 bucket の先頭表示件数
+
+function escapeCell(value) {
+  if (value === null || value === undefined) return '';
+  if (Array.isArray(value)) return value.map(formatToken).join(' \\| ');
+  return String(value).replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function formatToken(t) {
+  if (t === null || t === undefined) return '';
+  return String(t).replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function renderBucketTable(name, entries) {
+  const out = [];
+  out.push(`### ${name} (${entries.length} 件)`);
+  out.push('');
+  if (entries.length === 0) {
+    out.push('_該当なし_');
+    out.push('');
+    return out.join('\n');
+  }
+  const displayed = entries.slice(0, HEAD_ROWS);
+  out.push('| slug | issueType | sectionPath | segmentKind | missingTokens | inconclusiveCategory | inconclusiveReason |');
+  out.push('| --- | --- | --- | --- | --- | --- | --- |');
+  for (const e of displayed) {
+    out.push(
+      `| ${escapeCell(e.slug)} | ${escapeCell(e.issueType)} | ${escapeCell(e.sectionPath)} | ${escapeCell(e.segmentKind)} | ${escapeCell(e.missingTokens)} | ${escapeCell(e.inconclusiveCategory)} | ${escapeCell(e.inconclusiveReason)} |`
+    );
+  }
+  out.push('');
+  if (entries.length > displayed.length) {
+    out.push(`先頭 ${displayed.length} 件のみ表示。全 ${entries.length} 件は JSON を参照。`);
+    out.push('');
+  }
+  return out.join('\n');
+}
+
+function renderByIssueType(byIssueType) {
+  const keys = Object.keys(byIssueType).sort();
+  const out = [];
+  out.push('| issueType | count |');
+  out.push('| --- | --- |');
+  for (const k of keys) out.push(`| ${k} | ${byIssueType[k]} |`);
+  return out.join('\n');
+}
+
+function renderSummary(summary) {
+  const rows = [
+    ['reportableActiveFiles', summary.reportableActiveFiles],
+    ['baselinedIssues',       summary.baselinedIssues],
+    ['advisoryQueueIssues',   summary.advisoryQueueIssues],
+    ['auditSignalIssues',     summary.auditSignalIssues],
+  ];
+  const out = [];
+  out.push('| counter | value |');
+  out.push('| --- | --- |');
+  for (const [k, v] of rows) out.push(`| ${k} | ${v === null || v === undefined ? 'n/a' : v} |`);
+  return out.join('\n');
+}
+
+function renderSnapshotDiff(snap) {
+  const rows = [
+    ['changed', snap.changed],
+    ['added',   snap.added],
+    ['removed', snap.removed],
+  ];
+  const out = [];
+  out.push('| metric | value |');
+  out.push('| --- | --- |');
+  for (const [k, v] of rows) out.push(`| ${k} | ${v === null || v === undefined ? 'n/a' : v} |`);
+  return out.join('\n');
+}
+
+function main() {
+  const jsonPath = process.argv[2];
+  if (!jsonPath) {
+    console.error('usage: render_residual_inventory.mjs <inventory.json>');
+    process.exit(1);
+  }
+  const data = JSON.parse(readFileSync(jsonPath, 'utf8'));
+  const bucketOrder = [
+    'actionable',
+    'artifactCandidates',
+    'normalizerCandidates',
+    'intentionalDivergenceCandidates',
+    'advisoryResidual',
+  ];
+
+  const out = [];
+  out.push('# Parity Phase 4 Residual Inventory (5-bucket)');
+  out.push('');
+  out.push('Task 4.1 で `parity-baseline.json` を 5 bucket に分離した実測結果。');
+  out.push('Task 4.2 (artifact registry) / Task 4.3 (URL normalizer) / Task 4.4 (HTML extractor allow list) / Task 4.5 (翻訳修正) への入力分配に用いる。');
+  out.push('');
+  out.push('本ファイルは機械生成 (`scripts/phase4/render_residual_inventory.mjs`)。末尾の「分配方針」節のみ手動追記。');
+  out.push('');
+
+  out.push('## 1. 概要');
+  out.push('');
+  out.push(`- baseline entries 合計: **${data.baseline.total}**`);
+  out.push('');
+  out.push('### issueType 別件数');
+  out.push('');
+  out.push(renderByIssueType(data.baseline.byIssueType));
+  out.push('');
+
+  out.push('### bucket 別件数');
+  out.push('');
+  out.push('| bucket | count |');
+  out.push('| --- | --- |');
+  for (const name of bucketOrder) {
+    out.push(`| ${name} | ${data.buckets[name].length} |`);
+  }
+  out.push('');
+
+  out.push('## 2. bucket 別 entry 一覧');
+  out.push('');
+  for (const name of bucketOrder) {
+    out.push(renderBucketTable(name, data.buckets[name]));
+  }
+
+  out.push('## 3. summary counters');
+  out.push('');
+  out.push('`parity-check-status.json` から転記 (未生成の場合 `n/a`)。');
+  out.push('');
+  out.push(renderSummary(data.summary));
+  out.push('');
+
+  out.push('## 4. snapshotDiff');
+  out.push('');
+  out.push('`snapshot-diff-status.json` から転記 (未生成の場合 `n/a`)。');
+  out.push('');
+  out.push(renderSnapshotDiff(data.snapshotDiff));
+  out.push('');
+
+  process.stdout.write(out.join('\n'));
+}
+main();


### PR DESCRIPTION
## Summary

- Phase 4 Tasks 4.0-4.4 を **mechanism-only** で landing。baseline / schema v1 は不触。
- parity_artifact_registry (slug-scope token 抑止 + runtime coverage aggregator)、URL normalizer 対称化、HTML extractor の slug 限定 callout 正規化を導入。
- 後続の **bulk remediation** は別 plan で multi-PR 消化。**PR Z (Tasks 4.5-4.8 final cutover)** は baseline が十分薄くなってから別 worktree で実施。

## 分割経緯

Task 4.1 inventory 実測で baseline 1873 entries のうち **1851 件が actionable** (主に segment-untranslated 1571) と判明。1 セッション / 1 PR での完遂が非現実的だったため、Rev 6 plan の atomic cutover 規律を守るために執行を 3 段階に分離:

1. **PR A (本 PR)**: mechanism 層のみ投入
2. **中間 PRs**: bulk remediation plan に従って burn-down
3. **PR Z**: schema v2 atomic cutover + DoD 5-counter-0 達成

## 実装内容 (commits)

| Task | type | 内容 |
|---|---|---|
| 4.0 | `docs` | DoD を 5-counter-0 に再定義、final-goal.md で artifactCoverage / maskCoverage 契約を分離 |
| 4.1 | `chore` | 5-bucket residual inventory 実測 (actionable 1851 / artifact 7 / normalizer 1 / intentional 3 / advisory 11) |
| 4.2 | `feat` | parity_artifact_registry + createArtifactCoverage + alignSegments({slug, coverage}) 全呼出移行 (10 file) |
| 4.3 | `fix` | URL normalizer (help.testim.io ↔ /docs/) を fragment 保持 / trailing slash drop で対称化 |
| 4.4 | `feat` | preprocessHtml で EN blockquote→callout-note を slug allow list 限定正規化 (turndown 不触) |
| closeout | `fix` | CALLOUT_NORMALIZATION_SLUGS test を Set.freeze 誤誘導から修正 |
| closeout | `docs` | Phase 4 plan Rev 6 最終化 + Execution Strategy 追記 |
| closeout | `docs` | parity bulk remediation plan 新設 |

## Runtime 効果 (baseline 再生成時)

- artifact registry で **7 件抑止** (Task 4.2 で `artifactCoverage.matchedHits=7` 実測確認)
- extractor 正規化で `administration/api-access` **3 件 orphan baseline 化** (Task 4.4 で `npm run check:parity` 確認)
- URL 対称化は該当 1 件 (`/v2.0/docs/...`) が regex 非該当のため無効 — Stage B5 で処理予定

## Phase 4 discipline 遵守

1. **5 counter 0 DoD**: 未達成 (PR Z まで先延ばし)
2. **atomic cutover**: 守った (mechanism のみ。schema / baseline / advisory は不触)
3. **mask / artifact 分離**: `debug.maskCoverage` / `debug.artifactCoverage` は独立 field
4. **slug-scope default**: registry entries は全て `slugs: []` 配列 (global 登録なし)
5. **turndown 非侵襲**: `scripts/lib/turndown.mjs` 不触

## 次の step

1. 本 PR マージ → 別 worktree で **Stage B1** (segment-untranslated 1571 件 via LLM pipeline) を起票
2. Stage B2-B6 を順次実施して baseline を薄くする
3. **PR Z** (Phase 4 Task 4.5-4.8 final cutover) を新 worktree で起票

## Test plan
- [x] \`npm run test\` 1749/1749 pass
- [x] Task 4.2 runtime sanity: \`artifactCoverage = { registryEntries: 2, matchedHits: 7, bySlug: {6 slugs}, byToken: {'/docs/index': 5, 'http://google.com': 2} }\`
- [x] Task 4.4 runtime sanity: \`npm run check:parity -- --slug=administration/api-access\` で 3 件 orphan 化確認
- [x] Spec compliance + code quality review (subagent) 全 5 Task で pass
- [x] \`grep -rn "alignSegments\s*(" scripts/\` gate: illegitimate hit 0 件 (docstring / 2-arg safety-guard のみ残存)

## 関連 plan / spec

- Phase 4 plan (PR Z の contract): \`docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md\`
- Bulk remediation plan (中間 PRs の手順): \`docs/superpowers/plans/2026-04-15-parity-bulk-remediation.md\`
- Final goal (DoD 契約): \`docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md\`
- Residual inventory: \`docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.{json,md}\`