### PR TITLE
docs(M2): §5.2 #1 wording extension — cover <ul> + orphan-p interleave

### DIFF
--- a/docs/superpowers/plans/2026-04-16-m2-parity-burndown.md
+++ b/docs/superpowers/plans/2026-04-16-m2-parity-burndown.md
@@ -205,7 +205,7 @@ exception 追加は §5.2 と同じ security L2 gate (reviewer 承認 + plan へ
 
 M4 で確立した "JA 独自構造禁止" policy は **content-level** の独自構造追加を禁止する。以下は **mechanical / parser-level** の例外であり、検知器 (`source_parity_structure`) が kind-multiset fingerprint 上で許容している既知パターン。plan に明示登録することで、後続 agent が JA 独自構造との混同 / loophole 化するのを防ぐ:
 
-1. **flat `<ol>` の複数分割**: EN の単一 `<ol>` に non-`<li>` sibling (`<img>`/`<p>`/`<div class="note">`) が混在する場合、JA は ol を複数に分割して sibling を ol 外に出してよい。`<li value="N">` 属性に対応する番号は手動指定。(P2-1 pilot で初実施、kind-multiset fingerprint で同値)
+1. **flat リスト (`<ol>` / `<ul>` / 両者 interleave) の複数分割**: EN の単一 `<ol>` / `<ul>`、もしくは `<ol>` / `<ul>` + orphan `<p>` の interleave に non-`<li>` sibling (`<img>`/`<p>`/`<div class="note">`) が混在する場合、JA はリストを複数に分割して sibling をリスト外に出してよい。`<li value="N">` 属性に対応する番号は手動指定。(P2-1 pilot `deep-link-mobile` で `<ol>` pattern を pin、P2-2 Wave 1 `generating-a-random-value` で `<ul>` + `<ol>`/`<ul>` interleave pattern を pin。いずれも kind-multiset fingerprint で同値)
 2. **`:fa-arrow-right:` 段落融合**: EN の矢印 `→` プレフィックス段落は JA で `→**...するには:**` に変換するだけで段落は分離しない (PARITY_GUIDE §頻出パターン 2 で既定義)
 
 exception 追加は **reviewer 承認 + plan への明示登録** を条件とし、個別 PR の自由裁量では追加しない (security L2 gate)


### PR DESCRIPTION
## Summary

M2 parity burndown plan §5.2 #1 (flat list split mechanical exception) の wording を拡張し、PR #297 (`generating-a-random-value`) で実証した `<ul>` flat split + `<ol>`/`<ul>` + orphan `<p>` interleave pattern も §5.2 #1 範囲内であることを明文化。

## Background

- **§5.2 #1 originally** covered `<ol>` flat split with non-`<li>` siblings.
- **PR #297 (M2 P2-2 Wave 1)** で `<ul>` flat split + `<ol>`/`<ul>` + orphan `<p>` interleave (EN MadCap broken interleaved structure) を content-level で content-level で忠実に再現し、0-drift 化。kind-multiset fingerprint 上は既存 `<ol>` split と同値。
- 新 mechanical exception を追加するのは security L2 gate (reviewer approval + plan 明示登録) が必要だが、今回は**既存 #1 の自然延長** (parser-level 同値 / 新 loophole なし) として wording 拡張のみ実施。

## Change

- `docs/superpowers/plans/2026-04-16-m2-parity-burndown.md` §5.2 #1:
  - Before: `flat <ol> の複数分割`
  - After: `flat リスト (<ol> / <ul> / 両者 interleave) の複数分割`
  - Pilot slug 明記: `deep-link-mobile` (P2-1, `<ol>` pattern), `generating-a-random-value` (P2-2 Wave 1, `<ul>` + interleave pattern)

## Rationale

後続 Wave 2/3 agent が `<ul>` 系 flat split に遭遇した際、"§5.2 に登録されてないから carve-out 扱い" と誤解して §5.3.N proposal を大量に出すのを防ぐ。既存 CLEAN_PAGE_SLUGS sentinel (`generating-a-random-value` 含む) が regression pin として機能しているため、wording のみの更新で安全。

## Test plan

- [x] Plan markdown lint: このコミットは doc-only change のため `npm run lint:docs` は該当せず
- [x] §5.3 との整合: mechanical exception 枠の scope rule (§5.3 Scope preamble) 維持、新 exception 追加なし
- [x] Wave 1 sentinel 整合: `scripts/__tests__/source_parity_clean_page_fixtures.test.mjs` CLEAN_PAGE_SLUGS は既に `generating-a-random-value` を含む