### PR TITLE
feat(parity): M2 mechanism PR — §5.3.2 registration + /docs/index slug-scope extension

### DIFF
--- a/docs/PARITY_GUIDE.md
+++ b/docs/PARITY_GUIDE.md
@@ -198,6 +198,7 @@ node scripts/generate_parity_baseline.mjs --slug=advanced-editing/loops
 - **EN ゴミ混入禁止**: EN のアーティファクト（`</Image>` 等）を JA に含めない。baseline で管理する
 - **テスト確認**: リスト項目数を変更したら `KNOWN_ORDERED_DRIFTS`（`source_parity_segments_boundary.test.mjs`）を確認
 - **Prettier 注意**: `npm run format` はリポジトリ全体を変更する。PR 対象ファイルのみに限定する
+- **新 §5.3.N carve-out の提案手順**: エージェントが未知 pattern の mechanism-pending residual を発見した場合、**plan に §5.3.N として直接書き込まず**、PR description / コミット message に `[PENDING REVIEWER APPROVAL — §5.3.N proposal]` マーカーを付与して提案する。driver + 4-reviewer gate (architect / security 重点) の承認を経て初めて plan に確定登録する。自主宣言 (agent が承認前に plan に書き込む) は §5.3 Scope preamble で禁止されている。既存 `/docs/index` artifact への slug-scope extension など、明らかな "既存 mechanism の scope 拡張" については §5.3.2 のような先行実績があるが、それも reviewer 承認を前提とする (retroactive approval を回避するためにマーカー運用する)。
 
 ## Bug backlog の返済優先順位
 

--- a/docs/superpowers/plans/2026-04-16-m2-parity-burndown.md
+++ b/docs/superpowers/plans/2026-04-16-m2-parity-burndown.md
@@ -199,6 +199,16 @@ P2-2-1 pilot `configure-tricentis-mobile-agent` で初検知。EN の `<p><span 
 - **per-slug cap**: ≤ 2 件 (`section-structure-mismatch` + `segment-missing` / `segment-extra` の対)
 - **mitigation**: 該当 slug の baseline entry には commit message に `mechanism-pending: FileOrFilePath` ラベルを記載
 
+#### 5.3.2 EN `index.htm/#/` self-link artifact (slug-scope registry extension)
+
+P2-2 Wave 2 `use-agentic-test-automation-for-salesforce` で初検知。EN MadCap Flare が出力する self-link `<a href="index.htm/#/">` / `<a href="index.htm">` は `normalizeUrlToken` (`scripts/lib/source_parity_extract.mjs`) が `/docs/index` token に変換する。この token は **既存 `ARTIFACT_REGISTRY` entry (`reason: en-side-self-index-link-artifact`)** として 5 slug で登録済み。`salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce` は 6 番目の slug として同 entry の `slugs[]` に追加する slug-scope extension。新規 mechanism pattern ではなく、既存 mechanism の scope 拡張。
+
+- **symptom pattern**: EN ページ内 self-link `<a href="index.htm[/#/]">` が含まれる salesforce / integration / conditions / mobile recording / testops ページ
+- **per-slug cap**: ≤ 2 件 (`segment-token-gap` with `missingTokens: ["/docs/index"]`)
+- **mitigation**: 該当 slug の baseline entry には commit message に `mechanism-pending: docs-index-self-link-artifact` ラベルを記載
+- **follow-up mechanism PR**: `scripts/lib/parity_artifact_registry.mjs` `/docs/index` entry の `slugs[]` に新 slug を追加 (2026-04-17 PR #304 で処理)、同時に `scripts/__tests__/parity_artifact_registry.test.mjs` の hardcoded 件数 (5 slugs → 6 slugs) を更新。**registry + test の 2 files 更新**が必要 (架空の "1-line diff" ではない)。
+- **scope lock**: 本 §5.3.2 entry は **`/docs/index` token の既存 artifact entry 再利用のみ** 対象。別 token (`http://google.com`、`http://example.com` 等) に対する新規 registry 登録は独立 §5.3.N として別途 security L2 gate を経由する。
+
 exception 追加は §5.2 と同じ security L2 gate (reviewer 承認 + plan への明示登録) を要求する。
 
 ### 5.2 Source-first mechanical exceptions (M4 policy 補足)

--- a/scripts/__tests__/parity_artifact_registry.test.mjs
+++ b/scripts/__tests__/parity_artifact_registry.test.mjs
@@ -83,11 +83,12 @@ describe('parity_artifact_registry (inventory-driven exclusion)', () => {
     );
   });
 
-  it('excludes /docs/index for registered slugs (5 slugs in inventory)', () => {
+  it('excludes /docs/index for registered slugs (6 slugs in inventory)', () => {
     const registered = [
       'editing-tests/conditions/advanced-conditions-settings',
       'integrations/visual-validation/visual_validation_index',
       'recording-tests/recording-a-mobile-test/recording-a-local-mobile-test',
+      'salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce',
       'salesforce-testing/salesforce-steps/sfdc-step-login',
       'testops/insights/dashboard',
     ];

--- a/scripts/lib/parity_artifact_registry.mjs
+++ b/scripts/lib/parity_artifact_registry.mjs
@@ -32,6 +32,7 @@ export const ARTIFACT_REGISTRY = Object.freeze([
       'editing-tests/conditions/advanced-conditions-settings',
       'integrations/visual-validation/visual_validation_index',
       'recording-tests/recording-a-mobile-test/recording-a-local-mobile-test',
+      'salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce',
       'salesforce-testing/salesforce-steps/sfdc-step-login',
       'testops/insights/dashboard',
     ]),


### PR DESCRIPTION
## Summary

M2 Phase 2 Option X (mechanism PR 先行) — PR #303 (agentic-salesforce) merge 前に §5.3.2 carve-out を正規 L2 gate で先行登録。これにより #303 rebase 時に plan 自主宣言 commit を drop でき、clean audit trail を実現する。

### 4 つの変更

1. **\`parity_artifact_registry.mjs\`**: \`/docs/index\` artifact entry の slugs[] に agentic-salesforce 追加 (5→6 slug)
2. **\`parity_artifact_registry.test.mjs\`**: hardcoded inventory count 更新 (5→6)
3. **Plan §5.3.2 追加** (scope lock + follow-up 記述修正反映):
   - EN \`index.htm/#/\` self-link artifact の slug-scope registry extension
   - per-slug cap ≤ 2 件
   - scope lock: /docs/index token 再利用のみ対象、別 token は独立 §5.3.N
   - "1-line diff" → "registry + test の 2 files 更新" 訂正
4. **PARITY_GUIDE**: \`[PENDING REVIEWER APPROVAL — §5.3.N proposal]\` マーカー protocol

### Effect on PR #303

本 PR merge 後 → \`isArtifactExcluded\` runtime suppress 有効 → #303 rebase で agentic-salesforce slug の 2 entries (segment-token-gap) が 0 になる → CLEAN_PAGE_SLUGS sentinel 追加可能、§5.3.2 plan 追記 commit drop してクリーン merge

## Reviewer gate focus

architect + security 重点 (plan governance + L2 gate compliance)。qa / testing は軽量 (doc-only changes in plan/guide, registry 1-line add に test 1-line update)。

## Test plan

- [x] \`npm run test\` → 1973 pass (既存 + isArtifactExcluded で 6 slugs inventory 確認)
- [ ] 4-reviewer gate (architect / qa / testing / security) approval
- [ ] Phase 3: #303 rebase + baseline regen で 0 entries 確認