### PR TITLE
docs(M2): codify Wave 2 source-first practices into guides

### DIFF
--- a/docs/PARITY_GUIDE.md
+++ b/docs/PARITY_GUIDE.md
@@ -102,6 +102,25 @@ JA 側の構造修正で解消可能？
 
 この厳格条件により、`△` 欄は「自由裁量で baseline できる escape hatch」ではなく「具体 evidence + reviewer 承認必須の限定ケース」として運用される。
 
+## Wave 2 実績 pattern catalog
+
+2026-04-17 時点の Wave 2 (P2-2) で burn-down 済の source-first pattern 一覧。各 pattern は `scripts/__tests__/source_parity_clean_page_fixtures.test.mjs` の `CLEAN_PAGE_SLUGS` 内 sentinel slug で zero-drift として pin 済。新 pattern は本 catalog に **追加しない** (plan §5.2 mechanical exceptions / §5.3 carve-outs の reviewer 承認経由で initial 登録を経た pattern のみ codify 対象)。
+
+本 catalog は "既に確定した pattern" の reference であり、新規 `§5.3.N` carve-out の提案経路ではない。新規 mechanism-pending 残存を発見した場合は §並列エージェント委任チェックリスト 末尾の `[PENDING REVIEWER APPROVAL — §5.3.N proposal]` マーカー運用に従う。
+
+| # | pattern | 概要 | canonical sentinel slug |
+| --- | --- | --- | --- |
+| 1 | Arrow-fusion (plan §5.2 #2) | EN `<p>Context. →<strong>To X:</strong></p>` 単一段落を JA が 2 段落に分離していた drift を `。\n→ **Xするには:**` soft-break 融合で zero-drift 化 | `editing-tests/editing-your-tests/editing-target-element-properties` |
+| 2 | Flat-list split (plan §5.2 #1) | EN 単一 `<ol>` / `<ul>` に orphan `<p>` + `<img>` / `<div class="note">` が interleave する構造を、JA 側でリストを複数分割 + 外部 block sibling + `<li value="N">` 番号手動指定で mirror | `advanced-editing/deep-link-mobile` (+ `editing-tests/generating-a-random-value` で ol/ul interleave 拡張) |
+| 3 | ASCII punctuation mirror | UI-term `<li>Username.</li>` / `<li>Access key.</li>` 等の trailing `.` を JA で欠落させると `scoreSegmentMatch` の same-language penalty で score 0 に落ちるため、EN 側の trailing ASCII punctuation は verbatim mirror する | `integrations/visual-validation/lambdatest_integration` |
+| 4 | URL token verbatim mirror | EN URL を JA が canonical domain に置換していた drift (例: MadCap redirect `testmuai.com` → `lambdatest.com`) は `tokensInvariant` 不一致で検知される。EN URL が HTTP 200 OK で生きている限り verbatim mirror する | `integrations/visual-validation/lambdatest_integration` |
+| 5 | Broken-table-row paragraph mirror | EN MadCap Flare が吐く `<table>` 外 orphan paragraph (broken row artifact、本文中に `<p>&#124;...&#124;</p>` として現れる) を JA で backslash-escaped paragraph (`\|...\|` 形式) で段落として mirror する | `salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce` |
+| 6 | HTML `<table>` cell `<br />` mirror | EN `<td>` が `<br />` + nested `<p>` で複数行を包む場合、JA で slash セパレータに変換せず `<br />` をそのまま保持する (extractHtmlTableCells 経路との整合) | `advanced-editing/keyboard-shortcut-step` |
+| 7 | JA navigation link removal | EN `<a href="index.htm">` / `<a href="index.htm/#/">` の self-link MadCap artifact が JA にも残存している場合、JA 側でリンクを除去して mirror する (§5.3.2 registry の slug-scope extension 対象) | `salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce` |
+| 8 | Generic-English-residue translation | 一般英語語 (browser version / hover / geolocation / site-to-site / executive 等) は JA 化し、Testim / vendor name (Grid / Editor / VPN / IP / CLI / SauceLabs / BrowserStack) は英語維持する (GLOSSARY Tier A/B + Tier C closed-list 運用) | `integrations/grid-management` |
+
+各 pattern の判定・対処の詳細は sentinel test (`scripts/__tests__/source_parity_clean_page_fixtures.test.mjs`) の slug コメントを canonical reference とする。TRANSLATION_GUIDE §5.5 にも同 8 pattern の翻訳観点を codify している。
+
 ## 頻出パターン
 
 ### 1. preface に frontmatter description の重複段落（segment-extra）

--- a/docs/TRANSLATION_GUIDE.md
+++ b/docs/TRANSLATION_GUIDE.md
@@ -43,7 +43,7 @@
 | `segment-untranslated` | Testim UI 用語以外の英語 prose 残留 |
 | `segment-token-gap` | CLI flag / URL / 数値 token の欠落 |
 
-**これらの issue は必ず「JA を EN に追従させる」方向で解消する。baseline で許容してはならない。** 詳細は [WRITING_GUIDE.md §Source-First 構造契約](./WRITING_GUIDE.md) と [PARITY_GUIDE.md M2 burn-down recipe](./PARITY_GUIDE.md) を参照。
+**これらの issue は必ず「JA を EN に追従させる」方向で解消する。baseline で許容してはならない。** 詳細は [WRITING_GUIDE.md §Source-First 構造契約](./WRITING_GUIDE.md) と [PARITY_GUIDE.md M2 burn-down recipe](./PARITY_GUIDE.md) を参照。Wave 2 (P2-2) で確立済の具体的翻訳 pattern は [§5.5 Source-first 翻訳パターン](#55-source-first-翻訳パターンwave-2-確立) を参照。
 
 ## 1. 準備：公式サイトの構造を確認
 
@@ -599,6 +599,111 @@ Testim 固有名詞以外でも、以下の **一般 IT 用語** は英語のま
 **false-positive 事例**（M1 T4 で除外済）:
 
 - `browser version` / `major version` / `Add action` / `Add validation` は compound general であり、GLOSSARY に登録しない（一般 IT 英文の silent false-negative 源になる）
+
+### 5.5 Source-first 翻訳パターン（Wave 2 確立）
+
+2026-04-17 時点の Wave 2 (P2-2) で確立済の翻訳パターン一覧。各 pattern は `scripts/__tests__/source_parity_clean_page_fixtures.test.mjs` の `CLEAN_PAGE_SLUGS` 内 sentinel slug で zero-drift として pin 済。canonical reference は PARITY_GUIDE §Wave 2 実績 pattern catalog と各 sentinel slug のコメント。
+
+本 subsection は **既に確定したパターンの codification** であり、新規 mechanical exception / §5.3.N carve-out の提案経路ではない。翻訳作業中に未知 pattern を見つけた場合は §Source-first 例外の canonical registry (WRITING_GUIDE 冒頭) に従って reviewer gate を経由する。
+
+#### パターン 1: Arrow-fusion（矢印プレフィックス段落融合）
+
+EN 原文の `<p>Context. →<strong>To X:</strong></p>` は **1 段落**。JA で context と `**Xするには:**` を 2 段落に分割すると `segment-extra` 発火。`。\n→ **Xするには:**` soft-break で融合する。
+
+```text
+EN 原文:
+<p>Use loops to repeat actions. →<strong>To configure a loop:</strong></p>
+
+❌ NG (JA で 2 段落分離):
+ループを使用すると、同じアクションを繰り返せます。
+
+**ループを設定するには:**
+
+✅ OK (soft-break 融合):
+ループを使用すると、同じアクションを繰り返せます。
+→ **ループを設定するには:**
+```
+
+EN に `<br />` がある場合は `。  \n→ **Xするには:**` (trailing 2-space + newline) で hard break を保持する。判別は EN snapshot の `grep -oE '<br /> →|\. →'` で。
+
+Canonical sentinel: `editing-tests/editing-your-tests/editing-target-element-properties`
+
+#### パターン 2: Flat-list split（単一リストの複数分割）
+
+EN の単一 `<ol>` / `<ul>` に orphan `<p>` + `<img>` / `<div class="note">` が interleave する場合、JA 側でリストを複数に分割し、sibling 要素をリスト外に出す。番号は EN の `<li value="N">` に合わせて手動指定する。これは mechanical exception (plan §5.2 #1) であり JA 独自構造の追加ではない（kind-multiset fingerprint 上で検知器が許容する既知 pattern）。
+
+Canonical sentinel: `advanced-editing/deep-link-mobile` (ol 版) / `editing-tests/generating-a-random-value` (ol/ul interleave 版)
+
+#### パターン 3: ASCII punctuation mirror（trailing punctuation 維持）
+
+UI-term `<li>Username.</li>` / `<li>Access key.</li>` / `<li>Project token.</li>` 等の trailing `.` を JA で欠落させると `scoreSegmentMatch` の same-language penalty により score 0 に落ち、segment-untranslated が誤発火する。ASCII-only の UI-term は trailing punctuation を verbatim mirror する。
+
+```text
+❌ NG (JA で trailing punctuation 欠落):
+- Username
+- Access key
+
+✅ OK (EN 通りに trailing dot を保持):
+- Username.
+- Access key.
+```
+
+Canonical sentinel: `integrations/visual-validation/lambdatest_integration`
+
+#### パターン 4: URL token verbatim mirror（URL 文字列そのまま維持）
+
+EN の URL token は JA で canonical domain に置換しない (MadCap redirect 経由の domain も含めて verbatim mirror)。`tokensInvariant` が URL 文字列一致を要求するため、`testmuai.com` (MadCap redirect, HTTP/2 200 OK で生きている) を `lambdatest.com` に置換すると segment-token-gap が発火する。
+
+Canonical sentinel: `integrations/visual-validation/lambdatest_integration`
+
+#### パターン 5: Broken-table-row paragraph mirror（broken 行 artifact の mirror）
+
+EN MadCap Flare が吐く `<table>` 外 orphan `<p>|...|</p>` (broken row artifact) は、JA でも backslash-escaped paragraph (`\| ... \|`) で段落として mirror する。テーブル内に取り込まない。
+
+```text
+EN 原文 (table 外 orphan paragraph):
+<p>|Column A|Column B|High|</p>
+
+✅ OK (JA 側 backslash-escaped paragraph):
+\| Column A \| Column B \| 高 \|
+```
+
+Canonical sentinel: `salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce`
+
+#### パターン 6: HTML `<table>` cell `<br />` mirror（セル内改行の保持）
+
+EN `<td>` が `<br />` + nested `<p>` で複数行を包む場合、JA で ` / ` などのセパレータ文字に置換せず `<br />` をそのまま維持する (extractHtmlTableCells 経路との整合)。
+
+```text
+❌ NG (JA で ` / ` セパレータ):
+<td>Cmd+C / Ctrl+C</td>
+
+✅ OK (EN 通りに <br /> を保持):
+<td>Cmd+C<br />Ctrl+C</td>
+```
+
+Canonical sentinel: `advanced-editing/keyboard-shortcut-step`
+
+#### パターン 7: JA navigation link removal（MadCap self-link artifact の除去）
+
+EN MadCap Flare が吐く `<a href="index.htm">` / `<a href="index.htm/#/">` の self-link artifact が JA にも残存している場合、JA 側でリンクを除去する（text のみ残す）。これは plan §5.3.2 registry の slug-scope extension 対象パターン。
+
+Canonical sentinel: `salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce`
+
+#### パターン 8: Generic-English-residue translation（一般英語語は翻訳）
+
+Testim UI / vendor name (Grid / Editor / VPN / IP / CLI / SauceLabs / BrowserStack 等) は英語維持、一般英語語 (browser version / hover / geolocation / site-to-site / executive 等) は JA 化する。判定は GLOSSARY Tier A/B (Testim 固有) + Tier C (closed-list 一般 IT 英語維持語) の登録有無。未登録 generic 語を「業界共通語」として英語維持することは禁止 (§5.4 参照)。
+
+```text
+❌ NG (generic 語を英語維持):
+Hover した状態で geolocation を site-to-site で共有します。
+
+✅ OK (generic 語を JA 化、Testim / vendor name は英語維持):
+ホバーした状態で位置情報をサイト間で共有します。
+(ただし「Testim Grid」「SauceLabs」「BrowserStack」「VPN」「IP」「CLI」は英語維持)
+```
+
+Canonical sentinel: `integrations/grid-management`
 
 ## 6. ナビゲーション構造の確認
 

--- a/docs/WRITING_GUIDE.md
+++ b/docs/WRITING_GUIDE.md
@@ -28,9 +28,9 @@
 
 **本プロジェクトの最上位契約**: JA ドキュメントは **EN 原文の構造をそのまま写した日本語版** として整備する。JA 独自の構造は作成しない。
 
-1. **Source-First 絶対遵守**: `sourceUrl` の原文にある見出し・段落・番号手順・箇条書き・callout・画像は欠落なく、**構造そのまま** 日本語化する。JA 独自の section / 段落 / callout / リスト項目 / 見出しは **絶対に追加しない**（詳細は [§🪞 原文準拠ルール](#-原文準拠ルールsource-first-構造契約)）
+1. **Source-First 絶対遵守 — JA独自の構造は作成しない**: `sourceUrl` の原文にある見出し・段落・番号手順・箇条書き・callout・画像は欠落なく、**構造そのまま** 日本語化する。JA 独自の section / 段落 / callout / リスト項目 / 見出しは **絶対に追加しない**（詳細は [§🪞 原文準拠ルール](#-原文準拠ルールsource-first-構造契約)）。callout `:::note` / `:::warning` 等は EN `<div class="note">` / `<div class="warning">` 等に 1:1 mirror し、JA 側での種別変更・callout 分割・段落分割は禁止
 2. **Callout は EN 原文準拠**: EN の callout タイプ (`note` / `warning` / `caution` / `danger` / `tip` / `info`) にそのまま追従する。JA 独自 callout 種別の発明禁止（[Callout 規則](#-callout-規則)の変換マップ参照）
-3. **Testim 固有名詞の英語維持**: 機能名、製品名、画面名、UI ラベル、CLI flag、設定キーは原則として英語のまま維持する（正本: [GLOSSARY.md](./GLOSSARY.md) の 3-tier 分類）
+3. **Testim UI 用語は英語維持**: 機能名、製品名、画面名、UI ラベル、CLI flag、設定キーは原則として英語のまま維持する（正本: [GLOSSARY.md](./GLOSSARY.md) の 3-tier 分類 / 詳細は [§Testim 機能名・製品名・画面名の英語維持](#️-testim-機能名製品名画面名の英語維持)）
 4. **検知基盤との整合**: 上記 1–3 に違反すると `npm run check:parity` が gate で報告する。baseline 対象にする前に、まず **JA 側を EN 構造に追従させる** ことを優先する
 5. `npm run lint:docs` で検出される違反は必ず修正してからマージする
 6. 公開ページは原則 `.md` で管理し、特別な UI が必要な場合だけ `.mdx` を使う
@@ -38,6 +38,12 @@
 
 > **最終ゴール**: `parity-baseline.json` の entries = 0 / `npm run check:parity` の全 counter = 0。baseline は「時限的 ack」であって「恒常許容」ではない。
 > このゴールを達成するため、本ガイドは baseline を増やす方向の変更（JA 独自構造追加 / callout 改変 / Testim 用語翻訳）を全面禁止する。
+>
+> **Source-first 例外の canonical registry**:
+>
+> - **Mechanical exceptions (parser-level)**: kind-multiset fingerprint 上で検知器が許容する既知 pattern (flat-list split / arrow-fusion 段落融合 等) は [`docs/superpowers/plans/2026-04-16-m2-parity-burndown.md` §5.2](./superpowers/plans/2026-04-16-m2-parity-burndown.md) に登録。個別 PR の自由裁量で追加禁止 (reviewer 承認 + plan 明示登録の security L2 gate)
+> - **Mechanism-pending carve-outs**: content 修正で 0 到達不能な mechanism-level 残存 (FileOrFilePath paragraph vs code-fence kind-mismatch / EN self-link artifact 等) は同 plan §5.3 に `§5.3.N` 形式で登録。未登録の mechanism-pending を agent が自主宣言するのは禁止。新 pattern は `[PENDING REVIEWER APPROVAL — §5.3.N proposal]` マーカー経由で提案する ([PARITY_GUIDE.md §並列エージェント委任チェックリスト](./PARITY_GUIDE.md#並列エージェント委任チェックリスト) 参照)
+> - **Wave 2 実績 pattern**: P2-2 で確立した 8 pattern の catalog は [PARITY_GUIDE.md §Wave 2 実績 pattern catalog](./PARITY_GUIDE.md#wave-2-実績-pattern-catalog) に一覧化、翻訳観点は [TRANSLATION_GUIDE.md §5.5 Source-first 翻訳パターン](./TRANSLATION_GUIDE.md#55-source-first-翻訳パターンwave-2-確立) 参照
 
 ---
 


### PR DESCRIPTION
## Summary

Wave 2 (P2-2, PR #298–#304) で確立済の source-first 実践を、3 つの authority document (`WRITING_GUIDE.md` / `TRANSLATION_GUIDE.md` / `PARITY_GUIDE.md`) に codify します。**新規ルールは一切追加せず、既に merge 済の実績を文書化するだけ** (zero behavior change)。

## Zero behavior change claim

- 新 mechanical exception / §5.3.N carve-out 追加なし (plan §5.2 / §5.3 は unchanged)
- content file (`src/content/docs/**`) 変更なし
- script / test 変更なし
- 既存 sentinel test (`source_parity_clean_page_fixtures.test.mjs`) は touch せず、本 PR の pattern 記述は全て同 test の `CLEAN_PAGE_SLUGS` コメントを canonical reference として cross-link
- `git diff --stat`: `docs/PARITY_GUIDE.md` / `docs/TRANSLATION_GUIDE.md` / `docs/WRITING_GUIDE.md` の 3 file のみ

## Sections added / elevated

### `docs/WRITING_GUIDE.md`

- 🎯 最優先ルール §1-3 を明示的に elevate:
  - §1: "JA独自の構造は作成しない" を callout 1:1 mirror 要件を含めて明文化
  - §2: EN callout タイプ 1:1 追従 (既存文言を維持)
  - §3: "Testim UI 用語は英語維持" のタイトル化 + 既存 §Testim 機能名セクションへの cross-link 追加
- 新 blockquote "Source-first 例外の canonical registry" を追加:
  - plan §5.2 mechanical exceptions への pointer
  - plan §5.3 mechanism-pending carve-outs への pointer (`[PENDING REVIEWER APPROVAL — §5.3.N proposal]` marker 運用の cross-link)
  - PARITY_GUIDE §Wave 2 実績 pattern catalog / TRANSLATION_GUIDE §5.5 への cross-link

### `docs/TRANSLATION_GUIDE.md`

- §⚖️ 翻訳の構造契約 末尾に §5.5 への cross-link 追加
- 新 subsection §5.5 "Source-first 翻訳パターン (Wave 2 確立)" を追加、下記 8 pattern を sentinel slug 付きで codify

### `docs/PARITY_GUIDE.md`

- 新 subsection "Wave 2 実績 pattern catalog" を §頻出パターン の直前に追加、同 8 pattern を 1-line summary + canonical sentinel slug 対応表で一覧化
- §5.3.N marker protocol (`[PENDING REVIEWER APPROVAL — §5.3.N proposal]`) は PR #304 で既に反映済で、本 PR での追加修正なし

## 8 patterns documented

| # | pattern | canonical sentinel slug |
| --- | --- | --- |
| 1 | Arrow-fusion (§5.2 #2) | `editing-tests/editing-your-tests/editing-target-element-properties` |
| 2 | Flat-list split (§5.2 #1, ol + ol/ul interleave) | `advanced-editing/deep-link-mobile` / `editing-tests/generating-a-random-value` |
| 3 | ASCII punctuation mirror (UI-term trailing `.`) | `integrations/visual-validation/lambdatest_integration` |
| 4 | URL token verbatim mirror (MadCap redirect domain 含む) | `integrations/visual-validation/lambdatest_integration` |
| 5 | Broken-table-row paragraph mirror (backslash-escaped) | `salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce` |
| 6 | HTML `<table>` cell `<br />` mirror | `advanced-editing/keyboard-shortcut-step` |
| 7 | JA navigation link removal (§5.3.2 slug-scope extension) | `salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce` |
| 8 | Generic-English-residue translation (GLOSSARY Tier A/B/C 判定) | `integrations/grid-management` |

## Verification

- `npm run lint`: PASS (0 error, 0 warning in 288 file(s))
- `npm run test`: PASS (1976 / 1976 tests, 0 fail)
- `npm run build`: PASS (290 pages built in 14.48s)

## Test plan

- [x] `npm run lint` 0 error
- [x] `npm run test` all pass
- [x] `npm run build` clean build
- [x] `git diff --stat` shows only `docs/**` changes
- [x] `WRITING_GUIDE.md` top principle block cross-links to plan §5.2 / §5.3
- [x] `TRANSLATION_GUIDE.md` §5.5 documents 8 patterns with sentinel slug references
- [x] `PARITY_GUIDE.md` §Wave 2 実績 pattern catalog documents 8 patterns with sentinel slug references
- [x] 新 mechanical exception / §5.3.N carve-out 追加なし (zero behavior change)

## Merge command expected after 4-reviewer gate

```bash
# 4-reviewer gate (architect / security / consistency / factual) 承認後
gh pr merge --squash <this-pr-number>
```

Do NOT merge until 4-reviewer gate approval is confirmed.