### PR TITLE
mechanism(parity): §5.3.1 extend to paragraph-count-mismatch coverage

### DIFF
--- a/docs/PARITY_GUIDE.md
+++ b/docs/PARITY_GUIDE.md
@@ -219,6 +219,31 @@ node scripts/generate_parity_baseline.mjs --slug=advanced-editing/loops
 - **Prettier 注意**: `npm run format` はリポジトリ全体を変更する。PR 対象ファイルのみに限定する
 - **新 §5.3.N carve-out の提案手順**: エージェントが未知 pattern の mechanism-pending residual を発見した場合、**plan に §5.3.N として直接書き込まず**、PR description / コミット message に `[PENDING REVIEWER APPROVAL — §5.3.N proposal]` マーカーを付与して提案する。driver + 4-reviewer gate (architect / security 重点) の承認を経て初めて plan に確定登録する。自主宣言 (agent が承認前に plan に書き込む) は §5.3 Scope preamble で禁止されている。既存 `/docs/index` artifact への slug-scope extension など、明らかな "既存 mechanism の scope 拡張" については §5.3.2 のような先行実績があるが、それも reviewer 承認を前提とする (retroactive approval を回避するためにマーカー運用する)。
 
+## §5.3.1 FileOrFilePath carve-out coverage (audit-signal 拡張 2026-04-17)
+
+`2026-04-16-m2-parity-burndown.md` §5.3.1 の FileOrFilePath mechanism-pending carve-out は、当初 gate-blocking な `section-structure-mismatch` / `segment-missing` / `segment-extra` のみを scope としていたが、2026-04-17 に **`paragraph-count-mismatch` audit signal** を同 root cause 由来の副作用として §5.3.1 scope に追加する (詳細は plan §5.3.1.a)。
+
+### 分類境界
+
+| 対象 slug / section | issue type | gate 扱い | 対処 |
+| --- | --- | --- | --- |
+| `configure-tricentis-mobile-agent` §19 WDA Errors | `section-structure-mismatch` | baseline 登録済 / gate-blocking | §5.3.1 既存 carve-out |
+| `configure-tricentis-mobile-agent` §19 WDA Errors | `segment-missing` / `segment-extra` | baseline 登録済 / gate-blocking | §5.3.1 既存 carve-out |
+| `configure-tricentis-mobile-agent` §19 WDA Errors | `paragraph-count-mismatch` | `COARSE_SIGNAL_TYPES` / audit-only | §5.3.1.a 拡張 (本追加) |
+
+### 運用上の注意 (agent 向け)
+
+- `configure-tricentis-mobile-agent.md` で `paragraph-count-mismatch` (EN=5 / JA=4) を検知した場合、**content 修正を試みない** (JA 独自段落追加 = source-first policy 違反)
+- §5.3.1 の symptom (FileOrFilePath + code-fence) に一致するかを確認し、一致する場合は carve-out 済として skip
+- 同 slug の audit signal は agent の個別判断で baseline 追加 / ack / content 修正せず、本 §5.3.1.a 枠組み下で EN mechanism fix (M2 範囲外) を待つ
+- 他 slug で同 `paragraph-count-mismatch` + FileOrFilePath pattern が新規発現した場合は **§5.3.N proposal marker protocol に従って提案する** (自動 scope 拡張禁止)
+
+### 関連参照
+
+- 詳細: `docs/superpowers/plans/2026-04-16-m2-parity-burndown.md` §5.3.1.a
+- Root cause analysis: `docs/superpowers/analyses/2026-04-17-audit-signals-triage.md` (PR #312) §3.1 entry #18 / §5.4 Proposal A
+- 実装参照: `scripts/lib/source_parity_types.mjs` `COARSE_SIGNAL_TYPES` (= audit-only allowlist)、`scripts/lib/source_parity_extract.mjs` `extractParagraphCounts` / `normalizeEnArtifacts`、`scripts/lib/source_parity_segments_en.mjs` `INLINE_JOIN_TAGS`
+
 ## Bug backlog の返済優先順位
 
 Phase 0 後の baseline は「未解決バグの backlog」になる。Phase 1 以降で以下の優先順位で返済する:

--- a/docs/superpowers/plans/2026-04-16-m2-parity-burndown.md
+++ b/docs/superpowers/plans/2026-04-16-m2-parity-burndown.md
@@ -199,6 +199,41 @@ P2-2-1 pilot `configure-tricentis-mobile-agent` で初検知。EN の `<p><span 
 - **per-slug cap**: ≤ 2 件 (`section-structure-mismatch` + `segment-missing` / `segment-extra` の対)
 - **mitigation**: 該当 slug の baseline entry には commit message に `mechanism-pending: FileOrFilePath` ラベルを記載
 
+##### 5.3.1.a paragraph-count-mismatch audit signal coverage (2026-04-17 scope extension)
+
+PR #312 `audit-signals-triage` が `configure-tricentis-mobile-agent.md` §19 "WebDriverAgent (WDA) Errors" で `paragraph-count-mismatch` (EN=5 / JA=4) を追加検知。これは §5.3.1 既存 "FileOrFilePath paragraph vs code-fence kind-mismatch" の**同根**の副作用であり、新規 mechanism pattern ではない:
+
+- EN `<p><span class="FileOrFilePath">...Java stack trace...</span></p>` は paragraph kind で `extractParagraphCounts` に 1 件として乗る
+- JA は code-fence (```text / ```) で `code-block` kind に正規化されるため `extractParagraphCounts` でカウントされない
+- 結果: 同 section で segment-level の `section-structure-mismatch` / `segment-missing` (既存 §5.3.1 scope) と audit-signal の `paragraph-count-mismatch` が**同一 root cause から併発**する
+
+**Affected issue types** (scope extension):
+
+- `section-structure-mismatch` (既存 / baseline 対象 / gate-blocking)
+- `segment-missing` (既存 / baseline 対象 / gate-blocking)
+- `segment-extra` (既存 / baseline 対象 / gate-blocking)
+- `paragraph-count-mismatch` (**本 scope 拡張で追加 / `COARSE_SIGNAL_TYPES` 所属 / audit-only / gate-non-blocking**)
+
+**分類 rationale**: `paragraph-count-mismatch` は `scripts/lib/source_parity_types.mjs` §`COARSE_SIGNAL_TYPES` allowlist で既に gate 除外 (audit-only) され、`summary.auditSignalIssues` counter にのみ集計される。baseline への追加対象ではなく content 修正でも解消不能 (EN 側 extract mechanism 未改修の限り再発火)。本 scope 拡張は **classification-only** (plan 文書レベルでの既知 FileOrFilePath artifact への分類昇格) であり code / registry / baseline / test のいずれも変更不要。
+
+**対象 slug/entry (2026-04-17 実測)**:
+
+- slug: `recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent`
+- section: §19 "WebDriverAgent (WDA) Errors"
+- signal: `paragraph-count-mismatch`, EN=5 / JA=4 (-1)
+- 1 entry / 1 slug (per-slug cap は本 audit signal について ≤ 1 件、総合 §5.3.1 cap は ≤ 3 件に引き上げ — 既存 ≤ 2 gate-blocking + ≤ 1 audit-only)
+
+**M3 PR Z entry condition への影響**: `2026-04-16-m2-parity-burndown.md` §1 最終ゴールの `auditSignalIssues = 0` は**本 entry を §5.3.1 carve-out 由来として別枠で tracking** する (§P2-5 Exit の `auditSignalIssues = 0` 判定から除外)。M3 cutover 前に EN 抽出側 FileOrFilePath mechanism fix が入れば同時に解消される見込み。
+
+**Mitigation**: 該当 slug の baseline entry には commit message に `mechanism-pending: FileOrFilePath (audit-signal scope)` ラベルを追記。baseline 追加はしない (audit-only counter の定義上 baseline-ineligible)。
+
+**Non-goals of this scope extension**:
+
+- 新規 registry 追加なし (§5.3.2 と違い runtime 側の登録は存在しない)
+- `COARSE_SIGNAL_TYPES` の変更なし
+- `extractParagraphCounts` の code-fence 扱いの変更なし
+- 他 slug への scope 拡張なし (他 slug で同 pattern が再発した場合は本 §5.3.1.a entry の slug リストへの追記で L2 gate 再通過)
+
 #### 5.3.2 EN `index.htm/#/` self-link artifact (slug-scope registry extension)
 
 P2-2 Wave 2 `use-agentic-test-automation-for-salesforce` で初検知。EN MadCap Flare が出力する self-link `<a href="index.htm/#/">` / `<a href="index.htm">` は `normalizeUrlToken` (`scripts/lib/source_parity_extract.mjs`) が `/docs/index` token に変換する。この token は **既存 `ARTIFACT_REGISTRY` entry (`reason: en-side-self-index-link-artifact`)** として 5 slug で登録済み。`salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce` は 6 番目の slug として同 entry の `slugs[]` に追加する slug-scope extension。新規 mechanism pattern ではなく、既存 mechanism の scope 拡張。


### PR DESCRIPTION
## Summary

Classification-only scope extension of **§5.3.1 `FileOrFilePath paragraph vs code-fence kind-mismatch`** carve-out in `docs/superpowers/plans/2026-04-16-m2-parity-burndown.md`. Per PR #312 audit-signals-triage analysis, the `paragraph-count-mismatch` audit signal on `recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent.md` §19 "WebDriverAgent (WDA) Errors" (EN=5 / JA=4, -1) is classified as same-root-cause as existing §5.3.1 mechanism.

## Scope

**§5.3.1 is plan-level only** — it has no runtime registry (unlike §5.3.2 which uses `parity_artifact_registry.mjs`). This PR therefore makes no code / test / registry / baseline changes. The `paragraph-count-mismatch` issue type is already gate-excluded via `COARSE_SIGNAL_TYPES` allowlist in `scripts/lib/source_parity_types.mjs:61` — it is audit-only (tracked in `summary.auditSignalIssues`, not in `reportableActiveFiles` / baseline).

**What this PR does**:

- Plan `§5.3.1.a` new sub-section: documents that the FileOrFilePath root cause also emits `paragraph-count-mismatch` audit signal on the same slug + section, classified as FileOrFilePath-caused artifact. Raises total §5.3.1 per-slug cap 2 → 3 (≤ 2 gate-blocking + ≤ 1 audit-only).
- PARITY_GUIDE new `§5.3.1 FileOrFilePath carve-out coverage` section: boundary table (which issue types fall in which gate tier) + agent runbook note to prevent content-fix attempts on matching signals.

**What this PR does NOT do**:

- No `src/content/docs/**` edits
- No `parity-baseline.json` edits
- No `scripts/lib/**` changes (no mechanism / registry / extractor fix)
- No new test coverage (paragraph-count-mismatch is already gate-excluded by allowlist, no regression to protect)
- No peer agent scope (§5.3.2 ext / §5.3.3 new / §5.3.4 new are other agents' scope)

## Affected slug / entry

| slug | section | audit signal | Δ |
|---|---|---|---|
| `recording-tests/recording-a-mobile-test/configure-tricentis-mobile-agent` | §19 "WebDriverAgent (WDA) Errors" | `paragraph-count-mismatch` | EN=5 / JA=4 (-1) |

Per-slug cap ≤ 1 for audit-signal under §5.3.1.a. Total §5.3.1 cap (across all issue types) raised from ≤ 2 to ≤ 3.

## Rationale

The existing §5.3.1 entry already explains the FileOrFilePath paragraph-vs-code-fence asymmetry. PR #312 triage confirmed that the resulting `extractParagraphCounts` imbalance is a **deterministic side-effect** of the same EN-side extract mechanism: when EN extracts `<p><span class="FileOrFilePath">...</span></p>` as paragraph kind while JA normalizes to a code-fence, the JA paragraph count is 1 lower. No new pattern, no new mechanism — identical root cause. Classification-only update is the minimum-viable change to keep §5.3.1 scope-honest without inventing a new §5.3.N (which would be redundant since the PR #312 analysis itself acknowledges "既存 §5.3.1 scope 拡張").

## Test plan

- [x] `npm run lint` → 0 errors / 0 warnings / 288 files
- [x] `npm run test` → 2010 tests pass / 0 fail / 430 suites
- [x] `npm run build` → 290 pages built in 15.17s
- [x] No `src/content/docs/**` changes
- [x] No `parity-baseline.json` changes
- [x] No `scripts/lib/**` changes
- [x] No peer agent scope (§5.3.2 / §5.3.3 / §5.3.4) touched
- [ ] Reviewer approval of §5.3.1 scope extension (blocks L2 gate)

## [PENDING REVIEWER APPROVAL — §5.3.1 L2 gate]

This PR adds a sub-section (`§5.3.1.a`) extending an existing carve-out rather than inventing a new `§5.3.N` number, consistent with the task spec ("EXISTING mechanism, SCOPE EXTENSION — do NOT invent new numbers"). Per `docs/PARITY_GUIDE.md §新 §5.3.N carve-out の提案手順`, plan edits on §5.3 sections require reviewer L2 gate (architect / security review) before merge.

Refs: PR #312 `docs/superpowers/analyses/2026-04-17-audit-signals-triage.md` §3.1 entry #18 / §5.4 Proposal A