### PR TITLE
mechanism(parity): §5.3.2 extend /docs/index registry to testops/insights/reports

### DIFF
--- a/docs/superpowers/plans/2026-04-16-m2-parity-burndown.md
+++ b/docs/superpowers/plans/2026-04-16-m2-parity-burndown.md
@@ -207,6 +207,7 @@ P2-2 Wave 2 `use-agentic-test-automation-for-salesforce` で初検知。EN MadCa
 - **per-slug cap**: ≤ 2 件 (`segment-token-gap` with `missingTokens: ["/docs/index"]`)
 - **mitigation**: 該当 slug の baseline entry には commit message に `mechanism-pending: docs-index-self-link-artifact` ラベルを記載
 - **follow-up mechanism PR**: `scripts/lib/parity_artifact_registry.mjs` `/docs/index` entry の `slugs[]` に新 slug を追加 (2026-04-17 PR #304 で処理)、同時に `scripts/__tests__/parity_artifact_registry.test.mjs` の hardcoded 件数 (5 slugs → 6 slugs) を更新。**registry + test の 2 files 更新**が必要 (架空の "1-line diff" ではない)。
+  - 2026-04-17: +1 slug (`testops/insights/reports`) via mechanism PR (6 → 7 slugs, PR #314 content-side の前置き)
 - **scope lock**: 本 §5.3.2 entry は **`/docs/index` token の既存 artifact entry 再利用のみ** 対象。別 token (`http://google.com`、`http://example.com` 等) に対する新規 registry 登録は独立 §5.3.N として別途 security L2 gate を経由する。
 
 exception 追加は §5.2 と同じ security L2 gate (reviewer 承認 + plan への明示登録) を要求する。

--- a/scripts/__tests__/parity_artifact_registry.test.mjs
+++ b/scripts/__tests__/parity_artifact_registry.test.mjs
@@ -83,7 +83,7 @@ describe('parity_artifact_registry (inventory-driven exclusion)', () => {
     );
   });
 
-  it('excludes /docs/index for registered slugs (6 slugs in inventory)', () => {
+  it('excludes /docs/index for registered slugs (7 slugs in inventory)', () => {
     const registered = [
       'editing-tests/conditions/advanced-conditions-settings',
       'integrations/visual-validation/visual_validation_index',
@@ -91,6 +91,7 @@ describe('parity_artifact_registry (inventory-driven exclusion)', () => {
       'salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce',
       'salesforce-testing/salesforce-steps/sfdc-step-login',
       'testops/insights/dashboard',
+      'testops/insights/reports',
     ];
     for (const slug of registered) {
       assert.equal(

--- a/scripts/lib/parity_artifact_registry.mjs
+++ b/scripts/lib/parity_artifact_registry.mjs
@@ -35,6 +35,7 @@ export const ARTIFACT_REGISTRY = Object.freeze([
       'salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce',
       'salesforce-testing/salesforce-steps/sfdc-step-login',
       'testops/insights/dashboard',
+      'testops/insights/reports',
     ]),
     token: '/docs/index',
     reason: 'en-side-self-index-link-artifact',


### PR DESCRIPTION
## Summary

M2 mechanism PR — extends the existing §5.3.2 `/docs/index` artifact registry (`ARTIFACT_REGISTRY` in `scripts/lib/parity_artifact_registry.mjs`) by 1 slug (6 → 7). This unblocks content-level PR #314 (`claude/m2-wave3b2-testops-reports`) which mirrors the EN self-link pattern on `testops/insights/reports`.

**[PENDING REVIEWER APPROVAL — §5.3.2 L2 gate]**

## Precedent

PR #304 (`claude/m2-mechanism-docs-index-slug-extension`) established both the §5.3.2 carve-out and the mechanism-PR extension pattern (5 → 6 slugs, adding `use-agentic-test-automation-for-salesforce`). This PR reuses the identical pattern.

## Registry diff

```diff
--- a/scripts/lib/parity_artifact_registry.mjs
+++ b/scripts/lib/parity_artifact_registry.mjs
@@ -35,6 +35,7 @@ export const ARTIFACT_REGISTRY = Object.freeze([
       'salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce',
       'salesforce-testing/salesforce-steps/sfdc-step-login',
       'testops/insights/dashboard',
+      'testops/insights/reports',
     ]),
     token: '/docs/index',
```

## Test update

Hardcoded inventory count string `"(6 slugs in inventory)"` → `"(7 slugs in inventory)"` and `registered[]` array now includes the new slug.

```diff
--- a/scripts/__tests__/parity_artifact_registry.test.mjs
+++ b/scripts/__tests__/parity_artifact_registry.test.mjs
@@ -86,7 +86,7 @@ describe('parity_artifact_registry (inventory-driven exclusion)', () => {
-  it('excludes /docs/index for registered slugs (6 slugs in inventory)', () => {
+  it('excludes /docs/index for registered slugs (7 slugs in inventory)', () => {
     const registered = [
       ...
       'testops/insights/dashboard',
+      'testops/insights/reports',
     ];
```

## Plan update

Appended sub-bullet to existing §5.3.2 `follow-up mechanism PR` bullet (no shared-section edit — coordinates with parallel peer agents extending §5.3.1 / §5.3.3 / §5.3.4):

```diff
- **follow-up mechanism PR**: ... (PR #304 で処理) ...
+  - 2026-04-17: +1 slug (`testops/insights/reports`) via mechanism PR (6 → 7 slugs, PR #314 content-side の前置き)
```

## Expected runtime effect

After merge, `alignSegments({slug, coverage})` consults `isArtifactExcluded({slug: 'testops/insights/reports', token: '/docs/index'})` → `true`, so any `segment-token-gap` whose `missingTokens` contains `/docs/index` on that slug is suppressed without baseline entry.

This enables PR #314 to drop the EN `<a href="index.htm#selecting-a-branch">` self-link to plain text with zero baseline entry for the artifact.

## Verification

```
$ npm run test   → 2010/2010 pass (parity_artifact_registry inventory-driven exclusion now covers 7 slugs)
$ npm run lint   → 0 errors, 0 warnings in 288 files
$ npm run build  → 290 pages built, Complete!

$ npm run check:parity -- --slug=testops/insights/reports
  actionable: 1 ファイル (active: 0)
  問題種別:
    segment-missing: 2 件
    segment-extra: 2 件
    segment-untranslated: 1 件
  [frozen baseline] 凍結 drift (gate から除外): 5 件 / 1 ファイル
```

`parity-check-status.json` `issuesByType` for this slug: only `segment-missing` / `segment-extra` / `segment-untranslated` — **no `segment-token-gap`**, confirming the `/docs/index` artifact is correctly suppressed at runtime for the new slug.

## Scope & constraints observed

- Touched only `scripts/lib/parity_artifact_registry.mjs`, its co-located test, and the plan (sub-bullet append only).
- Did NOT touch `src/content/docs/**` (content-level changes are in PR #314).
- Did NOT touch `parity-baseline.json`.
- Scope lock per §5.3.2: restricted to `/docs/index` token reuse on the existing entry (not a new token / not a new §5.3.N).
- Did NOT claim §5.3.1, §5.3.3, or §5.3.4 (those are for parallel peer agents α / γ / δ).

## Do NOT merge

Awaiting reviewer gate approval.

## Test plan

- [x] `npm run test` → 2010/2010 pass
- [x] `npm run lint` → 0 errors, 0 warnings
- [x] `npm run build` → 290 pages built
- [x] `npm run check:parity -- --slug=testops/insights/reports` → 0 active, no `segment-token-gap`
- [ ] Reviewer approval for §5.3.2 slug-scope extension (L2 gate)