### PR TITLE
mechanism(parity): §5.3.3 new ja_omission_policy_registry (JA-side policy omission suppression)

### DIFF
--- a/docs/PARITY_GUIDE.md
+++ b/docs/PARITY_GUIDE.md
@@ -233,3 +233,48 @@ Phase 0 後の baseline は「未解決バグの backlog」になる。Phase 1 �
 | segment-inconclusive | tokenless-near-tie 等。自動判定の限界。手動確認 | 高 |
 
 Top 2 大物ファイルとロングテール (1-3 件ファイル 69 ファイル) はバッチ処理で返済する。
+
+## §5.3.3 JA-side intentional-omission policy (Tricentis removal-request registry)
+
+`[PENDING REVIEWER APPROVAL — §5.3.3 L2 gate]` — plan `docs/superpowers/plans/2026-04-16-m2-parity-burndown.md` §5.3.3 登録と対応。
+
+### 何に使うか
+
+`docs/WRITING_GUIDE.md §「原文から意図的に除外するコンテンツ」` で規定された **Tricentis からの削除依頼 policy** により、EN 原文にある特定 segment (pricing callout / changelog callout / `http://testim.io` intro URL 等) を JA 側で意図的に削除している slug の drift を quota-based で抑止する。
+
+既存 3 mechanism との棲み分け:
+
+| mechanism | 対象 | §5.3.3 との差異 |
+| --- | --- | --- |
+| `scripts/lib/source_sync_exclusions.mjs` | page-level EN-broken | JA 側意図的削除は対象外 (本 slug の EN は正常) |
+| `scripts/lib/parity_artifact_registry.mjs` (§5.3.2) | EN-side artifact token (`/docs/index` 等) | EN 側 artifact のみ。JA 削除は対象外 |
+| §5.3.1 FileOrFilePath | EN 抽出側 kind-mismatch | パーサ側問題。削除 policy は対象外 |
+| **§5.3.3 `ja_omission_policy_registry`** | **JA 側の意図的削除 (Tricentis removal-request policy)** | **新規** |
+
+### runtime 契約
+
+- `scripts/lib/ja_omission_policy_registry.mjs` が registry + `matchPolicy` + `createOmissionCoverage` + `NOOP_OMISSION_COVERAGE` を export する
+- `alignSegments(enSegments, jaSegments, { slug, coverage, omissionCoverage })` は diffs 生成後に `suppressJaOmissionDiffs` を呼び、registry と照合した上で quota 範囲内の diff を 1 件ずつ drop する
+- `check_source_parity.mjs` は run 単位で `createOmissionCoverage()` を 1 個生成し、全 slug の alignSegments に共有。最終的な `parity-check-status.json` の `debug.omissionCoverage` に snapshot を格納する
+
+### quota-based disambiguator の理由
+
+`overview/testim-overview` では 1 slug × `callout-body segment-missing` が 2 件出る (pricing + changelog)。同一 `(slug, issueType, segmentKind)` での複数 diff を個別に指すために、以下 3 候補から **quota-based** を採用:
+
+| 案 | 利点 | 欠点 | 採否 |
+| --- | --- | --- | --- |
+| (a) quota-based | 登録データが最小。EN 文面が変わっても安定 | 同種 drift の 3 件目が別原因で発生すると quota 内で誤抑止され得る (現実的には低確率) | **採用** |
+| (b) fingerprint-based | 厳密 | EN 文面更新で sha-256 変化。policy 意図 ("EN がどうなっても JA は出さない") と相反 | 不採用 |
+| (c) content-prefix match | 部分柔軟 | brittle / 監査しづらい / policy drift を許す | 不採用 |
+
+(a) の副作用 (同種 3 件目の誤抑止) は quota が尽きた時点で次の diff が通常通り surface するため、reviewer が気付いて registry entry を分割する運用で受容する。coverage snapshot の `exhaustedEntries` を監視対象にする。
+
+### entry 追加手順
+
+新 slug を追加する場合は `docs/WRITING_GUIDE.md §「原文から意図的に除外するコンテンツ」` 表の更新を先行条件とし、その上で以下を行う:
+
+1. `scripts/lib/ja_omission_policy_registry.mjs` の `JA_OMISSION_POLICY_REGISTRY` に entry を追加 (`slugs[]` / `issueTypes[]` / `segmentKinds` / `missingToken?` / `quota` / `reason` / `note` / `policySource` / `addedAt`)
+2. `scripts/__tests__/ja_omission_policy_registry.test.mjs` の inventory describe block に新 slug 用 assertion を追加
+3. plan §5.3.3 の initial inventory 行を更新
+
+registry 新規 token 追加は `§5.3.N` 新規 carve-out として reviewer L2 gate を経由する (本 §5.3.3 は Tricentis removal-request policy に scope lock)。

--- a/docs/superpowers/plans/2026-04-16-m2-parity-burndown.md
+++ b/docs/superpowers/plans/2026-04-16-m2-parity-burndown.md
@@ -209,6 +209,28 @@ P2-2 Wave 2 `use-agentic-test-automation-for-salesforce` で初検知。EN MadCa
 - **follow-up mechanism PR**: `scripts/lib/parity_artifact_registry.mjs` `/docs/index` entry の `slugs[]` に新 slug を追加 (2026-04-17 PR #304 で処理)、同時に `scripts/__tests__/parity_artifact_registry.test.mjs` の hardcoded 件数 (5 slugs → 6 slugs) を更新。**registry + test の 2 files 更新**が必要 (架空の "1-line diff" ではない)。
 - **scope lock**: 本 §5.3.2 entry は **`/docs/index` token の既存 artifact entry 再利用のみ** 対象。別 token (`http://google.com`、`http://example.com` 等) に対する新規 registry 登録は独立 §5.3.N として別途 security L2 gate を経由する。
 
+#### 5.3.3 JA-side intentional-omission policy (Tricentis removal-request registry)
+
+`[PENDING REVIEWER APPROVAL — §5.3.3 L2 gate]`
+
+M2 Wave 3 Batch 2 `overview/testim-overview` (PR #309) で初検知。`docs/WRITING_GUIDE.md §「原文から意図的に除外するコンテンツ」` で規定された **Tricentis 削除依頼 policy** により、EN 原文の特定 segment (pricing callout / changelog callout / `http://testim.io` intro URL) を JA 側で意図的に削除している。再追加は policy 違反 (commits `bf40dad`, `e5d9f88` で legal reasoning 記録済)。
+
+この JA-side 意図的除外は既存 3 mechanism のどれにも該当しない:
+- `scripts/lib/source_sync_exclusions.mjs` は EN-broken page を対象 (本 slug の EN は正常)
+- `scripts/lib/parity_artifact_registry.mjs` は EN-side artifact token のみ対象 (§5.3.2 の `/docs/index` self-link 等)
+- §5.3.1 FileOrFilePath は EN 抽出側 kind-mismatch を対象
+
+新 mechanism `scripts/lib/ja_omission_policy_registry.mjs` を追加し、alignSegments の post-filter で quota-based suppression を適用する。
+
+- **symptom pattern**: Tricentis 削除依頼対象の segment 群。具体的には (a) pricing callout、(b) changelog callout の派生 offset、(c) `http://testim.io` / `https://www.testim.io/pricing/` の intro URL 削除
+- **per-slug cap**: ≤ 4 件 (`segment-missing`/`segment-extra`/`segment-token-gap`/`section-structure-mismatch` の 4 drift type を合計。`testim-overview` は現状 4 entries に集約)
+- **disambiguator**: **quota-based** を採用。1 registry entry は `{slugs[], issueTypes[], segmentKinds, missingToken?, quota}` を持ち、alignSegments の post-filter で `(slug, issueType, segmentKind, missingTokens)` に match する diff を quota 範囲で 1 件ずつ drop する。fingerprint-based は EN 文面更新で sha-256 が変化しやすく、WRITING_GUIDE 除外が「EN 文面がどう変わっても JA は出さない」意思表示と相性が悪いため不採用。content-prefix は brittle で却下
+- **mitigation**: 新 registry module + runtime integration (`scripts/lib/source_parity_align.mjs` 末尾の `suppressJaOmissionDiffs`) + coverage aggregator (`createOmissionCoverage` / `NOOP_OMISSION_COVERAGE`) + full test coverage (`scripts/__tests__/ja_omission_policy_registry.test.mjs` 20 tests)
+- **registry scope lock**: 本 §5.3.3 entry は `docs/WRITING_GUIDE.md §「原文から意図的に除外するコンテンツ」` 対象 slug のみ。「翻訳省略したい」という agent 側要望で別 slug を追加するのは禁止。WRITING_GUIDE 除外表の更新が先行条件
+- **runtime integration**: `alignSegments({slug, omissionCoverage})` が diffs 生成後に `suppressJaOmissionDiffs` を呼ぶ。coverage snapshot (`snapshot().quotaUsage` / `exhaustedEntries`) は `parity-check-status.json` の `debug.omissionCoverage` に含まれ、後続 monitoring で quota 尽きに気付けるようにする
+- **initial inventory (2026-04-17)**: `overview/testim-overview` に 4 entries を登録。合計 quota = 5 で `parity-baseline.json` の該当 5 件を全て抑止する
+- **follow-up**: 本 PR merge 後、PR #309 側で baseline 再生成 (5 → 0) を実施
+
 exception 追加は §5.2 と同じ security L2 gate (reviewer 承認 + plan への明示登録) を要求する。
 
 ### 5.2 Source-first mechanical exceptions (M4 policy 補足)

--- a/scripts/__tests__/ja_omission_policy_registry.test.mjs
+++ b/scripts/__tests__/ja_omission_policy_registry.test.mjs
@@ -1,0 +1,374 @@
+// scripts/__tests__/ja_omission_policy_registry.test.mjs
+/**
+ * ja_omission_policy_registry の shape / empty-safe / inventory / runtime
+ * coverage aggregator / alignSegments 統合を検証する。
+ *
+ * 本 registry は §5.3.3 で新設した JA-side intentional-omission suppression
+ * mechanism で、alignSegments({slug, omissionCoverage}) から consume される。
+ * quota-based disambiguator を採用しているため、quota 範囲内の diff は抑止
+ * され、quota を超えた diff は通常通り surface される。
+ */
+import { before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+let matchPolicy;
+let registryEntries;
+let createOmissionCoverage;
+let NOOP_OMISSION_COVERAGE;
+let alignSegments;
+let createSegment;
+
+before(async () => {
+  ({
+    matchPolicy,
+    registryEntries,
+    createOmissionCoverage,
+    NOOP_OMISSION_COVERAGE,
+  } = await import('../lib/ja_omission_policy_registry.mjs'));
+  ({ alignSegments } = await import('../lib/source_parity_align.mjs'));
+  ({ createSegment } = await import('../lib/source_parity_segments_shared.mjs'));
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSeg(sectionPath, kind, segmentIndex, rawText) {
+  return createSegment({ sectionPath, kind, segmentIndex, rawText });
+}
+
+function makeHeading(sectionPath, segmentIndex, rawText) {
+  return makeSeg(sectionPath, 'heading', segmentIndex, rawText);
+}
+
+// ---------------------------------------------------------------------------
+// shape / empty-safe
+// ---------------------------------------------------------------------------
+
+describe('ja_omission_policy_registry (shape / empty-safe)', () => {
+  it('matchPolicy returns null for unregistered (slug, issueType)', () => {
+    assert.equal(
+      matchPolicy({
+        slug: 'nonexistent/slug',
+        issueType: 'segment-missing',
+        segmentKind: 'paragraph',
+      }),
+      null,
+    );
+  });
+
+  it('matchPolicy returns null when slug matches but issueType does not', () => {
+    assert.equal(
+      matchPolicy({
+        slug: 'overview/testim-overview',
+        issueType: 'segment-untranslated',
+        segmentKind: 'paragraph',
+      }),
+      null,
+    );
+  });
+
+  it('registry entries have required shape', () => {
+    for (const e of registryEntries()) {
+      assert.ok(Array.isArray(e.slugs) && e.slugs.length > 0, 'slugs must be non-empty array');
+      assert.ok(
+        Array.isArray(e.issueTypes) && e.issueTypes.length > 0,
+        'issueTypes must be non-empty array',
+      );
+      assert.ok(
+        e.segmentKinds === null || (Array.isArray(e.segmentKinds) && e.segmentKinds.length > 0),
+        'segmentKinds must be null or non-empty array',
+      );
+      assert.ok(
+        e.missingToken === null || (typeof e.missingToken === 'string' && e.missingToken.length > 0),
+        'missingToken must be null or non-empty string',
+      );
+      assert.ok(Number.isInteger(e.quota) && e.quota > 0, 'quota must be positive integer');
+      assert.ok(typeof e.reason === 'string' && e.reason.length > 0, 'reason must be non-empty string');
+      assert.ok(typeof e.note === 'string' && e.note.length > 0, 'note must be non-empty string');
+      assert.ok(typeof e.policySource === 'string' && e.policySource.length > 0,
+        'policySource must be non-empty string');
+      assert.ok(/^\d{4}-\d{2}-\d{2}$/.test(e.addedAt), 'addedAt must be YYYY-MM-DD');
+    }
+  });
+
+  it('registry entries are frozen (immutable)', () => {
+    for (const e of registryEntries()) {
+      assert.ok(Object.isFrozen(e), 'entry must be frozen');
+      assert.ok(Object.isFrozen(e.slugs), 'slugs must be frozen');
+      assert.ok(Object.isFrozen(e.issueTypes), 'issueTypes must be frozen');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inventory — testim-overview initial entries (2026-04-17 baseline)
+// ---------------------------------------------------------------------------
+
+describe('ja_omission_policy_registry (inventory — testim-overview)', () => {
+  it('covers pricing/changelog callout-body segment-missing (quota=2)', () => {
+    const entry = matchPolicy({
+      slug: 'overview/testim-overview',
+      issueType: 'segment-missing',
+      segmentKind: 'callout-body',
+    });
+    assert.ok(entry !== null, 'policy must match');
+    assert.equal(entry.quota, 2);
+    assert.equal(entry.reason, 'tricentis-pricing-changelog-callout-removal');
+  });
+
+  it('covers changelog callout-body segment-extra (quota=1)', () => {
+    const entry = matchPolicy({
+      slug: 'overview/testim-overview',
+      issueType: 'segment-extra',
+      segmentKind: 'callout-body',
+    });
+    assert.ok(entry !== null);
+    assert.equal(entry.quota, 1);
+    assert.equal(entry.reason, 'tricentis-changelog-callout-offset-remnant');
+  });
+
+  it('covers testim.io URL segment-token-gap (quota=1)', () => {
+    const entry = matchPolicy({
+      slug: 'overview/testim-overview',
+      issueType: 'segment-token-gap',
+      segmentKind: 'paragraph',
+      missingTokens: ['http://testim.io'],
+    });
+    assert.ok(entry !== null);
+    assert.equal(entry.missingToken, 'http://testim.io');
+    assert.equal(entry.quota, 1);
+  });
+
+  it('does NOT match segment-token-gap with different missing token', () => {
+    assert.equal(
+      matchPolicy({
+        slug: 'overview/testim-overview',
+        issueType: 'segment-token-gap',
+        segmentKind: 'paragraph',
+        missingTokens: ['http://example.com'],
+      }),
+      null,
+    );
+  });
+
+  it('covers the derivative section-structure-mismatch (quota=1, segmentKinds=null)', () => {
+    const entry = matchPolicy({
+      slug: 'overview/testim-overview',
+      issueType: 'section-structure-mismatch',
+      segmentKind: null,
+    });
+    assert.ok(entry !== null);
+    assert.equal(entry.segmentKinds, null);
+    assert.equal(entry.quota, 1);
+  });
+
+  it('does NOT match for non-registered slug even with matching issueType', () => {
+    assert.equal(
+      matchPolicy({
+        slug: 'overview/nonexistent',
+        issueType: 'segment-missing',
+        segmentKind: 'callout-body',
+      }),
+      null,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createOmissionCoverage — quota + hit aggregation
+// ---------------------------------------------------------------------------
+
+describe('createOmissionCoverage (quota + aggregation)', () => {
+  it('starts empty — consume always returns false for unregistered inputs', () => {
+    const c = createOmissionCoverage();
+    const s0 = c.snapshot();
+    assert.equal(s0.matchedHits, 0);
+    assert.equal(
+      c.consume({
+        slug: 'nonexistent/slug',
+        issueType: 'segment-missing',
+        segmentKind: 'paragraph',
+      }),
+      false,
+    );
+    assert.equal(c.snapshot().matchedHits, 0);
+  });
+
+  it('consumes callout-body segment-missing up to quota=2, then stops', () => {
+    const c = createOmissionCoverage();
+    const call = () =>
+      c.consume({
+        slug: 'overview/testim-overview',
+        issueType: 'segment-missing',
+        segmentKind: 'callout-body',
+      });
+    assert.equal(call(), true, 'first consume within quota');
+    assert.equal(call(), true, 'second consume within quota');
+    assert.equal(call(), false, 'third consume exceeds quota=2');
+    const s = c.snapshot();
+    assert.equal(s.matchedHits, 2);
+    assert.equal(s.bySlug['overview/testim-overview'], 2);
+    assert.equal(s.byIssueType['segment-missing'], 2);
+    assert.equal(s.byReason['tricentis-pricing-changelog-callout-removal'], 2);
+    assert.ok(s.exhaustedEntries.includes('tricentis-pricing-changelog-callout-removal'));
+  });
+
+  it('tracks per-entry quotaUsage including untouched entries', () => {
+    const c = createOmissionCoverage();
+    c.consume({
+      slug: 'overview/testim-overview',
+      issueType: 'segment-token-gap',
+      segmentKind: 'paragraph',
+      missingTokens: ['http://testim.io'],
+    });
+    const s = c.snapshot();
+    const tokenGapEntry = s.quotaUsage.find(
+      (u) => u.reason === 'tricentis-testim-io-url-removal',
+    );
+    assert.ok(tokenGapEntry);
+    assert.equal(tokenGapEntry.used, 1);
+    assert.equal(tokenGapEntry.remaining, 0);
+
+    const pricingEntry = s.quotaUsage.find(
+      (u) => u.reason === 'tricentis-pricing-changelog-callout-removal',
+    );
+    assert.ok(pricingEntry);
+    assert.equal(pricingEntry.used, 0);
+    assert.equal(pricingEntry.remaining, 2);
+  });
+
+  it('atomicity: consume=false does not advance quota when match fails', () => {
+    const c = createOmissionCoverage();
+    // wrong missingToken → no match → no quota decrement
+    const r = c.consume({
+      slug: 'overview/testim-overview',
+      issueType: 'segment-token-gap',
+      segmentKind: 'paragraph',
+      missingTokens: ['/docs/index'],
+    });
+    assert.equal(r, false);
+    const entry = c
+      .snapshot()
+      .quotaUsage.find((u) => u.reason === 'tricentis-testim-io-url-removal');
+    assert.equal(entry.used, 0, 'quota must not decrement on mismatch');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NOOP_OMISSION_COVERAGE — default for non-integrated callers
+// ---------------------------------------------------------------------------
+
+describe('NOOP_OMISSION_COVERAGE', () => {
+  it('consume always returns false', () => {
+    assert.equal(
+      NOOP_OMISSION_COVERAGE.consume({
+        slug: 'overview/testim-overview',
+        issueType: 'segment-missing',
+        segmentKind: 'callout-body',
+      }),
+      false,
+    );
+  });
+
+  it('snapshot returns 0 hits with quotaUsage populated from registry', () => {
+    const s = NOOP_OMISSION_COVERAGE.snapshot();
+    assert.equal(s.matchedHits, 0);
+    assert.equal(s.registryEntries, registryEntries().length);
+    assert.ok(Array.isArray(s.quotaUsage));
+    assert.equal(s.quotaUsage.length, registryEntries().length);
+    for (const u of s.quotaUsage) {
+      assert.equal(u.used, 0);
+      assert.equal(u.remaining, u.quota);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// alignSegments integration — §5.3.3 suppression in practice
+// ---------------------------------------------------------------------------
+
+describe('alignSegments — §5.3.3 JA omission policy integration', () => {
+  it('suppresses segment-missing callout-body in overview/testim-overview (quota-based)', () => {
+    // EN には callout-body が 2 つ、JA には 0。通常なら segment-missing × 2 が
+    // 出るが registry の quota=2 で両方抑止される。
+    const en = [
+      makeSeg('', 'paragraph', 0, 'Intro paragraph.'),
+      makeSeg('', 'callout-body', 0, 'Pricing information removed.'),
+      makeSeg('', 'callout-body', 1, 'Changelog callout body.'),
+    ];
+    const ja = [makeSeg('', 'paragraph', 0, '紹介段落')];
+    const coverage = createOmissionCoverage();
+    const result = alignSegments(en, ja, {
+      slug: 'overview/testim-overview',
+      omissionCoverage: coverage,
+    });
+    const missing = result.diffs.filter((d) => d.type === 'segment-missing');
+    assert.equal(
+      missing.length,
+      0,
+      `callout-body segment-missing should be suppressed (got ${missing.length})`,
+    );
+    const snap = coverage.snapshot();
+    assert.ok(snap.matchedHits >= 2, 'coverage should record both hits');
+    assert.equal(snap.bySlug['overview/testim-overview'] >= 2, true);
+  });
+
+  it('does NOT suppress segment-missing for unregistered slug', () => {
+    const en = [
+      makeSeg('', 'paragraph', 0, 'Intro.'),
+      makeSeg('', 'callout-body', 0, 'Callout body.'),
+    ];
+    const ja = [makeSeg('', 'paragraph', 0, '紹介段落')];
+    const coverage = createOmissionCoverage();
+    const result = alignSegments(en, ja, {
+      slug: 'unregistered/slug',
+      omissionCoverage: coverage,
+    });
+    const missing = result.diffs.filter((d) => d.type === 'segment-missing');
+    assert.ok(missing.length >= 1, 'unregistered slug should emit segment-missing');
+    assert.equal(coverage.snapshot().matchedHits, 0);
+  });
+
+  it('suppresses section-structure-mismatch (segmentKinds=null)', () => {
+    // EN: p → callout → p → ul → callout
+    // JA: p → p → ul → callout
+    const en = [
+      makeSeg('', 'paragraph', 0, 'Intro paragraph with http://testim.io.'),
+      makeSeg('', 'callout-body', 0, 'Pricing callout.'),
+      makeSeg('', 'paragraph', 1, 'Second EN paragraph.'),
+      makeSeg('', 'unordered-list-item', 0, 'list 1'),
+      makeSeg('', 'callout-body', 1, 'Changelog callout.'),
+    ];
+    const ja = [
+      makeSeg('', 'paragraph', 0, '紹介段落'),
+      makeSeg('', 'paragraph', 1, '2 つ目の段落'),
+      makeSeg('', 'unordered-list-item', 0, 'リスト 1'),
+      makeSeg('', 'callout-body', 0, '変更履歴 callout。'),
+    ];
+    const coverage = createOmissionCoverage();
+    const result = alignSegments(en, ja, {
+      slug: 'overview/testim-overview',
+      omissionCoverage: coverage,
+    });
+    const structure = result.diffs.filter((d) => d.type === 'section-structure-mismatch');
+    assert.equal(structure.length, 0, 'structure mismatch should be suppressed');
+    const snap = coverage.snapshot();
+    const hits = snap.byIssueType['section-structure-mismatch'] ?? 0;
+    assert.equal(hits, 1);
+  });
+
+  it('default NOOP_OMISSION_COVERAGE (no option) does not suppress anything', () => {
+    const en = [
+      makeSeg('', 'paragraph', 0, 'Intro.'),
+      makeSeg('', 'callout-body', 0, 'Pricing callout.'),
+    ];
+    const ja = [makeSeg('', 'paragraph', 0, '紹介段落')];
+    const result = alignSegments(en, ja, { slug: 'overview/testim-overview' });
+    const missing = result.diffs.filter((d) => d.type === 'segment-missing');
+    assert.ok(
+      missing.length >= 1,
+      'without omissionCoverage option, suppression is no-op and diffs still surface',
+    );
+  });
+});

--- a/scripts/check_source_parity.mjs
+++ b/scripts/check_source_parity.mjs
@@ -50,6 +50,7 @@ import { checkPageCoverage, checkSinglePageSnapshot } from './lib/source_parity_
 import { buildRunScope, validateRunLinkage } from './lib/source_sync_health.mjs';
 import { createMaskCoverage, maskSegmentText } from './lib/parity_glossary_mask.mjs';
 import { createArtifactCoverage } from './lib/parity_artifact_registry.mjs';
+import { createOmissionCoverage } from './lib/ja_omission_policy_registry.mjs';
 export { buildRunScope };
 
 const SNAPSHOTS_DIR = path.join(ROOT_DIR, 'snapshots', 'en', 'content');
@@ -382,6 +383,11 @@ export async function checkSourceParity({
   // 集計する run 単位 aggregator。Phase 4 で新設。
   const artifactCoverage = createArtifactCoverage();
 
+  // debug.omissionCoverage: §5.3.3 JA-side intentional-omission policy 抑止を
+  // 集計する run 単位 aggregator。`ja_omission_policy_registry` と照合した
+  // quota-based 抑止 hit を記録する。
+  const omissionCoverage = createOmissionCoverage();
+
   for (const filePath of allFiles) {
     const fileSlug = filePathToSlug(filePath);
     if (resolvedSlug && fileSlug !== resolvedSlug) {
@@ -511,6 +517,7 @@ export async function checkSourceParity({
             alignment = alignSegments(enSegments, jaSegments, {
               slug: fileSlug,
               coverage: artifactCoverage,
+              omissionCoverage,
             });
           } catch (e) {
             console.error(
@@ -745,6 +752,7 @@ export async function checkSourceParity({
     debug: {
       maskCoverage: maskCoverage.toJSON(),
       artifactCoverage: artifactCoverage.snapshot(),
+      omissionCoverage: omissionCoverage.snapshot(),
     },
   };
 

--- a/scripts/lib/ja_omission_policy_registry.mjs
+++ b/scripts/lib/ja_omission_policy_registry.mjs
@@ -1,0 +1,295 @@
+// scripts/lib/ja_omission_policy_registry.mjs
+/**
+ * JA-side intentional-omission policy registry + runtime coverage aggregator.
+ *
+ * `docs/WRITING_GUIDE.md` §「原文から意図的に除外するコンテンツ」で規定された
+ * Tricentis 削除依頼 policy により、EN 原文にある特定 segment を JA 側で
+ * 意図的に削除している。そのため alignSegments は以下 4 種の "本来期待される"
+ * drift を出す:
+ *
+ *   - `segment-missing`            (EN callout / paragraph が JA に無い)
+ *   - `segment-extra`              (JA の placeholder callout が EN に無い)
+ *   - `segment-token-gap`          (削除 segment 内の URL token が JA に無い)
+ *   - `section-structure-mismatch` (上記の派生として kind-multiset が一致しない)
+ *
+ * これらは content 修正で解消不可能 (re-add は policy 違反)。既存 mechanism は
+ * EN-side artifact (`parity_artifact_registry`) や EN-broken page
+ * (`source_sync_exclusions`) を対象としており、「JA 側の意図的除外」は
+ * covered されていなかった。本 registry が §5.3.3 として両者の gap を埋める。
+ *
+ * ## 契約
+ *
+ *   - registry は凍結された配列。entry 単位で `slugs[]`, `issueTypes[]`,
+ *     `segmentKinds`, optional `missingToken`, `quota` を持つ。
+ *   - glob / regex は使わない。entry 側が許容する具体的条件を列挙する。
+ *   - `matchPolicy({ slug, issueType, segmentKind, missingTokens })` は副作用
+ *     ゼロの純粋関数。マッチしたときは entry 参照を返し、それ以外は null。
+ *   - `createOmissionCoverage()` は run 単位で 1 個だけ生成する stateful
+ *     aggregator。`consume({slug, issueType, segmentKind, missingTokens})` は
+ *     registry 照合 + quota 減算 + hit 記録を 1 つの atomic 動作で行い、
+ *     quota 残があれば `true`、尽きたか match しなければ `false` を返す。
+ *   - quota は aggregator の内部 state (`_remaining` map) としてのみ減算する。
+ *     `ARTIFACT_REGISTRY` 本体は Object.freeze 済で不変を保つ。
+ *   - `NOOP_OMISSION_COVERAGE` は test / 呼び出し側で aggregator を差し込め
+ *     ないときのデフォルト。`consume()` は常に `false` を返す。
+ *
+ * ## 曖昧性の解消 (disambiguator design — quota-based)
+ *
+ * `overview/testim-overview` では 1 slug 内で
+ * `callout-body segment-missing` が 2 件出る。3 種の候補から quota-based を
+ * 採用した:
+ *
+ *   - (a) **quota-based** (採用): `{slug, issueType, segmentKind}` の組で
+ *     最大 N 件まで抑止する。登録データは最小で、ハッシュ計算も EN 側 segment
+ *     内容の安定性も要求しない。initial scope では 1 slug × 2 quota で十分。
+ *   - (b) fingerprint-based: entry に `enSegmentFingerprint` を持たせ exact
+ *     match する。EN 側 raw text が変わると sha-256 が変化してしまうため、
+ *     WRITING_GUIDE 除外は「EN 文面がどう変わっても JA は出さない」意思表示で
+ *     あることと相性が悪い。
+ *   - (c) content-prefix match: 部分文字列 / regex。brittle で policy drift を
+ *     許す危険があるため却下。
+ *
+ * 採用 (a) の副作用として「本来抑止されるべきで無い 3 件目の drift」も
+ * quota 尽きるまで抑止され得るが、現実には同種 drift がポリシー由来以外で
+ * 同一 slug に同時発生する確率は低い。もし発生したら 3 件目は drift として
+ * 表面化し、reviewer が quota 増やすか別 slug に分離するかを判断する。
+ *
+ * Spec: docs/superpowers/plans/2026-04-16-m2-parity-burndown.md §5.3.3
+ *
+ * @module ja_omission_policy_registry
+ */
+
+/**
+ * initial entries。§5.3.3 reviewer gate 承認を前提に登録する。
+ *
+ * `overview/testim-overview` の 3 件の Tricentis policy omission:
+ *   1. pricing callout 削除 (EN callout-body idx 0)
+ *   2. changelog callout のオフセット由来 missing (EN callout-body idx 1)
+ *      + JA 変更履歴 callout の orphan (segment-extra)
+ *   3. http://testim.io intro URL 削除 (EN paragraph idx 0 の token-gap)
+ *
+ * これら 3 件に加えて、上記の 3 件が派生的に引き起こす 1 件の
+ * `section-structure-mismatch` も合わせて計 5 baseline entries を抑止する。
+ */
+export const JA_OMISSION_POLICY_REGISTRY = Object.freeze([
+  Object.freeze({
+    slugs: Object.freeze(['overview/testim-overview']),
+    issueTypes: Object.freeze(['segment-missing']),
+    segmentKinds: Object.freeze(['callout-body']),
+    missingToken: null,
+    quota: 2,
+    reason: 'tricentis-pricing-changelog-callout-removal',
+    note:
+      'EN の pricing / changelog callout は WRITING_GUIDE §「原文から意図的に ' +
+      '除外するコンテンツ」により JA 側で意図的に削除 (2 件 quota)',
+    expectedIssueType: 'segment-missing',
+    policySource: 'docs/WRITING_GUIDE.md §原文から意図的に除外するコンテンツ',
+    addedAt: '2026-04-17',
+    linkedIssue: null,
+  }),
+  Object.freeze({
+    slugs: Object.freeze(['overview/testim-overview']),
+    issueTypes: Object.freeze(['segment-extra']),
+    segmentKinds: Object.freeze(['callout-body']),
+    missingToken: null,
+    quota: 1,
+    reason: 'tricentis-changelog-callout-offset-remnant',
+    note:
+      'JA の「変更履歴」callout は EN changelog callout の翻訳版だが、EN 側 ' +
+      'callout 2 件 → JA 側 1 件のオフセットで LCS が対応付けできず segment- ' +
+      'extra として表面化する',
+    expectedIssueType: 'segment-extra',
+    policySource: 'docs/WRITING_GUIDE.md §原文から意図的に除外するコンテンツ',
+    addedAt: '2026-04-17',
+    linkedIssue: null,
+  }),
+  Object.freeze({
+    slugs: Object.freeze(['overview/testim-overview']),
+    issueTypes: Object.freeze(['segment-token-gap']),
+    segmentKinds: Object.freeze(['paragraph']),
+    missingToken: 'http://testim.io',
+    quota: 1,
+    reason: 'tricentis-testim-io-url-removal',
+    note:
+      'EN の http://testim.io intro URL は WRITING_GUIDE §「原文から意図的に ' +
+      '除外するコンテンツ」により JA 側で意図的に削除',
+    expectedIssueType: 'segment-token-gap',
+    policySource: 'docs/WRITING_GUIDE.md §原文から意図的に除外するコンテンツ',
+    addedAt: '2026-04-17',
+    linkedIssue: null,
+  }),
+  Object.freeze({
+    slugs: Object.freeze(['overview/testim-overview']),
+    issueTypes: Object.freeze(['section-structure-mismatch']),
+    segmentKinds: null,
+    missingToken: null,
+    quota: 1,
+    reason: 'tricentis-callout-removal-structure-derivative',
+    note:
+      '上記 pricing / changelog callout 削除の派生として kind-multiset が ' +
+      'ズレる (EN=[p → callout → p → ul → callout] vs JA=[p → p → ul → callout])',
+    expectedIssueType: 'section-structure-mismatch',
+    policySource: 'docs/WRITING_GUIDE.md §原文から意図的に除外するコンテンツ',
+    addedAt: '2026-04-17',
+    linkedIssue: null,
+  }),
+]);
+
+/**
+ * 入力された diff 候補に一致する registry entry (の index) を返す。一致しない
+ * なら -1。純粋関数 — 副作用ゼロ。
+ *
+ * match ルール:
+ *   - `entry.slugs` に slug が含まれる
+ *   - `entry.issueTypes` に issueType が含まれる
+ *   - `entry.segmentKinds` が null でない場合、segmentKind が含まれる
+ *   - `entry.missingToken` が指定されている場合、`missingTokens` 配列に含まれる
+ *
+ * @param {{slug: string, issueType: string, segmentKind?: string|null, missingTokens?: string[]|null}} params
+ * @returns {number} entry index (-1 if no match)
+ */
+function findMatchingEntryIndex({ slug, issueType, segmentKind, missingTokens }) {
+  for (let i = 0; i < JA_OMISSION_POLICY_REGISTRY.length; i++) {
+    const entry = JA_OMISSION_POLICY_REGISTRY[i];
+    if (!entry.slugs.includes(slug)) continue;
+    if (!entry.issueTypes.includes(issueType)) continue;
+    if (entry.segmentKinds !== null) {
+      if (typeof segmentKind !== 'string') continue;
+      if (!entry.segmentKinds.includes(segmentKind)) continue;
+    }
+    if (entry.missingToken !== null) {
+      if (!Array.isArray(missingTokens)) continue;
+      if (!missingTokens.includes(entry.missingToken)) continue;
+    }
+    return i;
+  }
+  return -1;
+}
+
+/**
+ * 入力された diff 候補に一致する registry entry を返す (読み取り専用)。
+ * quota は減算しない — read-only な policy lookup。
+ *
+ * @param {{slug: string, issueType: string, segmentKind?: string|null, missingTokens?: string[]|null}} params
+ * @returns {object|null}
+ */
+export function matchPolicy(params) {
+  const idx = findMatchingEntryIndex(params);
+  if (idx < 0) return null;
+  return JA_OMISSION_POLICY_REGISTRY[idx];
+}
+
+/**
+ * registry の shallow copy を返す。呼び出し側で mutate しても registry 本体は
+ * 影響を受けない (配列コピーのみ。entry 自体は Object.freeze 済み)。
+ *
+ * @returns {ReadonlyArray<object>}
+ */
+export function registryEntries() {
+  return JA_OMISSION_POLICY_REGISTRY.slice();
+}
+
+/**
+ * runtime coverage aggregator。run 単位で 1 個生成し、quota-based 抑止が
+ * 発火したときに consume する。snapshot() は以下を返す:
+ *   - registryEntries:  registry の entry 数
+ *   - matchedHits:      consume が true を返した累計回数
+ *   - bySlug:           { [slug]: count }
+ *   - byIssueType:      { [issueType]: count }
+ *   - byReason:         { [reason]: count }
+ *   - quotaUsage:       [{ reason, slugs, quota, used, remaining }]
+ *   - exhaustedEntries: quota を使い切った entry の reason 配列
+ *
+ * `consume({slug, issueType, segmentKind, missingTokens})` は atomic:
+ *   1. registry を照合して entry を見つける
+ *   2. 見つかり、かつ quota 残があれば: 減算して hit 記録、`true` を返す
+ *   3. 見つからない、または quota 尽き: 何もせず `false` を返す
+ *
+ * 呼び出し側は `consume` が true のとき該当 diff を suppress する。
+ *
+ * @returns {{
+ *   consume: (params: {slug: string, issueType: string, segmentKind?: string|null, missingTokens?: string[]|null}) => boolean,
+ *   snapshot: () => {
+ *     registryEntries: number,
+ *     matchedHits: number,
+ *     bySlug: Record<string, number>,
+ *     byIssueType: Record<string, number>,
+ *     byReason: Record<string, number>,
+ *     quotaUsage: Array<{reason: string, slugs: string[], quota: number, used: number, remaining: number}>,
+ *     exhaustedEntries: string[],
+ *   },
+ * }}
+ */
+export function createOmissionCoverage() {
+  const remaining = JA_OMISSION_POLICY_REGISTRY.map((e) => e.quota);
+  const hits = [];
+
+  return {
+    consume({ slug, issueType, segmentKind, missingTokens }) {
+      const idx = findMatchingEntryIndex({ slug, issueType, segmentKind, missingTokens });
+      if (idx < 0) return false;
+      if (remaining[idx] <= 0) return false;
+      remaining[idx] -= 1;
+      const entry = JA_OMISSION_POLICY_REGISTRY[idx];
+      hits.push({
+        slug,
+        issueType,
+        segmentKind: segmentKind ?? null,
+        reason: entry.reason,
+      });
+      return true;
+    },
+    snapshot() {
+      const bySlug = {};
+      const byIssueType = {};
+      const byReason = {};
+      for (const h of hits) {
+        bySlug[h.slug] = (bySlug[h.slug] ?? 0) + 1;
+        byIssueType[h.issueType] = (byIssueType[h.issueType] ?? 0) + 1;
+        byReason[h.reason] = (byReason[h.reason] ?? 0) + 1;
+      }
+      const quotaUsage = JA_OMISSION_POLICY_REGISTRY.map((entry, i) => ({
+        reason: entry.reason,
+        slugs: entry.slugs.slice(),
+        quota: entry.quota,
+        used: entry.quota - remaining[i],
+        remaining: remaining[i],
+      }));
+      const exhaustedEntries = quotaUsage
+        .filter((u) => u.remaining === 0)
+        .map((u) => u.reason);
+      return {
+        registryEntries: JA_OMISSION_POLICY_REGISTRY.length,
+        matchedHits: hits.length,
+        bySlug,
+        byIssueType,
+        byReason,
+        quotaUsage,
+        exhaustedEntries,
+      };
+    },
+  };
+}
+
+/**
+ * coverage を集計したくない呼び出し側が使う no-op aggregator。
+ * `consume()` は常に `false` を返すため、diff 抑止は発火しない。
+ */
+export const NOOP_OMISSION_COVERAGE = Object.freeze({
+  consume: () => false,
+  snapshot: () => ({
+    registryEntries: JA_OMISSION_POLICY_REGISTRY.length,
+    matchedHits: 0,
+    bySlug: {},
+    byIssueType: {},
+    byReason: {},
+    quotaUsage: JA_OMISSION_POLICY_REGISTRY.map((entry) => ({
+      reason: entry.reason,
+      slugs: entry.slugs.slice(),
+      quota: entry.quota,
+      used: 0,
+      remaining: entry.quota,
+    })),
+    exhaustedEntries: [],
+  }),
+});

--- a/scripts/lib/source_parity_align.mjs
+++ b/scripts/lib/source_parity_align.mjs
@@ -41,6 +41,7 @@ import { compareSectionStructure } from './source_parity_structure.mjs';
 import { classifySegment } from './parity_glossary_mask.mjs';
 import { normalizeSegmentTokens } from './parity_normalize.mjs';
 import { isArtifactExcluded, NOOP_COVERAGE } from './parity_artifact_registry.mjs';
+import { NOOP_OMISSION_COVERAGE } from './ja_omission_policy_registry.mjs';
 
 const GATE_KIND_SET = new Set(GATE_ELIGIBLE_KINDS);
 
@@ -644,13 +645,27 @@ function alignSection(enSection, jaSection, crossSectionInfo, artifactCtx) {
  *
  * `options.coverage` は抑止 hit の runtime aggregator。省略時は `NOOP_COVERAGE`。
  *
+ * `options.omissionCoverage` は §5.3.3 で新設した JA-side intentional-omission
+ * 抑止の runtime aggregator。registry (`ja_omission_policy_registry`) と照合し、
+ * Tricentis policy による JA 側意図的削除に起因する drift (segment-missing /
+ * segment-extra / segment-token-gap / section-structure-mismatch) を quota
+ * 範囲内で抑止する。省略時は `NOOP_OMISSION_COVERAGE` で no-op。
+ *
  * @param {Segment[]} enSegments
  * @param {Segment[]} jaSegments
- * @param {{slug: string, coverage?: {record: Function, snapshot: Function}}} [options]
+ * @param {{
+ *   slug: string,
+ *   coverage?: {record: Function, snapshot: Function},
+ *   omissionCoverage?: {consume: Function, snapshot: Function},
+ * }} [options]
  * @returns {AlignResult}
  */
 export function alignSegments(enSegments, jaSegments, options = {}) {
-  const { slug, coverage = NOOP_COVERAGE } = options;
+  const {
+    slug,
+    coverage = NOOP_COVERAGE,
+    omissionCoverage = NOOP_OMISSION_COVERAGE,
+  } = options;
   if (typeof slug !== 'string' || slug.length === 0) {
     throw new Error('alignSegments: slug option is required');
   }
@@ -702,14 +717,19 @@ export function alignSegments(enSegments, jaSegments, options = {}) {
     for (const diff of sectionDiffs) diffs.push(diff);
   }
 
+  // §5.3.3: JA-side intentional-omission policy suppression. registry と照合
+  // した上で quota 範囲内の diff を 1 件ずつ consume して drop する。quota が
+  // 尽きる、または registry に一致しない diff は全てそのまま残す。
+  const filteredDiffs = suppressJaOmissionDiffs(diffs, slug, omissionCoverage);
+
   const ambiguousTokenlessSwap = detectAmbiguousAdjacentTokenlessSwap(
     enSections,
     jaSections,
-    diffs,
+    filteredDiffs,
   );
   if (ambiguousTokenlessSwap) {
     return {
-      diffs,
+      diffs: filteredDiffs,
       sectionsAligned: enSections.length,
       sectionsCompared: enSections.length,
       inconclusive: true,
@@ -729,7 +749,7 @@ export function alignSegments(enSegments, jaSegments, options = {}) {
   }
 
   return {
-    diffs,
+    diffs: filteredDiffs,
     sectionsAligned: enSections.length,
     sectionsCompared: enSections.length,
     inconclusive: false,
@@ -737,6 +757,34 @@ export function alignSegments(enSegments, jaSegments, options = {}) {
     inconclusiveMeta: null,
     inconclusiveReason: null,
   };
+}
+
+/**
+ * §5.3.3 JA-side omission suppression。各 diff に対して registry 照合と
+ * quota 減算を aggregator の `consume()` に委ねる (1 つの atomic 動作)。
+ *
+ *   - diff が registry に一致かつ quota 残あり: 減算して drop
+ *   - diff が一致しない、または quota 尽きた: そのまま残す
+ *
+ * 純粋関数的に新配列を返す (入力 `diffs` は mutate しない)。
+ *
+ * @param {object[]} diffs
+ * @param {string} slug
+ * @param {{consume: Function, snapshot: Function}} omissionCoverage
+ * @returns {object[]}
+ */
+function suppressJaOmissionDiffs(diffs, slug, omissionCoverage) {
+  const kept = [];
+  for (const diff of diffs) {
+    const suppressed = omissionCoverage.consume({
+      slug,
+      issueType: diff.type,
+      segmentKind: typeof diff.segmentKind === 'string' ? diff.segmentKind : null,
+      missingTokens: Array.isArray(diff.missingTokens) ? diff.missingTokens : null,
+    });
+    if (!suppressed) kept.push(diff);
+  }
+  return kept;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## [PENDING REVIEWER APPROVAL — §5.3.3 L2 gate]

## Summary

新規 `scripts/lib/ja_omission_policy_registry.mjs` を追加し、`docs/WRITING_GUIDE.md §「原文から意図的に除外するコンテンツ」` で規定された Tricentis 削除依頼 policy による JA 側意図的削除 drift を alignSegments で抑止する mechanism を導入する。PR #309 (`overview/testim-overview`) の blocker を解消する。

- **Mechanism gap fill**: 既存 3 mechanism (EN-broken `source_sync_exclusions`、EN-side artifact `parity_artifact_registry` §5.3.2、kind-mismatch §5.3.1) はどれも JA-side 意図的削除を対象にしていなかった。
- **Initial scope**: `overview/testim-overview` (PR #309 の 5 baseline entries) 全てを本 registry で抑止可能。

## 根本原因 (再掲 — agent 75 分析済)

PR #309 の 5 drift は全て `WRITING_GUIDE` の Tricentis 削除 policy に直接起因:

| baseline entry | 原因 |
|---|---|
| section-structure-mismatch (preface) | pricing + changelog callout 削除の派生 |
| segment-missing callout-body (EN idx 0) | pricing callout 意図的削除 |
| segment-missing callout-body (EN idx 1) | changelog callout の offset |
| segment-extra callout-body (JA idx 0) | 変更履歴 callout の orphan |
| segment-token-gap paragraph (`http://testim.io`) | intro URL 意図的削除 |

## 実装

### 1. Registry module `scripts/lib/ja_omission_policy_registry.mjs`

`parity_artifact_registry.mjs` を structural template にしつつ、quota-based 抑止に拡張した。

**Disambiguator 選定**: 1 slug × 同一 `(issueType, segmentKind)` で複数 drift が出るケース (例: testim-overview の callout-body × 2) を扱うため 3 案から選定:

| 案 | 採否 | 理由 |
|---|---|---|
| (a) **quota-based** | **採用** | 登録データ最小。EN 文面更新で安定。`overview/testim-overview` に十分 |
| (b) fingerprint-based (EN sha256) | 不採用 | EN 文面変更で無効化。WRITING_GUIDE の意思 (「EN がどうなっても JA は出さない」) と相性悪い |
| (c) content-prefix match | 不採用 | brittle / 監査困難 / policy drift を許容してしまう |

quota-based の副作用 (同種 drift 3 件目が別原因で発生した場合 quota 内で誤抑止され得る) は coverage snapshot の `exhaustedEntries` 監視で対処する運用と合わせる。

### 2. Initial registry entries (2026-04-17, `overview/testim-overview`)

| # | issueTypes | segmentKinds | missingToken | quota | reason |
|---|---|---|---|---|---|
| 1 | `segment-missing` | `callout-body` | — | **2** | tricentis-pricing-changelog-callout-removal |
| 2 | `segment-extra` | `callout-body` | — | 1 | tricentis-changelog-callout-offset-remnant |
| 3 | `segment-token-gap` | `paragraph` | `http://testim.io` | 1 | tricentis-testim-io-url-removal |
| 4 | `section-structure-mismatch` | `null` | — | 1 | tricentis-callout-removal-structure-derivative |

合計 quota = 5 で baseline の 5 entries を全て抑止する。

### 3. Runtime integration (`scripts/lib/source_parity_align.mjs`)

`alignSegments({ slug, coverage, omissionCoverage })` に第 3 option `omissionCoverage` を追加。diffs 生成後 (structure + LCS の両方を集めた後) / `detectAmbiguousAdjacentTokenlessSwap` の前に `suppressJaOmissionDiffs` を挟み、registry match + quota decrement を atomic に行う。`check_source_parity.mjs` は run 単位で 1 個 `createOmissionCoverage()` を生成して全 slug で共有し、`parity-check-status.json.debug.omissionCoverage` に snapshot を書き出す。

### 4. Test coverage `scripts/__tests__/ja_omission_policy_registry.test.mjs`

20 tests に以下を含む:

- **shape / empty-safe (4)**: frozen entries、必須 field 検証、未登録 slug/issueType で null
- **inventory (6)**: 4 entries 各々に対する match assertion + 非 match assertion + segmentKinds=null の structure mismatch
- **createOmissionCoverage (4)**: quota atomic 減算、exhaustion、mismatch での非 mutation、quotaUsage tracking
- **NOOP_OMISSION_COVERAGE (2)**: 常に false / quotaUsage は registry から populate
- **alignSegments integration (4)**: quota 内抑止、unregistered slug で非抑止、structure-mismatch 抑止 (segmentKinds=null)、option 未指定時 no-op

### 5. Docs

- plan `docs/superpowers/plans/2026-04-16-m2-parity-burndown.md` に §5.3.3 を追記 (§5.3.2 の後、§5.2 の前)
- `docs/PARITY_GUIDE.md` 末尾に §5.3.3 詳細セクションを追記 (peer agent との merge conflict 回避のため append のみ)

## 検証

- `npm run test` → 2030 tests pass (既存 2010 + 新 20)
- `npm run lint` → 0 error / 0 warning (288 files)
- `npm run build` → 290 pages built successfully

## 制約遵守

- `src/content/docs/**` 非変更 (#309 rebase 側の scope)
- `parity-baseline.json` 非変更 (baseline cleanup は #309 rebase 後)
- §5.3.1 / §5.3.2 / §5.3.4 セクションは非変更 (peer agents の scope)
- `[PENDING REVIEWER APPROVAL — §5.3.3 L2 gate]` marker を全 commit と PR body に付与

## 依頼事項 (4-reviewer L2 gate)

- [ ] architect: registry architecture (quota-based disambiguator + post-filter integration point)
- [ ] security: Tricentis legal request の遵守継続 (re-add 禁止 policy lock)
- [ ] QA: `overview/testim-overview` 4 entries + 合計 quota 5 の妥当性
- [ ] testing: 20 tests の coverage (shape / inventory / quota / integration) 設計レビュー

## Follow-up (本 PR merge 後)

1. PR #309 (`claude/m2-wave3b2-testim-overview`) を rebase → baseline を 5 → 0 に再生成
2. `parity-check-status.json.debug.omissionCoverage.exhaustedEntries` を monitoring 対象に追加 (別 chore PR)

## Test plan

- [x] `npm run test` — 2030 tests pass
- [x] `npm run lint` — 0 error / 0 warning
- [x] `npm run build` — 290 pages built
- [ ] reviewer gate approval for §5.3.3 L2
- [ ] post-merge: `npm run check:parity -- --slug=overview/testim-overview` で baseline 再生成時に 5 → 0 確認 (#309 rebase で実施)

## 参考

- 問題分析: `gh pr view 309` (draft)
- policy 源: `docs/WRITING_GUIDE.md` line 373-383
- plan §5.3.3: `docs/superpowers/plans/2026-04-16-m2-parity-burndown.md`
- guide §5.3.3: `docs/PARITY_GUIDE.md` 末尾新セクション

🤖 Generated with [Claude Code](https://claude.com/claude-code)