### PR TITLE
docs: JA エンジニアリング慣用英語 policy を WRITING_GUIDE + GLOSSARY に明文化

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -8,6 +8,15 @@
 - Testim / Tricentis の固有名詞（製品名・機能名・画面名）
 - 広く通用する英語 UI ラベルで、日本語化すると逆に混乱を招くもの
 - CLI コマンド名・設定キー名
+- **日本エンジニアリング慣用英語** (2026-04-17 §5.3.7 rework v2 で追加): 詳細判定基準は [WRITING_GUIDE §日本エンジニアリング慣用英語の判定基準](./WRITING_GUIDE.md#日本エンジニアリング慣用英語の判定基準-2026-04-17-537-rework-v2) 参照
+
+## 許容機構原則 (§5.3.7 absolute principle, 2026-04-17)
+
+本 GLOSSARY は `maskSegmentText` の正規チャネルであり、**WRITING_GUIDE で policy 化された term のみ text replacement で mask** する仕組み。設計原則:
+
+1. **GLOSSARY ≠ classifier allowlist**: 削除済の `TECH_TOKEN_ALLOWLIST` (residue-word-count filter) とは別経路。本 GLOSSARY の term は WRITING_GUIDE authoritative な英語維持 policy に紐付く
+2. **broken EN snapshot 退避のみ別機構**: `source_sync_exclusions.mjs` / `parity_artifact_registry.mjs` は EN 上流 broken 限定で、GLOSSARY とは別目的
+3. **新規追加は reviewer 承認**: 安易な追加は classifier 検知精度 dilution (将来 untranslated 見逃し)。WRITING_GUIDE 3 条件 (dev tools 標準 / JA エンジニア慣用 / 翻訳で情報損失) 全て満たさないと登録不可
 
 ## 3-tier 分類（M4 実施 / 2026-04-16）
 

--- a/docs/WRITING_GUIDE.md
+++ b/docs/WRITING_GUIDE.md
@@ -412,6 +412,63 @@ Testim の固有名詞は英語のまま維持してください。日本語に�
 - `Visual Editor`
 - `Agentic Test Automation`
 
+### 日本エンジニアリング慣用英語の判定基準 (2026-04-17 §5.3.7 rework v2)
+
+Testim 固有名詞に加えて、**日本のエンジニアリング現場で慣用的に英語のまま使われる技術用語**は JA 文中にそのまま残します。直訳すると可読性が下がり、UI / dev tools との cross-reference 性が損なわれるためです (例: `warning ログ` は自然、`警告ログ` は stiff)。
+
+**以下 3 条件全てを満たす場合のみ英語維持 (GLOSSARY 登録可)**:
+
+1. **Dev tools 標準用語**: Chrome DevTools / git / HTTP / 主要言語・フレームワーク の実装 / UI に同一表記で存在する
+2. **JA エンジニア慣用**: 実際の JA 技術記事 / Slack / 社内 Wiki 等で英語のまま使用される慣習が確立している
+3. **翻訳で情報損失 or 曖昧化**: 直訳すると技術的精度が下がる、または複数の訳が成立してしまう (固有名詞性の喪失を含む)
+
+**明確に許容される例**:
+
+| カテゴリ                 | 例                                                            |
+| ------------------------ | ------------------------------------------------------------- |
+| Log levels               | `debug` / `info` / `warning` / `error` / `verbose`            |
+| HTTP method / status     | `GET` / `POST` / `PUT` / `DELETE` / `401` / `500`             |
+| File formats             | `csv` / `json` / `yaml` / `xml` / `pdf` / `jpg`               |
+| Test lifecycle labels    | `sanity` / `nightly` / `monitor` / `smoke` / `e2e`            |
+| DevTools / network       | `XHR` / `JS` / `CSS` / `WS` / `Manifest`                      |
+| HTML 仕様 keyword / 属性 | `href` / `src` / `alt` / `disabled` / `title`                 |
+| Third-party vendor enum  | axe-core 影響度 / Applitools match level / Salesforce Edition |
+| Browser release channels | `Beta` / `Canary` / `Dev` / `Stable`                          |
+| Brand / service 固有名詞 | `YouTube` / `Twitter` / `LinkedIn` / `Facebook` 等            |
+
+**許容されない例 (普通に JA 訳)**:
+
+| 例                    | 理由                                                |
+| --------------------- | --------------------------------------------------- |
+| `button` → ボタン     | 一般英語、曖昧化なし、JA 自然                       |
+| `page` → ページ       | 同上                                                |
+| `menu` → メニュー     | 同上                                                |
+| `click` → クリック    | カタカナ定着                                        |
+| `save` → 保存         | 自然な JA、UI label でない限り翻訳                  |
+
+### JA 文中での埋め込み方 (recommended pattern)
+
+classifier を silent にしつつ自然な JA を実現する書き方:
+
+```markdown
+# ❌ 避ける: 英語のみ列挙 (classifier が untranslated と誤検知)
+オプション: Critical、Serious、Moderate、Minor。デフォルト = Minor。
+
+# ✅ 推奨: JA 文脈で英語 term を囲む
+Critical / Serious / Moderate / Minor の 4 段階から最小失敗レベルを選択します
+（それぞれ重大、深刻、中程度、軽微 に相当）。デフォルト値は Minor です。
+```
+
+### 「許容機構」原則との関係
+
+GLOSSARY 登録は `maskSegmentText` の正規チャネルであり、`§5.3.7 絶対原則` で禁止される「allowlist / registry / exclusion」とは **別経路**:
+
+- **GLOSSARY** (許容): WRITING_GUIDE で「英語維持」が policy 化された term のみ、text replacement で mask
+- **TECH_TOKEN_ALLOWLIST** (禁止): 設計原則違反、§5.3.7 で完全撤廃済
+- **broken EN snapshot evacuation** (SOURCE_SYNC_EXCLUSIONS / ARTIFACT_REGISTRY): EN 上流 broken 限定、`§5.3.7 絶対原則` で唯一正当化される許容機構
+
+新規 GLOSSARY 追加は **上記 3 条件 + reviewer 承認** を要する。安易な追加は classifier 検知精度 dilution のため避ける。
+
 ---
 
 ## 📏 表記統一ルール


### PR DESCRIPTION
## Summary

PR #325 §5.3.7 rework v2 で GLOSSARY に 35 terms 追加した際の policy を authoritative doc に反映。user 指示 (2026-04-17):

- Testim UI 用語 + 日本エンジニアリング慣用英語 (log levels / HTTP / file formats / DevTools / browser channels 等) は英語維持が自然・検索性向上
- 単純一般語 (button / page / menu 等) は通常 JA 翻訳
- 3 条件 (dev tools 標準 / JA エンジニア慣用 / 翻訳で情報損失) 全て満たす場合のみ GLOSSARY 登録可、安易な追加禁止

## 変更内容

- `docs/WRITING_GUIDE.md` §Testim 用語英語維持 に新規 sub-section:
  - 「日本エンジニアリング慣用英語の判定基準」(3 条件)
  - 明確に許容される例 (9 カテゴリ、table)
  - 許容されない例 (普通に JA 訳)
  - JA 文中での埋め込み方 (recommended pattern): JA 文脈で英語 term を囲む
  - 「許容機構」原則との関係: GLOSSARY と `TECH_TOKEN_ALLOWLIST` の差別化
- `docs/GLOSSARY.md` header: 登録基準に「日本エンジニアリング慣用英語」追加、許容機構原則 sub-section で「GLOSSARY != classifier allowlist」を明示

## rationale

将来 agent が GLOSSARY 追加判断する際の authoritative guide。§5.3.7 絶対原則 (許容機構は broken EN snapshot 退避のみ) との整合性を担保し、GLOSSARY 膨張による classifier 検知精度 dilution を抑止する。

## Test plan

- [x] `npm run lint` 0 errors / 0 warnings
- [x] `npm run test` 2084 pass
- [x] `npm run build` 290 pages
- [x] baseline 無影響 (doc-only commit、parity-baseline.json 未変更)
- [x] GLOSSARY / WRITING_GUIDE 整合性 (cross-link 機能)