### PR TITLE
fix(parity): UD-010 MadCap artifact bundle — codeship + parameters-for-groups

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -361,6 +361,7 @@ Testim が統合 / 連携する第三者製品。JA 文中でも英語のまま�
 | Tricentis Test Management for Jira | TTM for Jira の完全表記 |
 | TDC | Tricentis Device Cloud 略称 |
 | qTest API | qTest の API |
+| webdriver-manager | npm パッケージ名 (Selenium WebDriver バイナリを取得する CLI) |
 
 ## [Tier B] 画面 / UI 領域
 

--- a/docs/superpowers/specs/upstream-defect-tracker.md
+++ b/docs/superpowers/specs/upstream-defect-tracker.md
@@ -19,7 +19,7 @@ UD-NNN IDs are allocated **centrally** via updates to this table, not per-PR ad-
 | UD-007 | _(unallocated)_ | _TBD_ | reserved | TBD |
 | UD-008 | _(unallocated)_ | _TBD_ | reserved | TBD |
 | UD-009 | `index.htm` self-link miswire in grid-management child pages | `href-miswire` | applied | M2 PR D |
-| UD-010 | MadCap authoring-artifact family (ZWSP / escaped-detail fragment / broken-table-row variants) | `madcap-artifact` | reserved | TBD (next MadCap artifact family PR) |
+| UD-010 | MadCap authoring-artifact family (ZWSP / escaped-detail fragment / broken-table-row variants) | `madcap-artifact` | applied | M2 UD-010 bundle (codeship broken h2 + parameters-for-groups broken step-5) |
 
 ### Allocation protocol
 
@@ -259,6 +259,37 @@ JA 翻訳は原文構造準拠を崩さないため、JA markdown 側で workaro
   2. `grep 'href="index.htm#adding-a-grid"'` が全 5 file で 0 hit を確認
   3. `scripts/lib/en_source_patches.mjs` から UD-009 entry を削除
   4. `node scripts/generate_parity_baseline.mjs --regenerate --rationale="UD-009 upstream fix confirmed"` で baseline を再生成 (新規追加 0、既存 entry への影響無しを期待)
+
+### UD-010: MadCap authoring-artifact family (ZWSP + literal-markdown-prefix-in-paragraph)
+
+- **Patch IDs**: `UD-010A-codeship-broken-h2-paragraph`, `UD-010B-parameters-for-groups-broken-step-paragraph`
+- **Defect class**: `madcap-artifact`
+- **Added**: 2026-04-20
+- **Applied**: 2026-04-20 (M2 UD-010 bundle — codeship inconclusive + parameters-for-groups step-count audit-signal)
+- **Review after**: 2026-10-20
+- **Affected slugs** (2):
+  - `integrations/integrate-testim-to-your-ci/codeship-integration` (UD-010A)
+  - `advanced-editing/parameters/parameters-for-groups` (UD-010B)
+- **Defect**: MadCap Flare が structural element (`<h2>` heading, `<li value="5">` ordered-list-item) を誤って `<p>` 要素にシリアライズし、テキスト内容の先頭に zero-width space (U+200B) + markdown-style prefix (`## ` for heading / `5. ` for step number) を残す authoring-artifact。2 つの variant を UD-010 family として集約:
+  - **UD-010A (codeship)**: 3 番目の section heading "Run with external Selenium Grid" が `<p>\u200b## Run with external Selenium Grid<br /> When your app...</p>` という単一の `<p>` に融合。同ページの他 2 つの h2 ("Project configuration" / "Run with local Selenium Grid") は正しく `<h2><a name="..."></a>Heading</h2>` 形状を取っているため、第 3 heading のみが MadCap 側の authoring defect。`extractHeadingSequence` は EN=2 / JA=3 とカウントし `segment-inconclusive [heading-count-mismatch]` として surface。
+  - **UD-010B (parameters-for-groups)**: 「Adding Parameters to a Group」section の step 5 が `<li value="4">` と `<li value="5">` の間に orphan `<p>\u200b5. Enter a value in the field below...</p>` として挿入。この `<p>` は正規の `<li>` ではないが turndown が Markdown paragraph に変換し、先頭行が `extractStepCounts` の `^\d+\.\s` regex にヒットするため EN step count が実際の `<li>` 個数 (6) より 1 多く (7) 算出される。JA は translator が正規の 6 step として構造化済み (値入力の説明文を step 4 の後の通常 paragraph に統合) のため step-count audit-signal (EN=7, JA=6) が section #2 で発火。
+- **Observed symptom**:
+  - UD-010A: `segment-inconclusive` [heading-count-mismatch] EN=2 vs JA=3 for `codeship-integration` (previously baseline-covered)
+  - UD-010B: `step-count-mismatch` audit-signal EN=7 vs JA=6 for `parameters-for-groups` section #2
+- **JA side**: 両 slug ともに JA は正規の構造 (codeship: 3 h2 sections / parameters-for-groups: 6 numbered steps) を既に保持している。JA 改変なしで EN 側 patch のみで parity 一致する。ただし codeship UD-010A 適用により EN 側に出現する `webdriver-manager` plain-text token が JA paragraph 「Selenium Server (webdriver-manager)」で residue word count を 3 に到達させ `segment-untranslated` を副次的に発火する。これを解消するため `docs/GLOSSARY.md` Tier A 外部製品 / 第三者ツール に `webdriver-manager` (npm パッケージ名, Selenium WebDriver バイナリ取得 CLI) を Tier A 追加する (一般的な CLI tool name retention policy 準拠)。
+- **Fix applied**:
+  - `UD-010A-codeship-broken-h2-paragraph`: broken `<p>\u200b## ...<br /> body...</p>` → `<h2><a name="run-with-external-selenium-grid"></a>Run with external Selenium Grid</h2><p>body...</p>`。sibling h2 と同じ `<a name="...">` anchor 形式を踏襲。
+  - `UD-010B-parameters-for-groups-broken-step-paragraph`: `<p>\u200b5. Enter a value...</p>` → `<p>Enter a value...</p>`。先頭の `\u200b5. ` prefix を削除し、content は通常 paragraph として残す (extractStepCounts の `^\d+\.\s` regex にマッチしなくなる)。
+  - GLOSSARY Tier A 追加: `webdriver-manager`。
+- **Status**: `applied`
+- **Tricentis upstream report status**: _pending_ (担当: JA Docs subsystem, 報告 ticket TBD — MadCap authoring tool での heading/step-item シリアライゼーション bug、同種 pattern が他ページにも潜在する可能性あり)
+- **Removal SOP** (after upstream fix confirmed):
+  1. codeship + parameters-for-groups の EN HTML snapshot を再取得
+  2. UD-010A: `grep '<p>\u200b## Run with external'` が 0 hit になったことを確認
+  3. UD-010B: `grep '<p>\u200b5. Enter a value'` が 0 hit になったことを確認
+  4. `scripts/lib/en_source_patches.mjs` から UD-010A/B entry を削除
+  5. `docs/GLOSSARY.md` から `webdriver-manager` entry を保持するか否か判断 (upstream 修正と独立した policy decision)
+  6. `node scripts/generate_parity_baseline.mjs --regenerate --rationale="UD-010 upstream fix confirmed"` で baseline を再生成し、新規追加 0 を確認
 
 ## Adding a new defect
 

--- a/parity-baseline.json
+++ b/parity-baseline.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-04-20T01:19:08.291Z",
-  "generatedFromRunId": "2026-04-20T01:19:08.291Z#parity-check-status",
-  "rationale": "frozen baseline — partial regeneration for integrations/bug-tracker-settings/connecting-testim-to-jira, integrations/bug-tracker-settings/connecting-testim-to-slack, integrations/bug-tracker-settings/connecting-testim-to-trello",
+  "generatedAt": "2026-04-20T01:39:25.520Z",
+  "generatedFromRunId": "2026-04-20T01:39:25.520Z#parity-check-status",
+  "rationale": "frozen baseline — partial regeneration for integrations/integrate-testim-to-your-ci/codeship-integration, advanced-editing/parameters/parameters-for-groups, advanced-editing/hooks, advanced-editing/parameters, editing-tests/search-within-a-test",
   "entries": [
     {
       "slug": "advanced-editing/data-driven-testing/configuring-a-data-driven-test-from-the-visual-editor",
@@ -35,49 +35,6 @@
       "enSourceFingerprint": null,
       "jaSourceFingerprint": "sha256:9f9f565647fe27495ed900972424b34856c6a62eeb7248bb2b80a95c625a3f5c",
       "missingTokens": null,
-      "inconclusiveCategory": null,
-      "inconclusiveReason": null,
-      "sectionIndex": null,
-      "structureCategory": null,
-      "structureFingerprint": null,
-      "usabilityReason": null
-    },
-    {
-      "slug": "advanced-editing/hooks",
-      "issueType": "segment-token-gap",
-      "snapshotFingerprint": "sha256:95f061a56e749fd8b40900235f7188609b5035701a835f0f50782ac9a947696f",
-      "reviewAfter": "2026-12-26",
-      "sectionPath": "Creating Hooks via the Config File",
-      "segmentKind": "paragraph",
-      "enSegmentIndex": 1,
-      "jaSegmentIndex": null,
-      "enSourceFingerprint": "sha256:7b72784eb1c893a1cd6e5d7eadb8f28c056e4e30808b4110944437482df235a2",
-      "jaSourceFingerprint": null,
-      "missingTokens": [
-        "/docs/configuration-file-parameters#defining-parameters-in-a-configuration-file",
-        "/docs/configuration-file-run-hooks"
-      ],
-      "inconclusiveCategory": null,
-      "inconclusiveReason": null,
-      "sectionIndex": null,
-      "structureCategory": null,
-      "structureFingerprint": null,
-      "usabilityReason": null
-    },
-    {
-      "slug": "advanced-editing/parameters",
-      "issueType": "segment-token-gap",
-      "snapshotFingerprint": "sha256:96c304afb2270f34fea71175d3d6a9a91d02ff0e2bdede035cb8cadd5439d4bc",
-      "reviewAfter": "2026-12-09",
-      "sectionPath": "Predefined (out of the box) parameters > Testim Iterator Parameter",
-      "segmentKind": "paragraph",
-      "enSegmentIndex": 1,
-      "jaSegmentIndex": null,
-      "enSourceFingerprint": "sha256:00cd123c4a4f18c23b913e8d1a3a78611465fa8d8ac667d4dcd93cf8545d35cc",
-      "jaSourceFingerprint": null,
-      "missingTokens": [
-        "/docs/loops#using-the-loop-iterator-parameter"
-      ],
       "inconclusiveCategory": null,
       "inconclusiveReason": null,
       "sectionIndex": null,
@@ -181,27 +138,6 @@
       "usabilityReason": null
     },
     {
-      "slug": "editing-tests/search-within-a-test",
-      "issueType": "segment-token-gap",
-      "snapshotFingerprint": "sha256:b9bf0557753653df0c2c3874bf6ae6bc1b7c45402938f677270fd38ff999d8cd",
-      "reviewAfter": "2026-12-19",
-      "sectionPath": "Understanding the search results > Search limitations",
-      "segmentKind": "unordered-list-item",
-      "enSegmentIndex": 2,
-      "jaSegmentIndex": null,
-      "enSourceFingerprint": "sha256:fc34d167c39974716c99cdda2452dd46a6c8e61c4e5e54da35e5ee5571f88c13",
-      "jaSourceFingerprint": null,
-      "missingTokens": [
-        "-variable"
-      ],
-      "inconclusiveCategory": null,
-      "inconclusiveReason": null,
-      "sectionIndex": null,
-      "structureCategory": null,
-      "structureFingerprint": null,
-      "usabilityReason": null
-    },
-    {
       "slug": "editing-tests/steps",
       "issueType": "segment-untranslated",
       "snapshotFingerprint": "sha256:1fad4c0943ea00b629dd551c91418964045be5731b591e5a383ca496454e13f1",
@@ -215,25 +151,6 @@
       "missingTokens": null,
       "inconclusiveCategory": null,
       "inconclusiveReason": null,
-      "sectionIndex": null,
-      "structureCategory": null,
-      "structureFingerprint": null,
-      "usabilityReason": null
-    },
-    {
-      "slug": "integrations/integrate-testim-to-your-ci/codeship-integration",
-      "issueType": "segment-inconclusive",
-      "snapshotFingerprint": "sha256:96499dba24701bf25dedfa3a46e14cb2af35277d2fbf6f2873b60b31e4b343b2",
-      "reviewAfter": "2026-11-20",
-      "sectionPath": null,
-      "segmentKind": null,
-      "enSegmentIndex": null,
-      "jaSegmentIndex": null,
-      "enSourceFingerprint": null,
-      "jaSourceFingerprint": null,
-      "missingTokens": null,
-      "inconclusiveCategory": "heading-count-mismatch",
-      "inconclusiveReason": "Heading count mismatch: EN has 2 headings, JA has 3",
       "sectionIndex": null,
       "structureCategory": null,
       "structureFingerprint": null,

--- a/scripts/__tests__/en_source_patches.test.mjs
+++ b/scripts/__tests__/en_source_patches.test.mjs
@@ -427,6 +427,74 @@ describe('applyEnSourcePatches (UD-001 / UD-002 application)', () => {
     );
   });
 
+  it('applies UD-010A rewriting codeship broken <p>## heading → proper <h2>', () => {
+    const html =
+      '<p>\u200b## Run with external Selenium Grid<br /> When your app is deployed on a publicly ' +
+      'available server, you can run your tests on an external Selenium Grid. In that case, you ' +
+      "don't need the local Selenium Server (webdriver-manager), so just add these lines to the " +
+      'setup commands section:</p>';
+    const cov = createEnSourcePatchCoverage();
+    const out = applyEnSourcePatches(
+      html,
+      'integrations/integrate-testim-to-your-ci/codeship-integration',
+      cov,
+    );
+    assert.ok(
+      out.includes('<h2><a name="run-with-external-selenium-grid"></a>Run with external Selenium Grid</h2>'),
+      'patch must emit proper <h2>-with-anchor for the third section heading',
+    );
+    assert.ok(
+      out.includes('<p>When your app is deployed'),
+      'body paragraph must be preserved as a separate <p> element',
+    );
+    assert.equal(
+      out.includes('\u200b##'),
+      false,
+      'ZWSP + literal ## prefix must be removed',
+    );
+    assert.equal(
+      out.includes('<br /> When your app'),
+      false,
+      'MadCap <br /> line break between broken heading and body must be gone',
+    );
+    assert.equal(
+      cov.snapshot().byPatchId['UD-010A-codeship-broken-h2-paragraph'],
+      1,
+    );
+  });
+
+  it('applies UD-010B stripping parameters-for-groups broken step-5 prefix', () => {
+    const html =
+      "<p>\u200b5. Enter a value in the field below the parameter name. If the value is a constant " +
+      "string value use ' ' around it. For example, 'guest'. This value will be available in this " +
+      'test only (i.e., the value will not be shared across tests.</p>';
+    const cov = createEnSourcePatchCoverage();
+    const out = applyEnSourcePatches(
+      html,
+      'advanced-editing/parameters/parameters-for-groups',
+      cov,
+    );
+    assert.ok(
+      out.includes('<p>Enter a value in the field below the parameter name.'),
+      'paragraph content must survive with the "\u200b5. " prefix stripped',
+    );
+    assert.equal(
+      out.includes('\u200b5.'),
+      false,
+      'ZWSP + "5. " step-number prefix must be removed',
+    );
+    // Sanity: extractStepCounts regex /^\d+\.\s/ would no longer match the paragraph
+    // (the leading character is now capital "E", not a digit).
+    assert.ok(
+      out.match(/<p>[^<]/) && !out.match(/<p>\u200b?\d+\.\s/),
+      'patched paragraph must not start with a markdown-style step-number prefix',
+    );
+    assert.equal(
+      cov.snapshot().byPatchId['UD-010B-parameters-for-groups-broken-step-paragraph'],
+      1,
+    );
+  });
+
   it('does NOT apply UD-001A on sfdc-step-edit (slug mismatch)', () => {
     const html = '<p>Verify -this action verifies x</p>';
     const cov = createEnSourcePatchCoverage();

--- a/scripts/lib/en_source_patches.mjs
+++ b/scripts/lib/en_source_patches.mjs
@@ -306,6 +306,65 @@ export const EN_SOURCE_PATCHES = Object.freeze([
     addedAt: '2026-04-18',
     reviewAfter: '2026-10-18',
   }),
+  Object.freeze({
+    id: 'UD-010A-codeship-broken-h2-paragraph',
+    slugs: Object.freeze([
+      'integrations/integrate-testim-to-your-ci/codeship-integration',
+    ]),
+    defectClass: 'madcap-artifact',
+    find:
+      '<p>\u200b## Run with external Selenium Grid<br /> When your app is deployed on a publicly ' +
+      'available server, you can run your tests on an external Selenium Grid. In that case, you ' +
+      "don't need the local Selenium Server (webdriver-manager), so just add these lines to the " +
+      'setup commands section:</p>',
+    replace:
+      '<h2><a name="run-with-external-selenium-grid"></a>Run with external Selenium Grid</h2>' +
+      '<p>When your app is deployed on a publicly available server, you can run your tests on ' +
+      "an external Selenium Grid. In that case, you don't need the local Selenium Server " +
+      '(webdriver-manager), so just add these lines to the setup commands section:</p>',
+    rationale:
+      'Upstream MadCap authoring artifact: the third section heading ("Run with external Selenium Grid") ' +
+      'was serialized into a single <p> element whose text content begins with a zero-width space (U+200B) ' +
+      'followed by a literal markdown-style "## " prefix and then fused with the following body paragraph ' +
+      'via a <br /> line break, instead of the expected <h2><a name="..."></a>Heading</h2> + separate <p>. ' +
+      'Adjacent sections on the same page ("Project configuration" / "Run with local Selenium Grid") use ' +
+      'the correct <h2>-with-anchor shape, so the broken third heading is clearly a MadCap source-side ' +
+      'serialization defect. Symptom: `extractHeadingSequence` counts EN=2 while JA has 3 H2 headings, ' +
+      'surfacing as a `segment-inconclusive` [heading-count-mismatch] entry for the slug. Patch rewrites ' +
+      'the broken <p> to a canonical <h2> + <p> pair matching sibling heading anchors; parity counts ' +
+      'converge to 3 on both sides.',
+    linkedDefect: 'docs/superpowers/specs/upstream-defect-tracker.md#UD-010',
+    addedAt: '2026-04-20',
+    reviewAfter: '2026-10-20',
+  }),
+  Object.freeze({
+    id: 'UD-010B-parameters-for-groups-broken-step-paragraph',
+    slugs: Object.freeze(['advanced-editing/parameters/parameters-for-groups']),
+    defectClass: 'madcap-artifact',
+    find:
+      "<p>\u200b5. Enter a value in the field below the parameter name. If the value is a constant " +
+      "string value use ' ' around it. For example, 'guest'. This value will be available in this " +
+      'test only (i.e., the value will not be shared across tests.</p>',
+    replace:
+      "<p>Enter a value in the field below the parameter name. If the value is a constant string " +
+      "value use ' ' around it. For example, 'guest'. This value will be available in this test " +
+      'only (i.e., the value will not be shared across tests.</p>',
+    rationale:
+      'Upstream MadCap authoring artifact: step 5 of the "Adding Parameters to a Group" ordered list ' +
+      'was serialized as an orphan <p> element interleaved between <li value="4"> and <li value="5"> ' +
+      '(where the list item with value="5" carries different content — "Repeat steps 4-5 to add ' +
+      'additional parameters"). The orphan <p> begins with a zero-width space (U+200B) followed by ' +
+      'a literal "5. " step-number prefix, which turndown converts to a Markdown paragraph whose ' +
+      'first line matches `extractStepCounts` "^\\d+\\.\\s" regex, inflating the EN step count from ' +
+      '6 (the correct <li value> count) to 7. JA is already correctly structured as 6 numbered steps ' +
+      'with the translated value-entry guidance folded into a prose paragraph between steps, so the ' +
+      'symptom surfaces as a `step-count-mismatch` audit signal (EN=7, JA=6) for section #2. Patch ' +
+      'strips the leading "\u200b5. " prefix so the content remains as prose (matching JA) but is no ' +
+      'longer counted as a numbered step by extractStepCounts.',
+    linkedDefect: 'docs/superpowers/specs/upstream-defect-tracker.md#UD-010',
+    addedAt: '2026-04-20',
+    reviewAfter: '2026-10-20',
+  }),
 ]);
 
 /**


### PR DESCRIPTION
## Summary

Allocate **UD-010** (previously reserved in upstream-defect-tracker v2) as the MadCap authoring-artifact family for the **ZWSP + literal-markdown-prefix-in-paragraph** defect pattern. Applies 2 patches for 2 slugs that resolve 1 inconclusive entry + 3 audit-signal entries + 3 stale baseline orphans.

## Defect pattern (UD-010)

MadCap Flare serializes structural elements (h2 heading, ordered-list-item) as `<p>` text that begins with U+200B (ZWSP) followed by a literal markdown prefix (`## ` for heading, `5. ` for step-number) and optionally a `<br />` line break fusing the broken heading with the following body paragraph. Sibling structural elements on the same page use the correct tags, so each occurrence is a clear MadCap source-side serialization defect.

## Patches

### UD-010A — codeship-integration (broken h2 paragraph)

- EN has `<p>​## Run with external Selenium Grid<br /> When your app is deployed...</p>` — the third section heading fused into a single `<p>` with ZWSP + `##` prefix + `<br />` + body, while the other 2 h2s on the same page are correctly serialized.
- Symptom: `extractHeadingSequence` EN=2 / JA=3 → `segment-inconclusive [heading-count-mismatch]`.
- Patch: rewrite to canonical `<h2><a name="run-with-external-selenium-grid"></a>Run with external Selenium Grid</h2><p>When your app...</p>` matching sibling heading anchor shape.

### UD-010B — parameters-for-groups (broken step-5 paragraph)

- EN has `<p>​5. Enter a value in the field below...</p>` as an orphan paragraph between `<li value="4">` and `<li value="5">` (where `<li value="5">` carries different "Repeat steps 4-5" content).
- Symptom: turndown converts the orphan `<p>` to a Markdown paragraph that `extractStepCounts` (regex `/^\d+\.\s/`) counts as an extra step, inflating EN step count from 6 to 7 while JA correctly has 6. → `step-count-mismatch` audit signal for section #2.
- Patch: strip leading `\u200b5. ` prefix so content remains as prose (matching JA's folded-in-paragraph structure) but no longer counted as a numbered step.

### GLOSSARY side-effect mitigation

UD-010A applied exposes the EN body paragraph token `webdriver-manager` (plain text in "local Selenium Server (webdriver-manager)"). JA mirrors with the same plain-text token. Classifier residue-word count reaches 3 (Grid, webdriver-manager, commands) flipping segment-untranslated. Resolved by adding `webdriver-manager` to GLOSSARY Tier A external tools (consistent with other npm tool names — policy: CLI tool names are retained in English).

## Impact

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| baseline entries | 27 | **23** | **-4** |
| baseline slugs | 19 | 15 | -4 |
| segment-inconclusive (baselined) | 8 | **7** | **-1** (codeship) |
| step-count-mismatch (active signal) | 6 | **4** | **-2** (parameters-for-groups) |
| paragraph-count-mismatch (active signal) | 10 | **9** | **-1** (same root cause) |
| total auditSignalIssues | 19 | **16** | **-3** |

Baseline monotonic non-increase preserved. The 3 token-gap orphans cleaned up (advanced-editing/hooks, advanced-editing/parameters, editing-tests/search-within-a-test) are stale baseline entries left over from earlier UD-005/UD-006 partial regenerations — this PR's partial regen for those slugs clears them.

## Files

- `scripts/lib/en_source_patches.mjs` — registry size 15 → 17 (+2 frozen entries)
- `scripts/__tests__/en_source_patches.test.mjs` — +2 application tests (idempotency + coverage assertions)
- `docs/superpowers/specs/upstream-defect-tracker.md` — UD-010 status `reserved` → `applied` in Reserved IDs table + full registry entry (defect variants, observed symptoms, fix rationale, Removal SOP)
- `docs/GLOSSARY.md` — +1 Tier A entry: `webdriver-manager`
- `parity-baseline.json` — partial regen for 5 slugs (2 patched + 3 orphan cleanups), 27 → 23 entries

## Verification

- [x] `npm run test` green — 2165/2165 pass (+2 new UD-010 tests)
- [x] `npm run lint:docs` — 0 errors, 0 warnings in 288 files
- [x] `npm run build` — 290 pages built in 6.15s
- [x] `npm run check:parity --slug` — 0 active issues for codeship-integration + parameters-for-groups (with inconclusive orphan for codeship cleaned via baseline regen)

## Remaining work (not in this PR)

- **7 inconclusive** still in baseline: 6 tokenless-near-tie (algorithm limitation — `detectAmbiguousAdjacentTokenlessSwap` uses only body length similarity as signal; requires mechanism PR adding heading-token tiebreaker) + 1 heading-count-mismatch for sealights-integration (requires JA restructure of list-wrapped code fences).
- **16 audit-signal** remaining for per-slug content audit (different root causes per page).