### PR TITLE
fix(parity): §5.3.9 classifier escaped-pipe symmetry + heading-mismatch JA level promotion

### DIFF
--- a/scripts/lib/source_parity_extract.mjs
+++ b/scripts/lib/source_parity_extract.mjs
@@ -98,7 +98,11 @@ export function extractStepCounts(body) {
     const trimmed = line.trim();
 
     // Markdown の pipe table 行は、セル内の記号を箇条書きとして数えない。
-    if (/^\|/.test(trimmed)) continue;
+    // §5.3.9: recognize both unescaped `|` (EN turndown output) and `\|`
+    // (JA UD-003 broken-row-mirror pattern) so pipe-table rows are skipped
+    // symmetrically on both sides. Without this, JA-side `\|...\|` rows
+    // are counted as paragraphs while EN-side `|...|` rows are not.
+    if (/^\\?\|/.test(trimmed)) continue;
 
     if (/^:::(note|warning|info|tip|caution|danger)/.test(trimmed)) {
       inCallout = true;
@@ -224,7 +228,11 @@ export function extractBulletCounts(body) {
     const trimmed = line.trim();
 
     // Markdown の pipe table 行は、セル内の記号を箇条書きとして数えない。
-    if (/^\|/.test(trimmed)) continue;
+    // §5.3.9: recognize both unescaped `|` (EN turndown output) and `\|`
+    // (JA UD-003 broken-row-mirror pattern) so pipe-table rows are skipped
+    // symmetrically on both sides. Without this, JA-side `\|...\|` rows
+    // are counted as paragraphs while EN-side `|...|` rows are not.
+    if (/^\\?\|/.test(trimmed)) continue;
 
     if (/^:::(note|warning|info|tip|caution|danger)/.test(trimmed)) {
       inCallout = true;
@@ -351,7 +359,7 @@ export function classifyLine(line, state = {}) {
     nextState.inParagraph = false;
     return { kind: 'image', nextState };
   }
-  if (/^\|/.test(trimmed)) {
+  if (/^\\?\|/.test(trimmed)) {
     nextState.inParagraph = false;
     return { kind: 'markdown-table', nextState };
   }

--- a/src/content/docs/advanced-editing/auto-grouping2.md
+++ b/src/content/docs/advanced-editing/auto-grouping2.md
@@ -72,7 +72,7 @@ Auto grouping は、プロジェクト全体のテストから重複したステ
 
 ![自動グルーピングのスクリーンショット](/images/advanced-features/auto-grouping2/bdbe859-Screen_Shot_2020-10-27_at_11.58.10.png)
 
-### 自動グルーピング候補の編集（Editing the auto-grouping suggestion）
+## 自動グルーピング候補の編集（Editing the auto-grouping suggestion）
 
 **自動グルーピング候補を編集するには:**
 

--- a/src/content/docs/advanced-editing/hooks.md
+++ b/src/content/docs/advanced-editing/hooks.md
@@ -166,11 +166,11 @@ Before/After each step フックは、テスト内の「各ステップの直前
  </tbody>
 </table>
 
-### テスト構成からフックを作成する {#creating-hooks-via-the-test-configuration}
+## テスト構成からフックを作成する {#creating-hooks-via-the-test-configuration}
 
 Test Configuration Hooks は、プロパティパネル／構成リスト画面／テストの既定構成から作成できます。
 
-#### プロパティパネルからフックを作成する {#creating-hooks-via-the-properties-panel}
+### プロパティパネルからフックを作成する {#creating-hooks-via-the-properties-panel}
 
 テストの**プロパティパネル**から作成できるフック:
 
@@ -216,7 +216,7 @@ Test Configuration Hooks は、プロパティパネル／構成リスト画面�
 
 ![フック設定のスクリーンショット](/images/advanced-features/hooks/603e29d-propertiespanel.gif)
 
-#### Configuration List 画面からフックを作成する {#creating-hooks-via-the-configuration-list-screen}
+### Configuration List 画面からフックを作成する {#creating-hooks-via-the-configuration-list-screen}
 
 **Configuration List** 画面からは、次のフックを作成できます。
 
@@ -254,7 +254,7 @@ Test Configuration Hooks は、プロパティパネル／構成リスト画面�
 
 ![フック設定のスクリーンショット](/images/advanced-features/hooks/0cbe19a-configlist.gif)
 
-#### Default Configuration 設定からフックを作成する {#creating-hooks-via-the-default-configuration-setting}
+### Default Configuration 設定からフックを作成する {#creating-hooks-via-the-default-configuration-setting}
 
 **Default Configuration からフックを作成するには:**
 
@@ -287,7 +287,7 @@ Test Configuration Hooks は、プロパティパネル／構成リスト画面�
 
 ![フック設定のスクリーンショット](/images/advanced-features/hooks/c475584-defaultconfig.gif)
 
-### Test Configuration Hooks の実行パラメーター {#test-configuration-hooks-run-parameters}
+## Test Configuration Hooks の実行パラメーター {#test-configuration-hooks-run-parameters}
 
 一部の Test Configuration Hooks には、テスト実行時の情報を取得するための追加パラメーターが用意されています。これらはステップ／テスト側から参照できるため、カスタムステップ内でログ出力やカスタム検証に利用できます。
 
@@ -338,7 +338,7 @@ Hooks を含むテストを実行すると、エディター上でさまざま�
 Turbo Mode でテストを実行している場合、不要なデータ保存を避けるためフックの表示は制限されます。Turbo Mode では、フックが可視化されるのは失敗した実行のみです。
 :::
 
-### Before/After each step フックの可視化 {#viewing-before-after-each-step-hooks}
+## Before/After each step フックの可視化 {#viewing-before-after-each-step-hooks}
 
 Before/After each step フックが設定されているステップには、実行後にステップ上へ「Hook」ボタンが表示されます（ステップにカーソルを合わせたときに表示）。
 
@@ -378,7 +378,7 @@ Hook ボタンをクリックすると、そのステップに紐づいている
 Hook ステップの **View Screenshot** をクリックしてサイドバイサイド表示を見る場合、Baseline（基準画像）は表示されず、結果側のみが表示されます。
 :::
 
-### Before/After test フックの可視化 {#viewing-before-after-test-hooks}
+## Before/After test フックの可視化 {#viewing-before-after-test-hooks}
 
 Before/After test フックはテストごとに 1 回、テストの開始前／終了後に実行されます。実行後、最初のステップ（Setup ステップ）にカーソルを合わせると「Hook」ボタンが表示されます。
 
@@ -402,7 +402,7 @@ Hook ボタンをクリックすると、テスト前後に実行された共有
 Hook ステップのスクリーンショットをサイドバイサイド表示した場合、Baseline 側は表示されず、結果側のみ表示されます。
 :::
 
-### 成功／失敗条件により実行されなかったフックの確認 {#viewing-hooks-that-did-not-run-due-to-success-failure-conditions}
+## 成功／失敗条件により実行されなかったフックの確認 {#viewing-hooks-that-did-not-run-due-to-success-failure-conditions}
 
 フック作成時に、ステップ／グループが成功した場合のみ／失敗した場合のみ実行するように条件を設定できます。この条件により実行されなかったフックは、青いドットでマークされます。
 
@@ -416,7 +416,7 @@ Hook ステップのスクリーンショットをサイドバイサイド表示
 
 ![フック設定のスクリーンショット](/images/advanced-features/hooks/bd7554b-2023-01-10_13-46-41.png)
 
-### フックに関連するエラーの確認 {#viewing-errors-related-to-hooks}
+## フックに関連するエラーの確認 {#viewing-errors-related-to-hooks}
 
 テスト実行後にエラーが発生した場合、そのエラーがフックステップに起因することがあります。フックステップでエラーが発生した場合、関連ステップの左側（before each step / before test のフックエラー）または右側（after each step / after test のフックエラー）に赤いドットが表示されます。
 


### PR DESCRIPTION
## Summary

Two parallel audit-signal fixes: a 3-regex mechanism symmetry patch (§5.3.9) and content-level JA heading-level promotion for 2 slugs. Reduces auditSignalIssues 13 → 9 (-4).

## §5.3.9 — classifier escaped-pipe line symmetry

### Problem

3 places in `scripts/lib/source_parity_extract.mjs` use `/^\|/` to skip pipe-table rows during paragraph / bullet / step counting. This matches EN turndown output (`|...|`) but NOT the intentional JA UD-003 broken-row-mirror pattern (`\|...\|`) documented in `PARITY_GUIDE §頻出パターン #5` and pinned by sentinel slug `use-agentic-test-automation-for-salesforce` in `source_parity_clean_page_fixtures.test.mjs`.

Result: 2 slugs that correctly mirror the UD-003 broken-EN broken-table-row-as-paragraph pattern have their JA-side `\|...\|` counted as paragraphs while the EN-side `|...|` is not — yielding a false paragraph-count-mismatch audit signal.

### Fix

Extend the 3 skip regexes from `/^\|/` to `/^\\?\|/`:

- `extractStepCounts` (line 101)
- `extractBulletCounts` (line 227)
- `classifyLine` (line 354)

Now both unescaped and escaped pipe-rows are skipped symmetrically.

### Affected slugs

| slug | before | after |
|---|---|---|
| `administration/subscription-plans` §6 "What is Counted Towards the Parallelism Quota" | paragraph-count EN=0 / JA=1 | ✓ clean |
| `salesforce-testing/create-a-salesforce-test/use-agentic-test-automation-for-salesforce` §3 "How to create prompts" | paragraph-count EN=1 / JA=2 | ✓ clean |

## Heading-mismatch JA level promotion

2 slugs had JA headings deeper than their EN counterparts — source-first violation (JA should mirror EN heading hierarchy exactly).

### `advanced-editing/auto-grouping2` (1 heading)

`### 自動グルーピング候補の編集` → `##` to match EN H2 "Editing the auto-grouping suggestion".

### `advanced-editing/hooks` (9 headings)

5 JA H3 → H2 + 3 JA H4 → H3 + 1 JA H3 → H2, aligning the entire "Creating hooks" / "Viewing hooks" hierarchy with EN:

- "テスト構成からフックを作成する" H3 → H2
- "プロパティパネルから..." H4 → H3
- "Configuration List 画面から..." H4 → H3
- "Default Configuration 設定から..." H4 → H3
- "Test Configuration Hooks の実行パラメーター" H3 → H2
- "Before/After each step フックの可視化" H3 → H2
- "Before/After test フックの可視化" H3 → H2
- "成功／失敗条件により実行されなかったフックの確認" H3 → H2
- "フックに関連するエラーの確認" H3 → H2

## Parity delta

| metric                             | before         | after          | delta   |
| ---------------------------------- | -------------- | -------------- | ------- |
| auditSignalIssues                  | 13             | **9**          | **-4**  |
| paragraph-count-mismatch           | 8              | **6**          | **-2**  |
| heading-mismatch                   | 2              | **0**          | **-2**  |
| baseline entries                   | 17             | 17             | ±0      |
| active actionable files            | 0              | 0              | ±0      |

## Verification

- [x] `npm run test` — 2166/2166 pass (classifier regex changes backward-compatible — `\\?` makes `\|` optional, prior `|` behavior preserved)
- [x] `npm run lint:docs` — 0 errors, 0 warnings
- [x] `npm run build` — 290 pages in 6.05s
- [x] `npm run check:parity` — audit-signal 13 → 9