### PR TITLE
fix(parity): editing-tests/steps §5 broken-row UD-003 mirror pattern

### DIFF
--- a/src/content/docs/editing-tests/steps.md
+++ b/src/content/docs/editing-tests/steps.md
@@ -469,4 +469,4 @@ keywords:
  </tbody>
 </table>
 
-Drag & Drop — AUT 内でアーティファクトをドラッグ&amp;ドロップ時（[Drag & Drop ステップ](/docs/advanced-editing/handling-ui-actions/drag-drop-step)を参照）
+\| Drag & Drop \| AUT 内でアーティファクトをドラッグ&amp;ドロップ時（[Drag & Drop ステップ](/docs/advanced-editing/handling-ui-actions/drag-drop-step)を参照） \|


### PR DESCRIPTION
## Summary

Follow-up to PR #354 §5.3.9 classifier escaped-pipe symmetry fix. Converts the JA-side orphan paragraph in `editing-tests/steps` §5 "Automatically Recorded Steps" to the established UD-003 broken-row-mirror pattern (`\|...\|`), so the classifier symmetrically skips both EN pipe-row and JA backslash-pipe-row for paragraph counting.

## Problem

EN has `<p>| Drag & Drop | upon dragging and dropping artifacts in AUT (See ...) |</p>` — a MadCap broken-table-row serialized as an orphan paragraph (UD-003 defect pattern). JA translator rendered this as prose `Drag & Drop — AUT 内で...（参照）` rather than using the established pipe-escape mirror pattern.

After PR #354's classifier fix `/^\|/` → `/^\\?\|/`, EN pipe-row paragraphs are skipped; JA needs to use the same `\|` form to match the sentinel pattern from `use-agentic-test-automation-for-salesforce`.

## Fix

`src/content/docs/editing-tests/steps.md`:

```diff
-Drag & Drop — AUT 内でアーティファクトをドラッグ&amp;ドロップ時（[Drag & Drop ステップ](...) を参照）
+\| Drag & Drop \| AUT 内でアーティファクトをドラッグ&amp;ドロップ時（[Drag & Drop ステップ](...) を参照） \|
```

## Parity delta

- auditSignalIssues 9 → **8** (-1)
- paragraph-count-mismatch 6 → **5** (-1)
- No baseline entry change

## Verification

- [x] `npm run test` — 2166/2166 pass
- [x] `npm run lint:docs` — 0 errors, 0 warnings
- [x] `npm run build` — 290 pages / 5.82s
- [x] per-slug parity check — `editing-tests/steps` section 5 paragraph-count aligned (EN=0 / JA=0 after classifier skip)