### PR TITLE
refactor: Phase 4 final cutover (PR Z) — baseline=0 / schema v2 / artifact registry + coverage

### DIFF
--- a/docs/OPS_DESIGN.md
+++ b/docs/OPS_DESIGN.md
@@ -380,27 +380,24 @@ revert すると segment-* issues は cutover 前の状態に戻る。baseline �
    - 再生成 diff を含む PR を起こし、PR description に必ず justification を記載:
      - なぜ翻訳追従でなく rebaseline を選んだか
      - 想定される paydown のタイミング
-     - `reviewAfter` を継承するか延長するか（延長する場合は理由）
+     - `priority` を `high`/`medium`/`low` のどれに設定したか（`medium` 以外なら理由）
 
 **重要**: rebaseline を「snapshot 変更時の自動的な逃げ道」にしてはならない。原則は常に **翻訳追従が第一**。rebaseline は justification がある例外的ケースに限る。
 
 ### Baseline 運用ルール
 
-- `parity-baseline.json` は cutover 時点の既知 drift を凍結したもの
-- 新規発生の segment-* issue は baseline に載らず即 gate fail
-- baseline entries は `reviewAfter` を持つ。期限を過ぎた entry は **gate に再突入する** (`isFrozenByBaseline` が `false` を返し、`isReportableParityIssue` が `true` を返す)。`scripts/__tests__/source_parity_issue_state.test.mjs` の "still accepts expired baseline on non-coarse actionable issues (refire)" が固定する
-- 大量 entry が同じ `reviewAfter` に集中すると cliff failure になるため、`generate_parity_baseline.mjs` は slug ハッシュで `reviewAfter` を分散させる (staggered expiry)
-- `parityFollowup` issue が **30 日以内に expire する entry** を事前警告として出す。CLI の `expiring baseline entries: N` も同様
-- baseline paydown は明示的な PR で実施する（段階的縮小）。期限切れによる自動再点火に頼ってはいけない
+- `parity-baseline.json` は schema v2 (Phase 4 cutover 以降)。`reviewAfter` による期限管理は撤廃し、`priority` (`high`/`medium`/`low`) と `note` で paydown 優先度を表現する
+- Phase 4 完了時点で `entries.length === 0` を維持する。新規発生の segment-* / structure issue は baseline に載らず即 gate fail — 翻訳追従 / artifact registry / normalizer / extractor / alignment / source lock のいずれかで解消する
+- `isFrozenByBaseline(issue) ≡ issue.baselined === true` — 期限概念は撤廃されたので、baseline に載った entry は明示的に削除するまで gate を抑止し続ける。paydown は **必ず明示的な PR** として行う (段階的縮小 / rebaseline のいずれか)
 - `segment-extra` と `segment-shifted` は acknowledgeable、それ以外の segment-* は `NON_ACKNOWLEDGEABLE_TYPES` に残したまま frozen baseline で運用する
-- `tokenless-near-tie` baseline エントリは `--include-advisory` review queue として triage する
+- `tokenless-near-tie` は baseline 対象外 (schema v2 で `segment-inconclusive` は `BASELINE_ELIGIBLE_TYPES` から除外)。`--include-advisory` review queue として triage する
 
 ### Phase 0 後の baseline 運用（2026-04-14 以降）
 
 baseline は bug backlog として運用する:
 
-- 新規 issue は原則として baseline に追加しない。修正するか、glossary / normalize / page-level exclusion のいずれかで説明可能に除外する
-- `reviewAfter` フィールドは既存 entry の互換性のため残すが、新規 entry では不要（Phase 4 で schema から削除予定）
+- 新規 issue は原則として baseline に追加しない。修正するか、glossary / normalize / artifact registry / page-level exclusion のいずれかで説明可能に除外する
+- schema v2 では entry に `priority` (`high`/`medium`/`low`) と任意 `note` を付与する。paydown の優先順位決定はこれらで行う
 - Quarterly review は「方針再検討」ではなく「残 backlog の burn-down 進捗確認」として実施
 - 再生成手順: `npm run check:parity` と `node scripts/generate_parity_baseline.mjs`
 

--- a/docs/PARITY_GUIDE.md
+++ b/docs/PARITY_GUIDE.md
@@ -82,7 +82,7 @@ jq "[.entries[] | select(.slug == \"<slug>\")] | length" parity-baseline.json
 1. **具体 EN HTML anomaly への traceability**: 該当 artifact が `snapshots/en/content/<slug>.html` 内の具体的な EN 側不整合（例: `<a href="...">display-text</a>` の href と display-text 不一致 / EN-only ZWS / broken anchor 等）に 1:1 対応すること。「EN が曖昧だから」等の抽象理由は不可
 2. **1 slug あたり最大 1 件**: 同一 slug で 2 件以上発生した場合は baseline せず、upstream 修正待ちとして Phase 4 plan の `source_sync_exclusions` に page 単位で登録するか否かを判断する
 3. **Baseline entry への justification comment 必須**: `parity-baseline.json` の該当 entry に `rationale` フィールドで具体 anomaly を 1 文で記述する（例: `"EN-only broken href: display='google.com' vs href=''"`）。記述なしの baseline 追加は禁止
-4. **reviewAfter 期限 ≤ 3 ヶ月**: 長期凍結禁止。期限切れは `orphanBaselineEntries` として検知される
+4. **schema v2 契約**: `priority` (`high`/`medium`/`low`、default `medium`) を必ず設定し、`note` フィールドに具体 anomaly の 1 文記述を書く。長期凍結禁止の運用圧力は `priority='high'` + PR paydown schedule で維持する (v2 では `reviewAfter` 期限概念は撤廃)
 
 **判定フロー**:
 

--- a/docs/superpowers/specs/2026-04-14-parity-phase4-report.md
+++ b/docs/superpowers/specs/2026-04-14-parity-phase4-report.md
@@ -1,0 +1,121 @@
+# Parity Phase 4 — Final Cutover Report (PR Z)
+
+**Generated:** 2026-04-20
+**Branch:** `claude/pr-z-schema-v2-cutover`
+**Plan reference:** `docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md` (Rev 7)
+
+---
+
+## 完了条件 (all true)
+
+- [x] `parity-baseline.json.entries.length = 0`
+- [x] `parity-baseline.json.schemaVersion = 2`
+- [x] `parity-check-status.summary.reportableActiveFiles = 0`
+- [x] `parity-check-status.summary.baselinedIssues = 0`
+- [x] `parity-check-status.summary.advisoryQueueIssues = 0`
+- [x] `parity-check-status.summary.auditSignalIssues = 0`
+- [x] `parity-check-status.debug.artifactCoverage` shape OK (`{ registryEntries, matchedHits, bySlug, byToken }`)
+- [x] `parity-check-status.debug.baselineSchemaVersion = 2`
+- [x] `snapshot-diff-status.summary.{changed, added, removed} = 0`
+- [x] `npm run test` green (2150 pass / 0 fail / 1 skip)
+- [x] `npm run lint` green (0 errors / 0 warnings in 288 files)
+- [x] `npm run build` green (290 pages built)
+- [x] `alignSegments()` call-site leak scan: 0 (全 runtime + test call が `{ slug }` option 付き)
+- [x] deprecated field scope grep clean — baseline 側の `reviewAfter` / `baselineReviewAfter` / `baselineExpired` は全撤去 (en_source_patches / acknowledgements 側は別 schema として保持)
+
+---
+
+## 削減結果
+
+| Metric | Phase 4 cutover 前 | Phase 4 完了後 (PR Z) |
+|---|---|---|
+| `parity-baseline.json.entries.length` | 14 (M2.5-C 開始時) | **0** |
+| `parity-baseline.json.schemaVersion` | 1 | **2** |
+| `reportableActiveFiles` | > 0 | **0** |
+| `auditSignalIssues` | > 0 | **0** |
+| `advisoryQueueIssues` | > 0 | **0** |
+| `segment-inconclusive` (baselined) | 発生可能 | **baseline 対象外** |
+| `snapshot-incomplete` / `source-unusable` (baselined) | 発生可能 | **baseline 対象外** |
+
+---
+
+## Schema migration (v1 → v2)
+
+**削除 (entry fields):**
+- `reviewAfter` — 期限管理を撤廃 (`priority` に置換)
+- `inconclusiveReason` / `inconclusiveCategory` — runtime issue のみ保持
+- `usabilityReason` — baseline 対象外になったため不要
+
+**削除 (tagging / queue fields):**
+- `baselineReviewAfter` — `tagIssuesWithBaseline()` から撤去
+- `baselineExpired` / `baselineExpiringSoon` — 期限概念全廃
+- `expiredBaselineEntries` / `expiringBaselineEntries30d` (summary counters) — 同
+
+**追加 (entry fields):**
+- `priority: 'high' | 'medium' | 'low'` — 必須、default `'medium'`
+- `note: string | null` — 任意、max 500 chars
+
+**追加 (status payload):**
+- `debug.baselineSchemaVersion` — runtime が読んだ baseline schema を明示
+
+**縮約 (`BASELINE_ELIGIBLE_TYPES`, 10 → 7):**
+```
+segment-missing, segment-extra, segment-shifted,
+segment-untranslated, segment-token-gap,
+section-structure-mismatch, segment-order-mismatch
+```
+除外: `segment-inconclusive`, `snapshot-incomplete`, `source-unusable`
+
+**縮約 (`TYPES_ARG_ALLOWLIST`, 4 → 2):**
+```
+section-structure-mismatch, segment-order-mismatch
+```
+
+**契約 (schema v2):**
+- `isFrozenByBaseline(issue) ≡ issue.baselined === true`
+- `alignSegments()` は必ず `{ slug }` option 付きで呼ばれる (全 runtime / test call 移行済)
+- `debug.artifactCoverage` は `{ registryEntries, matchedHits, bySlug, byToken }` (値は非ゼロ可)
+- generator CLI は `--review-after` を reject (exit 1) — v2 では該当 field が存在しない
+
+---
+
+## 運用側の変更
+
+**Baseline 運用:**
+- 新規 issue を baseline に逃がす運用圧力は廃止 (`priority='high'` + 明示 PR paydown で代替)
+- Phase 4 完了後は `entries.length === 0` 維持が DoD
+
+**CI gate:**
+- `reportableActiveFiles / baselinedIssues / advisoryQueueIssues / auditSignalIssues` 4 counter ＋ snapshot-diff 3 counter ＋ `baseline.entries.length` で機械判定
+- 期限切れ concept が無いため "baseline refires gate" tests は撤去済
+
+**Tooling:**
+- `scripts/phase4/migrate_baseline_schema.mjs` — v1→v2 migration helper (export `migrateEntry` / `migrateBaseline`)
+- `generate_parity_baseline.mjs` は v2 を出力 (`--regenerate` / `--slug` / `--types=section-structure-mismatch,segment-order-mismatch`)
+
+---
+
+## Checker simplification
+
+Phase 4 で入った新機構 (既出):
+
+- `parity_normalize`: `help.testim.io` ↔ `/docs` URL fragment 対称化
+- `parity_artifact_registry`: slug-scope token + runtime coverage aggregator
+- `preprocessHtml`: slug allow list 限定 `<blockquote>→<div class="callout-note">` (turndown 非侵襲)
+- `alignSegments({ slug, coverage })` 化 + 全呼出移行
+
+PR Z で追加された切り替え:
+
+- baseline v2 validator / loader (期限関数削除 / priority/note 検証)
+- generator v2 出力 + migration helper
+- summary / advisory / detection_reports / status v2 対応
+
+---
+
+## 残タスク (本 PR の外)
+
+1. **Phase A (`claude/upstream-recovery-phase-a`)** — PR Z 並列可 — `check_upstream_recovery.mjs` + test 拡張 + `reviewAfter` parity (sync_exclusions)
+2. **Phase B (`claude/upstream-recovery-phase-b`)** — PR Z merge **後**必須 — detection_reports の `enPatchRecovery` / `sourceSyncRecovery` section + sticky PR comment + 2-mechanism lifecycle docs
+3. **pull-requests.md cleanup** — 別 PR として分離 (seeded pin test との scope 混合回避)
+
+詳細: `docs/superpowers/plans/2026-04-20-upstream-recovery-detection.md`

--- a/parity-baseline.json
+++ b/parity-baseline.json
@@ -1,7 +1,7 @@
 {
-  "schemaVersion": 1,
-  "generatedAt": "2026-04-20T04:59:53.111Z",
+  "schemaVersion": 2,
+  "generatedAt": "2026-04-20T07:39:59.796Z",
   "generatedFromRunId": "2026-04-20T04:59:53.111Z#parity-check-status",
-  "rationale": "M2.5-C content burndown — source-first mirror",
+  "rationale": "M2.5-C content burndown — source-first mirror / Phase 4 v2",
   "entries": []
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -565,15 +565,21 @@ frozen baseline 機構は exact diff engine を deterministic に primary gate �
 
 - `scripts/lib/source_parity_baseline.mjs` — schema validation, key 生成,
   page-level invalidation を含む tagging（純粋関数のみ）
-- `scripts/generate_parity_baseline.mjs` — baseline 生成 CLI
-  - `--regenerate` で full、`--slug=<csv>` で partial 再生成
+- `scripts/generate_parity_baseline.mjs` — baseline 生成 CLI (schema v2)
+  - `--regenerate` で full、`--slug=<csv>` で partial 再生成、`--types=<csv>` で
+    structure family のみ部分再生成 (`section-structure-mismatch` /
+    `segment-order-mismatch` の 2 種のみ許可)
   - 入力の `parity-check-status.json` は full `npm run check:parity` 実行結果が必須
-  - `--rationale=<text>` / `--review-after=<YYYY-MM-DD>` で再現性を確保
-  - 出力は deterministic（`parity-check-status.json` の
+  - `--rationale=<text>` で provenance を明示化
+  - **v2 で `--review-after` option は削除された**。stale 指定時は exit 1 で reject
+  - 出力は deterministic (`parity-check-status.json` の
     `summary.checkedAt` を `generatedAt` / `generatedFromRunId` の seed に使い、
-    安定ソート + 2-space indent + LF 終端）
-- `parity-baseline.json` — frozen baseline file (entries は staggered reviewAfter で
-  cliff failure を防ぐ)
+    安定ソート + 2-space indent + LF 終端)
+- `parity-baseline.json` — frozen baseline file (schema v2)。各 entry は
+  `priority` (`high`/`medium`/`low`, default `medium`) と任意 `note` を持つ。
+  Phase 4 cutover 後は `entries.length === 0` を維持する
+- `scripts/phase4/migrate_baseline_schema.mjs` — one-shot v1→v2 migration
+  helper (`migrateEntry` / `migrateBaseline` を export)
 
 **npm script**:
 
@@ -588,8 +594,10 @@ npm run generate:parity-baseline -- --slug=overview/foo # 部分再生成
 - gate: `segment-*` issue は primary gate の actionable 集計に乗り、frozen baseline
   で既存 drift を active 集計から除外する
 - recall benchmark: 9/9 strict mutation type で 100% を維持する (Recall ベンチマークの節を参照)
-- baseline 失効: `reviewAfter` を過ぎた entry は gate に refire する。
-  paydown は明示的な PR で進め、期限切れの自動再点火に頼らない
+- baseline は v2 schema で期限管理を撤廃済。entry が載ったままになる抑止は
+  `priority='high'` + 明示 PR による paydown schedule で行う。新規 issue を
+  baseline に逃がすのではなく、artifact registry / normalizer / extractor /
+  翻訳追従で解消する (Phase 4 完了後は `entries.length === 0` 維持)
 - snapshot drift で baseline が invalidate された場合は translate-first を原則とし、
   rebaseline は justification 必須の例外として扱う
 

--- a/scripts/__tests__/baseline_schema_migration.test.mjs
+++ b/scripts/__tests__/baseline_schema_migration.test.mjs
@@ -1,0 +1,254 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  migrateEntry,
+  migrateBaseline,
+} from '../phase4/migrate_baseline_schema.mjs';
+
+const VALID_FP = 'sha256:' + 'f'.repeat(64);
+
+function v1SegmentMissingEntry(overrides = {}) {
+  return {
+    slug: 'overview/foo',
+    issueType: 'segment-missing',
+    snapshotFingerprint: VALID_FP,
+    reviewAfter: '2026-10-09',
+    sectionPath: 'header',
+    segmentKind: 'paragraph',
+    enSegmentIndex: 3,
+    jaSegmentIndex: null,
+    enSourceFingerprint: VALID_FP,
+    jaSourceFingerprint: null,
+    missingTokens: null,
+    inconclusiveCategory: null,
+    inconclusiveReason: null,
+    sectionIndex: null,
+    structureCategory: null,
+    structureFingerprint: null,
+    usabilityReason: null,
+    ...overrides,
+  };
+}
+
+describe('migrateEntry — v1 → v2 field migration', () => {
+  it('drops the 4 removed fields (reviewAfter / inconclusiveReason / inconclusiveCategory / usabilityReason)', () => {
+    const v1 = v1SegmentMissingEntry({
+      reviewAfter: '2026-10-09',
+      inconclusiveReason: 'some reason',
+      inconclusiveCategory: 'align-exception',
+      usabilityReason: 'shallow-snapshot',
+    });
+
+    const v2 = migrateEntry(v1);
+
+    assert.ok(v2);
+    assert.equal(Object.hasOwn(v2, 'reviewAfter'), false);
+    assert.equal(Object.hasOwn(v2, 'inconclusiveReason'), false);
+    assert.equal(Object.hasOwn(v2, 'inconclusiveCategory'), false);
+    assert.equal(Object.hasOwn(v2, 'usabilityReason'), false);
+  });
+
+  it('drops entries of the 3 removed issueTypes (segment-inconclusive / snapshot-incomplete / source-unusable)', () => {
+    for (const removedType of [
+      'segment-inconclusive',
+      'snapshot-incomplete',
+      'source-unusable',
+    ]) {
+      const v1 = v1SegmentMissingEntry({ issueType: removedType });
+      const v2 = migrateEntry(v1);
+      assert.equal(v2, null, `issueType=${removedType} must be dropped`);
+    }
+  });
+
+  it('defaults priority to "medium" when absent', () => {
+    const v1 = v1SegmentMissingEntry();
+    // Sanity: v1 entries never carry priority.
+    assert.equal(Object.hasOwn(v1, 'priority'), false);
+
+    const v2 = migrateEntry(v1);
+
+    assert.equal(v2.priority, 'medium');
+  });
+
+  it('preserves an existing priority value (does not overwrite)', () => {
+    const v1 = v1SegmentMissingEntry();
+    v1.priority = 'high';
+
+    const v2 = migrateEntry(v1);
+
+    assert.equal(v2.priority, 'high');
+  });
+
+  it('treats null priority as missing and defaults to "medium"', () => {
+    const v1 = v1SegmentMissingEntry();
+    v1.priority = null;
+
+    const v2 = migrateEntry(v1);
+
+    assert.equal(v2.priority, 'medium');
+  });
+
+  it('preserves identity fields (slug / issueType / snapshotFingerprint / enSegmentIndex / enSourceFingerprint)', () => {
+    const v1 = v1SegmentMissingEntry({ enSegmentIndex: 7 });
+
+    const v2 = migrateEntry(v1);
+
+    assert.equal(v2.slug, 'overview/foo');
+    assert.equal(v2.issueType, 'segment-missing');
+    assert.equal(v2.snapshotFingerprint, VALID_FP);
+    assert.equal(v2.enSegmentIndex, 7);
+    assert.equal(v2.enSourceFingerprint, VALID_FP);
+  });
+
+  it('returns null for non-object inputs (defensive)', () => {
+    assert.equal(migrateEntry(null), null);
+    assert.equal(migrateEntry(undefined), null);
+    assert.equal(migrateEntry(42), null);
+    assert.equal(migrateEntry('string'), null);
+  });
+
+  it('migrates structure-mismatch entries (identity preserved, priority defaulted)', () => {
+    const v1 = {
+      slug: 'overview/foo',
+      issueType: 'section-structure-mismatch',
+      snapshotFingerprint: VALID_FP,
+      reviewAfter: '2026-10-09',
+      sectionPath: 'h1',
+      sectionIndex: 2,
+      structureCategory: 'kind-multiset',
+      structureFingerprint: VALID_FP,
+    };
+
+    const v2 = migrateEntry(v1);
+
+    assert.ok(v2);
+    assert.equal(v2.issueType, 'section-structure-mismatch');
+    assert.equal(v2.sectionIndex, 2);
+    assert.equal(v2.structureCategory, 'kind-multiset');
+    assert.equal(v2.structureFingerprint, VALID_FP);
+    assert.equal(v2.priority, 'medium');
+    assert.equal(Object.hasOwn(v2, 'reviewAfter'), false);
+  });
+});
+
+describe('migrateBaseline — top-level payload migration', () => {
+  it('bumps schemaVersion to 2 and annotates rationale with "Phase 4 v2"', () => {
+    const v1 = {
+      schemaVersion: 1,
+      generatedAt: '2026-04-09T00:00:00Z',
+      generatedFromRunId: 'run-1',
+      rationale: 'frozen baseline',
+      entries: [],
+    };
+
+    const v2 = migrateBaseline(v1);
+
+    assert.equal(v2.schemaVersion, 2);
+    assert.match(v2.rationale, /Phase 4 v2/);
+  });
+
+  it('does not double-annotate rationale on already-migrated input', () => {
+    const existing = {
+      schemaVersion: 1,
+      rationale: 'frozen baseline / Phase 4 v2',
+      entries: [],
+    };
+
+    const v2 = migrateBaseline(existing);
+
+    // Only one occurrence of "Phase 4 v2" should appear in the rationale.
+    const matches = v2.rationale.match(/Phase 4 v2/g) ?? [];
+    assert.equal(matches.length, 1);
+  });
+
+  it('filters out dropped-type entries from the migrated payload', () => {
+    const v1 = {
+      schemaVersion: 1,
+      rationale: 'frozen baseline',
+      entries: [
+        v1SegmentMissingEntry({ slug: 'a' }),
+        v1SegmentMissingEntry({ slug: 'b', issueType: 'segment-inconclusive' }),
+        v1SegmentMissingEntry({ slug: 'c', issueType: 'source-unusable' }),
+        v1SegmentMissingEntry({ slug: 'd' }),
+      ],
+    };
+
+    const v2 = migrateBaseline(v1);
+
+    assert.equal(v2.entries.length, 2);
+    assert.deepEqual(
+      v2.entries.map((e) => e.slug),
+      ['a', 'd'],
+    );
+  });
+
+  it('defaults every migrated entry priority to "medium" when absent', () => {
+    const v1 = {
+      schemaVersion: 1,
+      rationale: 'frozen baseline',
+      entries: [v1SegmentMissingEntry(), v1SegmentMissingEntry({ slug: 'other' })],
+    };
+
+    const v2 = migrateBaseline(v1);
+
+    for (const entry of v2.entries) {
+      assert.equal(entry.priority, 'medium');
+    }
+  });
+
+  it('sets a fresh generatedAt timestamp (ISO 8601 UTC)', () => {
+    const v1 = {
+      schemaVersion: 1,
+      generatedAt: '2023-01-01T00:00:00Z',
+      rationale: 'frozen baseline',
+      entries: [],
+    };
+
+    const before = Date.now();
+    const v2 = migrateBaseline(v1);
+    const after = Date.now();
+
+    assert.ok(typeof v2.generatedAt === 'string');
+    const generatedAtMs = Date.parse(v2.generatedAt);
+    assert.ok(Number.isFinite(generatedAtMs));
+    assert.ok(generatedAtMs >= before && generatedAtMs <= after);
+  });
+
+  it('throws when input is not an object', () => {
+    assert.throws(() => migrateBaseline(null), /must be a baseline object/);
+    assert.throws(() => migrateBaseline([]), /must be a baseline object/);
+    assert.throws(() => migrateBaseline('string'), /must be a baseline object/);
+  });
+
+  it('throws when entries is not an array (fail-closed on corrupt input)', () => {
+    // Regression pin for Codex C1 / reviewer R1: silent coercion of a non-array
+    // entries field to [] would mask corrupted input behind a technically-valid
+    // empty v2 baseline. Fail-closed is the only safe behavior for a migration.
+    assert.throws(
+      () => migrateBaseline({ schemaVersion: 1, entries: 'oops' }),
+      /entries must be an array/,
+    );
+    assert.throws(
+      () => migrateBaseline({ schemaVersion: 1, entries: null }),
+      /entries must be an array/,
+    );
+    assert.throws(
+      () => migrateBaseline({ schemaVersion: 1, entries: { not: 'array' } }),
+      /entries must be an array/,
+    );
+  });
+
+  it('handles empty entries array cleanly (round-trip test)', () => {
+    const v1 = {
+      schemaVersion: 1,
+      rationale: 'frozen baseline',
+      entries: [],
+    };
+
+    const v2 = migrateBaseline(v1);
+
+    assert.deepEqual(v2.entries, []);
+    assert.equal(v2.schemaVersion, 2);
+  });
+});

--- a/scripts/__tests__/check_source_parity.test.mjs
+++ b/scripts/__tests__/check_source_parity.test.mjs
@@ -417,12 +417,13 @@ describe('CLI coverage helpers', () => {
 
     it('baselined snapshot-incomplete 単独 → " (covered by baseline/ack)"', () => {
       // baseline 経路も advisory より優先。
+      // (schema v2 では baselineExpired/baselineReviewAfter は emit されないので
+      //  fixture にも付けない — `baselined: true` のみが gate state を駆動する)
       const state = getConsoleCoverageState([
         {
           type: 'snapshot-incomplete',
           severity: 'actionable',
           baselined: true,
-          baselineExpired: false,
         },
       ]);
       assert.deepEqual(state, {

--- a/scripts/__tests__/check_source_parity.test.mjs
+++ b/scripts/__tests__/check_source_parity.test.mjs
@@ -134,11 +134,10 @@ describe('CLI coverage helpers', () => {
     assert.equal(isValidAcknowledgedIssue({ acknowledged: false, ackExpired: false }), false);
   });
 
-  it('treats non-expired baselines and valid acknowledgements as non-blocking', () => {
+  it('treats baselined issues and valid acknowledgements as non-blocking', () => {
     assert.equal(isNonBlockingIssue({ baselined: true }), true);
     assert.equal(isNonBlockingIssue({ acknowledged: true, ackExpired: false }), true);
-    // 期限切れ baseline は再び blocking 扱いに戻る。
-    assert.equal(isNonBlockingIssue({ baselined: true, baselineExpired: true }), false);
+    // v2: baseline expiry is gone — baselined:true always freezes the issue.
     assert.equal(isNonBlockingIssue({ acknowledged: true, ackExpired: true }), false);
     assert.equal(isNonBlockingIssue({ severity: 'actionable' }), false);
   });
@@ -166,17 +165,6 @@ describe('CLI coverage helpers', () => {
       allCovered: true,
       icon: '⏸️',
       suffix: ' (covered by baseline/ack)',
-    });
-  });
-
-  it('treats expired baselines as blocking for console coverage', () => {
-    // 期限切れ baseline は console coverage でも blocking に戻す。
-    const state = getConsoleCoverageState([{ baselined: true, baselineExpired: true }]);
-    assert.deepEqual(state, {
-      allAcked: false,
-      allCovered: false,
-      icon: '❌',
-      suffix: '',
     });
   });
 
@@ -244,7 +232,6 @@ describe('CLI coverage helpers', () => {
           type: 'section-structure-mismatch',
           severity: 'actionable',
           baselined: true,
-          baselineExpired: false,
         },
         { type: 'segment-missing', severity: 'actionable' },
       ]);
@@ -262,7 +249,6 @@ describe('CLI coverage helpers', () => {
           type: 'section-structure-mismatch',
           severity: 'actionable',
           baselined: true,
-          baselineExpired: false,
         },
       ]);
       assert.deepEqual(state, {
@@ -296,7 +282,6 @@ describe('CLI coverage helpers', () => {
           type: 'section-structure-mismatch',
           severity: 'actionable',
           baselined: true,
-          baselineExpired: false,
         },
         { type: 'source-unusable', severity: 'actionable' },
       ]);
@@ -308,36 +293,17 @@ describe('CLI coverage helpers', () => {
       });
     });
 
-    it('expired baseline on structure-mismatch → icon ❌, suffix "" (re-fire)', () => {
-      const state = getConsoleCoverageState([
-        {
-          type: 'section-structure-mismatch',
-          severity: 'actionable',
-          baselined: true,
-          baselineExpired: true,
-        },
-      ]);
-      assert.deepEqual(state, {
-        allAcked: false,
-        allCovered: false,
-        icon: '❌',
-        suffix: '',
-      });
-    });
-
     it('structure-mismatch + source-unusable both baselined → icon ⏸️, suffix " (covered by baseline/ack)"', () => {
       const state = getConsoleCoverageState([
         {
           type: 'section-structure-mismatch',
           severity: 'actionable',
           baselined: true,
-          baselineExpired: false,
         },
         {
           type: 'source-unusable',
           severity: 'actionable',
           baselined: true,
-          baselineExpired: false,
         },
       ]);
       assert.deepEqual(state, {
@@ -576,7 +542,7 @@ describe('computeExitCode (gate uses reportableActive counters)', () => {
     assert.equal(computeExitCode(summary, null), 0);
   });
 
-  it('returns 0 for coarse-only with expired baseline', () => {
+  it('returns 0 for coarse-only baselined run (baselined:true freezes the audit signal)', () => {
     const summary = {
       reportableActiveFiles: 0,
       reportableActiveActionableFiles: 0,
@@ -585,7 +551,7 @@ describe('computeExitCode (gate uses reportableActive counters)', () => {
       activeFiles: 1,
       activeActionableFiles: 0,
       activeErrorFiles: 0,
-      expiredBaselineEntries: 1,
+      baselinedIssues: 1,
     };
     assert.equal(computeExitCode(summary, 'actionable'), 0);
     assert.equal(computeExitCode(summary, 'any'), 0);
@@ -796,6 +762,29 @@ describe('parity-check-status.json — debug.artifactCoverage emit (Phase 4)', (
       assert.equal(typeof ac.matchedHits, 'number');
       assert.ok(typeof ac.bySlug === 'object' && ac.bySlug !== null);
       assert.ok(typeof ac.byToken === 'object' && ac.byToken !== null);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v2 cutover: debug.baselineSchemaVersion must be 2
+// ---------------------------------------------------------------------------
+
+describe('parity-check-status.json — debug.baselineSchemaVersion is 2 (v2 cutover)', () => {
+  it('status.debug.baselineSchemaVersion === 2 when baseline is loaded', async () => {
+    const { default: main } = await import('../check_source_parity.mjs');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'parity-baseline-schema-'));
+    const outputPath = path.join(tmp, 'parity-check-status.json');
+    try {
+      await main({ outputPath });
+      const status = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+      assert.equal(
+        status.debug?.baselineSchemaVersion,
+        2,
+        'debug.baselineSchemaVersion must reflect v2 after cutover',
+      );
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -492,50 +492,6 @@ describe('buildActionableReport', () => {
     assert.equal(report.parityRegression.summary.issueCount, 0);
   });
 
-  it('does NOT re-light parity issue for expired-baseline on coarse signal', () => {
-    // Same intent via the baseline path.
-    const snapshot = {
-      checkedAt: '2026-03-19T00:00:00Z',
-      summary: { totalSnapshots: 100, changed: 0, added: 0, removed: 0, unchanged: 100 },
-      changes: [],
-      sidebar: { changed: false, addedPages: [], removedPages: [] },
-    };
-    const parity = {
-      summary: {
-        checkedAt: '2026-03-19T00:00:00Z',
-        actionableFiles: 0,
-        signalFiles: 1,
-        errorFiles: 0,
-        activeActionableFiles: 0,
-        activeFiles: 1,
-        activeErrorFiles: 0,
-        expiredBaselineEntries: 1,
-        issuesByType: { 'heading-mismatch': 1 },
-        issuesBySeverity: { signal: 1 },
-      },
-      files: [
-        {
-          file: 'src/content/docs/example.md',
-          issues: [
-            {
-              type: 'heading-mismatch',
-              severity: 'signal',
-              detail: 'expired baseline coarse',
-              baselined: true,
-              baselineExpired: true,
-            },
-          ],
-        },
-      ],
-      advisoryQueue: [],
-      advisoryQueueScope: null,
-    };
-
-    const report = buildActionableReport(snapshot, parity, []);
-    assert.equal(report.parityRegression.shouldOpenIssue, false);
-    assert.equal(report.parityRegression.summary.issueCount, 0);
-  });
-
   it('filters acknowledged issues out of top entries but keeps active ones on the same file', () => {
     const snapshot = {
       checkedAt: '2026-03-19T00:00:00Z',
@@ -763,7 +719,6 @@ describe('renderSummaryMarkdown', () => {
           baselineDebt: {
             baselinedIssues: 1,
             baselinedFiles: 1,
-            expiredBaselineEntries: 1,
             baselineInvalidatedSlugs: ['overview/page-a'],
           },
           advisoryQueue: {
@@ -889,7 +844,6 @@ describe('parityFollowup in buildActionableReport', () => {
       errorFiles: 0,
       baselinedIssues: 0,
       baselinedFiles: 0,
-      expiredBaselineEntries: 0,
       baselineInvalidatedSlugs: [],
       advisoryQueueIssues: 0,
       advisoryQueueFiles: 0,
@@ -916,14 +870,28 @@ describe('parityFollowup in buildActionableReport', () => {
     assert.equal(report.parityFollowup.body, '');
   });
 
-  it('shouldOpenIssue = true when expiredBaselineEntries > 0', () => {
+  it('shouldOpenIssue = true when baselinedIssues > 0', () => {
     const parity = {
       ...cleanParity,
-      summary: { ...cleanParity.summary, expiredBaselineEntries: 3 },
+      summary: {
+        ...cleanParity.summary,
+        baselinedIssues: 3,
+        baselinedFiles: 1,
+      },
+      files: [
+        {
+          file: 'src/content/docs/overview/page-a.md',
+          issues: [
+            { type: 'segment-missing', severity: 'actionable', baselined: true, detail: 'frozen1' },
+            { type: 'segment-extra', severity: 'actionable', baselined: true, detail: 'frozen2' },
+            { type: 'segment-shifted', severity: 'actionable', baselined: true, detail: 'frozen3' },
+          ],
+        },
+      ],
     };
     const report = buildActionableReport(emptySnapshot, parity, []);
     assert.equal(report.parityFollowup.shouldOpenIssue, true);
-    assert.equal(report.parityFollowup.summary.baselineDebt.expiredBaselineEntries, 3);
+    assert.equal(report.parityFollowup.summary.baselineDebt.baselinedIssues, 3);
   });
 
   it('shouldOpenIssue = true when baselineInvalidatedSlugs has entries', () => {
@@ -987,7 +955,8 @@ describe('parityFollowup in buildActionableReport', () => {
       ...cleanParity,
       summary: {
         ...cleanParity.summary,
-        expiredBaselineEntries: 1,
+        // baselineInvalidatedSlugs triggers parityFollowup to open.
+        baselineInvalidatedSlugs: ['overview/page-a'],
         advisoryQueueIssues: 2,
         advisoryQueueFiles: 1,
       },
@@ -998,10 +967,7 @@ describe('parityFollowup in buildActionableReport', () => {
             {
               type: 'segment-missing',
               severity: 'actionable',
-              baselined: true,
-              baselineExpired: true,
-              baselineReviewAfter: '2026-03-01',
-              detail: 'expired',
+              detail: 'invalidated slug re-fire',
             },
           ],
         },
@@ -1058,16 +1024,20 @@ describe('parityFollowup in buildActionableReport', () => {
     ]);
   });
 
-  it('parityFollowup body contains expired baseline file details', () => {
+  it('parityFollowup body contains baselined file details', () => {
     const parity = {
       ...cleanParity,
-      summary: { ...cleanParity.summary, expiredBaselineEntries: 2 },
+      summary: {
+        ...cleanParity.summary,
+        baselinedIssues: 2,
+        baselinedFiles: 1,
+      },
       files: [
         {
           file: 'src/content/docs/overview/page-a.md',
           issues: [
-            { type: 'segment-missing', severity: 'actionable', baselined: true, baselineExpired: true, baselineReviewAfter: '2026-03-01', detail: 'expired' },
-            { type: 'segment-extra', severity: 'actionable', baselined: true, baselineExpired: true, detail: 'expired2' },
+            { type: 'segment-missing', severity: 'actionable', baselined: true, detail: 'frozen' },
+            { type: 'segment-extra', severity: 'actionable', baselined: true, detail: 'frozen2' },
           ],
         },
       ],
@@ -1186,7 +1156,6 @@ describe('parityFollowup sourceUnusable subsection exposure', () => {
       errorFiles: 0,
       baselinedIssues: 0,
       baselinedFiles: 0,
-      expiredBaselineEntries: 0,
       baselineInvalidatedSlugs: [],
       advisoryQueueIssues: 0,
       advisoryQueueFiles: 0,
@@ -1247,7 +1216,8 @@ describe('parityFollowup sourceUnusable subsection exposure', () => {
       ...cleanParity,
       summary: {
         ...cleanParity.summary,
-        expiredBaselineEntries: 1,
+        baselinedIssues: 1,
+        baselinedFiles: 1,
         snapshotUnusableIssues: 4,
         snapshotUnusableFiles: 2,
         snapshotUnusableByType: { 'snapshot-incomplete': 3, 'source-unusable': 1 },
@@ -1260,9 +1230,7 @@ describe('parityFollowup sourceUnusable subsection exposure', () => {
               type: 'segment-missing',
               severity: 'actionable',
               baselined: true,
-              baselineExpired: true,
-              baselineReviewAfter: '2026-03-01',
-              detail: 'expired',
+              detail: 'frozen',
             },
           ],
         },
@@ -1285,7 +1253,8 @@ describe('parityFollowup sourceUnusable subsection exposure', () => {
       ...cleanParity,
       summary: {
         ...cleanParity.summary,
-        expiredBaselineEntries: 1,
+        baselinedIssues: 1,
+        baselinedFiles: 1,
         snapshotUnusableIssues: 0,
         snapshotUnusableFiles: 0,
         snapshotUnusableByType: {},
@@ -1298,8 +1267,7 @@ describe('parityFollowup sourceUnusable subsection exposure', () => {
               type: 'segment-missing',
               severity: 'actionable',
               baselined: true,
-              baselineExpired: true,
-              detail: 'expired',
+              detail: 'frozen',
             },
           ],
         },
@@ -1364,7 +1332,6 @@ describe('renderSummaryMarkdown structure / source unusable sections', () => {
           baselineDebt: {
             baselinedIssues: 0,
             baselinedFiles: 0,
-            expiredBaselineEntries: 0,
             baselineInvalidatedSlugs: [],
           },
           advisoryQueue: { issues: 0, files: 0, blockingItems: 0, advisoryQueueScope: null },
@@ -1431,7 +1398,7 @@ describe('renderSummaryMarkdown structure / source unusable sections', () => {
       },
       parityFollowup: {
         summary: {
-          baselineDebt: { baselinedIssues: 0, baselinedFiles: 0, expiredBaselineEntries: 0, baselineInvalidatedSlugs: [] },
+          baselineDebt: { baselinedIssues: 0, baselinedFiles: 0, baselineInvalidatedSlugs: [] },
           advisoryQueue: { issues: 0, files: 0, blockingItems: 0, advisoryQueueScope: null },
           sourceUnusable: {
             snapshotUnusableIssues: 0,
@@ -1500,40 +1467,14 @@ describe('parityRegression excludes non-expired baselined issues', () => {
     assert.deepEqual(report.parityRegression.summary.issuesBySeverity, {});
   });
 
-  it('opens parity issue when baselined issue has expired', () => {
+  it('baselined issue is NEVER in parityRegression topEntries (v2: no expiry)', () => {
+    // v2: baselined:true alone freezes the issue — there is no expiry path to
+    // re-fire it. Non-baselined active issues still appear.
     const parity = {
       summary: {
         checkedAt: '2026-04-07T00:00:00Z',
         actionableFiles: 1,
         errorFiles: 0,
-        expiredBaselineEntries: 1,
-        activeActionableFiles: 1,
-        activeFiles: 1,
-        baselineInvalidatedSlugs: [],
-      },
-      files: [
-        {
-          file: 'src/content/docs/overview/page-a.md',
-          issues: [
-            { type: 'segment-missing', severity: 'actionable', baselined: true, baselineExpired: true, detail: 'expired' },
-          ],
-        },
-      ],
-      advisoryQueue: [],
-      advisoryQueueScope: null,
-    };
-    const report = buildActionableReport(emptySnapshot, parity, []);
-    assert.equal(report.parityRegression.shouldOpenIssue, true);
-    assert.equal(report.parityRegression.summary.issueCount, 1);
-  });
-
-  it('baselined issue is NOT in parityRegression topEntries but expired baselined IS', () => {
-    const parity = {
-      summary: {
-        checkedAt: '2026-04-07T00:00:00Z',
-        actionableFiles: 1,
-        errorFiles: 0,
-        expiredBaselineEntries: 1,
         activeActionableFiles: 1,
         baselineInvalidatedSlugs: [],
       },
@@ -1542,7 +1483,7 @@ describe('parityRegression excludes non-expired baselined issues', () => {
           file: 'src/content/docs/overview/page-a.md',
           issues: [
             { type: 'segment-missing', severity: 'actionable', baselined: true, detail: 'frozen — must not appear' },
-            { type: 'segment-extra', severity: 'actionable', baselined: true, baselineExpired: true, detail: 'expired — must appear' },
+            { type: 'segment-extra', severity: 'actionable', detail: 'active — must appear' },
           ],
         },
       ],
@@ -1878,23 +1819,23 @@ describe('parityRegression excludes coarse audit signals', () => {
     assert.equal(report.parityRegression.summary.issueCount, 0);
   });
 
-  it('coarse-only file does not appear in parityRegression even with expired baseline', () => {
+  it('coarse-only file with baselined: true still does not appear in parityRegression', () => {
+    // v2: baselined:true always freezes. Coarse signals are also non-reportable
+    // by type regardless of baseline state.
     const parity = {
       summary: {
         checkedAt: '2026-04-07T00:00:00Z',
         actionableFiles: 0,
-        expiredBaselineEntries: 1,
       },
       files: [
         {
-          file: 'src/content/docs/expired-baseline-coarse.md',
+          file: 'src/content/docs/baselined-coarse.md',
           issues: [
             {
               type: 'heading-mismatch',
               severity: 'signal',
-              detail: 'expired baseline',
+              detail: 'frozen coarse',
               baselined: true,
-              baselineExpired: true,
             },
           ],
         },
@@ -2032,7 +1973,7 @@ describe('family count and audit manifest invariants', () => {
       parityRegression: { summary: { issueCount: 0 } },
       parityFollowup: {
         summary: {
-          baselineDebt: { baselinedIssues: 0, baselinedFiles: 0, expiredBaselineEntries: 0, baselineInvalidatedSlugs: [] },
+          baselineDebt: { baselinedIssues: 0, baselinedFiles: 0, baselineInvalidatedSlugs: [] },
           advisoryQueue: { issues: 0, files: 0, blockingItems: 0, advisoryQueueScope: null },
         },
       },

--- a/scripts/__tests__/generate_parity_baseline.test.mjs
+++ b/scripts/__tests__/generate_parity_baseline.test.mjs
@@ -1,9 +1,19 @@
 /**
- * Tests for the baseline generation script.
+ * Tests for the baseline generation script (schema v2).
  *
  * Validates pure helpers (buildBaselineFromStatus, serializeBaseline,
- * mergePartialBaseline, defaultReviewAfter) and verifies determinism.
+ * mergePartialBaseline) and verifies determinism.
  * The CLI invocation is exercised by an end-to-end smoke test.
+ *
+ * v2 変更点:
+ *   - `--review-after` フラグ撤去 (渡すと exit 1)
+ *   - baseline entry から reviewAfter / inconclusiveCategory /
+ *     inconclusiveReason / usabilityReason を削除
+ *   - 出力 schemaVersion=2、priority='medium' default
+ *   - BASELINE_ELIGIBLE_TYPES から segment-inconclusive / snapshot-incomplete /
+ *     source-unusable を除外 (7 type のみ baseline-able)
+ *   - TYPES_ARG_ALLOWLIST も 2 type だけ: section-structure-mismatch /
+ *     segment-order-mismatch
  */
 import { before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -11,6 +21,8 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
 import {
   assertFullParityStatus,
@@ -19,12 +31,19 @@ import {
   buildGenerationMeta,
   serializeBaseline,
   mergePartialBaseline,
-  defaultReviewAfter,
   parseArgs,
   mergePartialBaselineByType,
   loadSnapshotDiffStatus,
 } from '../generate_parity_baseline.mjs';
 import { computeStructureFingerprint } from '../lib/source_parity_baseline.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), '..', '..');
+const GENERATE_SCRIPT = path.join(
+  REPO_ROOT,
+  'scripts',
+  'generate_parity_baseline.mjs',
+);
 
 const VALID_FINGERPRINT = 'sha256:' + 'a'.repeat(64);
 const OTHER_FINGERPRINT = 'sha256:' + 'b'.repeat(64);
@@ -77,6 +96,7 @@ const sampleStatus = {
           detail: '[CLI] JA paragraph drops EN invariant tokens: --proxy, TESTIM_KEY',
         },
         {
+          // segment-inconclusive is NOT baseline-eligible in v2 — must be skipped
           type: 'segment-inconclusive',
           severity: 'actionable',
 
@@ -102,32 +122,8 @@ const fingerprintMap = new Map([['overview/example', VALID_FINGERPRINT]]);
 const meta = {
   runId: 'test-run',
   generatedAt: '2026-04-06T03:00:00Z',
-  // Locks every entry to 2026-10-06 by overriding the staggered default,
-  // so legacy assertions that expect a single reviewAfter date keep working.
-  reviewAfterOverride: '2026-10-06',
   rationale: 'test',
 };
-
-// ---------------------------------------------------------------------------
-// defaultReviewAfter
-// ---------------------------------------------------------------------------
-
-describe('defaultReviewAfter', () => {
-  it('returns YYYY-MM-DD 6 months after the given UTC date', () => {
-    const result = defaultReviewAfter(new Date('2026-04-06T00:00:00Z'));
-    assert.equal(result, '2026-10-06');
-  });
-
-  it('respects custom monthsAhead', () => {
-    const result = defaultReviewAfter(new Date('2026-04-06T00:00:00Z'), 3);
-    assert.equal(result, '2026-07-06');
-  });
-
-  it('formats single-digit month and day with leading zeros', () => {
-    const result = defaultReviewAfter(new Date('2026-01-05T00:00:00Z'));
-    assert.equal(result, '2026-07-05');
-  });
-});
 
 // ---------------------------------------------------------------------------
 // buildGenerationMeta
@@ -139,13 +135,11 @@ describe('buildGenerationMeta', () => {
       regenerate: true,
       slugs: null,
       rationale: null,
-      reviewAfter: null,
     });
     const metaFromLaterCall = buildGenerationMeta(sampleStatus, {
       regenerate: true,
       slugs: null,
       rationale: null,
-      reviewAfter: null,
     });
     assert.deepEqual(metaFromEarlyCall, metaFromLaterCall);
     assert.equal(metaFromEarlyCall.generatedAt, '2026-04-06T03:00:00Z');
@@ -153,20 +147,15 @@ describe('buildGenerationMeta', () => {
       metaFromEarlyCall.runId,
       '2026-04-06T03:00:00Z#parity-check-status',
     );
-    // No reviewAfter on meta — per-entry stagger lives in
-    // buildBaselineFromStatus. The override slot defaults to null.
-    assert.equal(metaFromEarlyCall.reviewAfterOverride, null);
   });
 
-  it('honors explicit rationale and reviewAfter overrides', () => {
+  it('honors explicit rationale override', () => {
     const metaOverride = buildGenerationMeta(sampleStatus, {
       regenerate: false,
       slugs: ['overview/example'],
       rationale: 'custom rationale',
-      reviewAfter: '2026-12-31',
     });
     assert.equal(metaOverride.rationale, 'custom rationale');
-    assert.equal(metaOverride.reviewAfterOverride, '2026-12-31');
   });
 });
 
@@ -203,13 +192,12 @@ describe('assertFullParityStatus', () => {
 // ---------------------------------------------------------------------------
 
 describe('buildBaselineFromStatus', () => {
-  it('extracts only BASELINE_ELIGIBLE_TYPES issues', () => {
+  it('extracts only BASELINE_ELIGIBLE_TYPES issues (v2: 3 of 5 here; inconclusive is not eligible)', () => {
     const baseline = buildBaselineFromStatus(sampleStatus, fingerprintMap, meta);
-    assert.equal(baseline.entries.length, 4);
+    assert.equal(baseline.entries.length, 3);
     const types = baseline.entries.map((e) => e.issueType).sort();
     assert.deepEqual(types, [
       'segment-extra',
-      'segment-inconclusive',
       'segment-missing',
       'segment-token-gap',
     ]);
@@ -222,11 +210,37 @@ describe('buildBaselineFromStatus', () => {
     assert.equal(extra.enSegmentIndex, null);
   });
 
-  it('preserves inconclusiveCategory and inconclusiveReason for segment-inconclusive', () => {
+  it('does NOT emit segment-inconclusive entries (not baseline-able in v2)', () => {
     const baseline = buildBaselineFromStatus(sampleStatus, fingerprintMap, meta);
     const inc = baseline.entries.find((e) => e.issueType === 'segment-inconclusive');
-    assert.equal(inc.inconclusiveCategory, 'heading-count-mismatch');
-    assert.match(inc.inconclusiveReason, /Heading count mismatch/);
+    assert.equal(inc, undefined);
+  });
+
+  it('emits schemaVersion=2 on the output baseline', () => {
+    const baseline = buildBaselineFromStatus(sampleStatus, fingerprintMap, meta);
+    assert.equal(baseline.schemaVersion, 2);
+  });
+
+  it('emits priority=medium on every entry by default', () => {
+    const baseline = buildBaselineFromStatus(sampleStatus, fingerprintMap, meta);
+    for (const entry of baseline.entries) {
+      assert.equal(entry.priority, 'medium');
+    }
+  });
+
+  it('does NOT emit reviewAfter / inconclusiveCategory / usabilityReason on entries (v2 schema)', () => {
+    const baseline = buildBaselineFromStatus(sampleStatus, fingerprintMap, meta);
+    for (const entry of baseline.entries) {
+      assert.ok(!('reviewAfter' in entry), `entry for ${entry.issueType} must not have reviewAfter`);
+      assert.ok(
+        !('inconclusiveCategory' in entry),
+        `entry for ${entry.issueType} must not have inconclusiveCategory`,
+      );
+      assert.ok(
+        !('usabilityReason' in entry),
+        `entry for ${entry.issueType} must not have usabilityReason`,
+      );
+    }
   });
 
   it('skips files whose slug has no fingerprint mapping (defensive)', () => {
@@ -239,7 +253,7 @@ describe('buildBaselineFromStatus', () => {
     const status = JSON.parse(JSON.stringify(sampleStatus));
     status.files[0].issues[0].baselined = true;
     const baseline = buildBaselineFromStatus(status, fingerprintMap, meta);
-    assert.equal(baseline.entries.length, 4);
+    assert.equal(baseline.entries.length, 3);
   });
 
   it('attaches the page-level snapshotFingerprint to every entry', () => {
@@ -257,140 +271,6 @@ describe('buildBaselineFromStatus', () => {
     assert.equal(missing.enSourceFingerprint, EN_SEGMENT_FINGERPRINT);
     assert.equal(extra.jaSourceFingerprint, JA_SEGMENT_FINGERPRINT);
     assert.deepEqual(tokenGap.missingTokens, ['--proxy', 'TESTIM_KEY']);
-  });
-
-  it('staggers reviewAfter per slug when no override is set (§5)', () => {
-    // Two slugs from a sample status with no reviewAfterOverride. Their
-    // reviewAfter values must each be 6 months out from generatedAt plus
-    // a deterministic per-slug offset in [0, 90) days.
-    const status = {
-      summary: { checkedAt: '2026-04-06T00:00:00Z', checkedFiles: 2, totalFiles: 2 },
-      files: [
-        {
-          file: 'src/content/docs/section/page-a.md',
-          issues: [
-            {
-              type: 'segment-missing',
-              sectionPath: 'Setup',
-              segmentKind: 'paragraph',
-              enSegmentIndex: 0,
-              enSourceFingerprint: EN_SEGMENT_FINGERPRINT,
-            },
-          ],
-        },
-        {
-          file: 'src/content/docs/section/page-b.md',
-          issues: [
-            {
-              type: 'segment-missing',
-              sectionPath: 'Setup',
-              segmentKind: 'paragraph',
-              enSegmentIndex: 0,
-              enSourceFingerprint: EN_SEGMENT_FINGERPRINT,
-            },
-          ],
-        },
-      ],
-    };
-    const fpMap = new Map([
-      ['section/page-a', VALID_FINGERPRINT],
-      ['section/page-b', VALID_FINGERPRINT],
-    ]);
-    const baseline = buildBaselineFromStatus(status, fpMap, {
-      runId: 'r',
-      generatedAt: '2026-04-06T00:00:00Z',
-      reviewAfterOverride: null,
-      rationale: 'r',
-    });
-    const a = baseline.entries.find((e) => e.slug === 'section/page-a');
-    const b = baseline.entries.find((e) => e.slug === 'section/page-b');
-    assert.match(a.reviewAfter, /^\d{4}-\d{2}-\d{2}$/);
-    assert.match(b.reviewAfter, /^\d{4}-\d{2}-\d{2}$/);
-    // Different slugs MUST hit different cells of the stagger window
-    // (deterministic per-slug hash). If this ever flakes, recheck
-    // staggeredOffsetDays.
-    assert.notEqual(a.reviewAfter, b.reviewAfter);
-    // Both must be at least 6 months past generatedAt (the base date).
-    assert.ok(a.reviewAfter >= '2026-10-06');
-    assert.ok(b.reviewAfter >= '2026-10-06');
-    // And both must be within base + 90 days (stagger window).
-    assert.ok(a.reviewAfter < '2027-01-04');
-    assert.ok(b.reviewAfter < '2027-01-04');
-  });
-
-  it('staggered reviewAfter is deterministic across runs (§5)', () => {
-    const status = {
-      summary: { checkedAt: '2026-04-06T00:00:00Z', checkedFiles: 1, totalFiles: 1 },
-      files: [
-        {
-          file: 'src/content/docs/section/page-a.md',
-          issues: [
-            {
-              type: 'segment-missing',
-              sectionPath: 'Setup',
-              segmentKind: 'paragraph',
-              enSegmentIndex: 0,
-              enSourceFingerprint: EN_SEGMENT_FINGERPRINT,
-            },
-          ],
-        },
-      ],
-    };
-    const fpMap = new Map([['section/page-a', VALID_FINGERPRINT]]);
-    const metaNoOverride = {
-      runId: 'r',
-      generatedAt: '2026-04-06T00:00:00Z',
-      reviewAfterOverride: null,
-      rationale: 'r',
-    };
-    const a = buildBaselineFromStatus(status, fpMap, metaNoOverride);
-    const b = buildBaselineFromStatus(status, fpMap, metaNoOverride);
-    assert.equal(a.entries[0].reviewAfter, b.entries[0].reviewAfter);
-  });
-
-  it('reviewAfterOverride disables stagger and locks every entry to one date (§5)', () => {
-    const status = {
-      summary: { checkedAt: '2026-04-06T00:00:00Z', checkedFiles: 2, totalFiles: 2 },
-      files: [
-        {
-          file: 'src/content/docs/section/page-a.md',
-          issues: [
-            {
-              type: 'segment-missing',
-              sectionPath: 'Setup',
-              segmentKind: 'paragraph',
-              enSegmentIndex: 0,
-              enSourceFingerprint: EN_SEGMENT_FINGERPRINT,
-            },
-          ],
-        },
-        {
-          file: 'src/content/docs/section/page-b.md',
-          issues: [
-            {
-              type: 'segment-missing',
-              sectionPath: 'Setup',
-              segmentKind: 'paragraph',
-              enSegmentIndex: 0,
-              enSourceFingerprint: EN_SEGMENT_FINGERPRINT,
-            },
-          ],
-        },
-      ],
-    };
-    const fpMap = new Map([
-      ['section/page-a', VALID_FINGERPRINT],
-      ['section/page-b', VALID_FINGERPRINT],
-    ]);
-    const baseline = buildBaselineFromStatus(status, fpMap, {
-      runId: 'r',
-      generatedAt: '2026-04-06T00:00:00Z',
-      reviewAfterOverride: '2027-01-15',
-      rationale: 'r',
-    });
-    for (const entry of baseline.entries) {
-      assert.equal(entry.reviewAfter, '2027-01-15');
-    }
   });
 });
 
@@ -415,7 +295,7 @@ describe('serializeBaseline', () => {
 
   it('sorts entries by slug → issueType → sectionPath → segmentKind → index', () => {
     const baseline = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       generatedAt: '2026-04-06T03:00:00Z',
       generatedFromRunId: 'test',
       rationale: 'test',
@@ -431,9 +311,7 @@ describe('serializeBaseline', () => {
           jaSourceFingerprint: null,
           missingTokens: null,
           snapshotFingerprint: VALID_FINGERPRINT,
-          inconclusiveCategory: null,
-          inconclusiveReason: null,
-          reviewAfter: '2026-10-06',
+          priority: 'medium',
         },
         {
           slug: 'a/page',
@@ -446,9 +324,7 @@ describe('serializeBaseline', () => {
           jaSourceFingerprint: null,
           missingTokens: null,
           snapshotFingerprint: VALID_FINGERPRINT,
-          inconclusiveCategory: null,
-          inconclusiveReason: null,
-          reviewAfter: '2026-10-06',
+          priority: 'medium',
         },
       ],
     };
@@ -471,7 +347,7 @@ describe('serializeBaseline', () => {
 
 describe('mergePartialBaseline', () => {
   const existing = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt: '2026-04-01T00:00:00Z',
     generatedFromRunId: 'old-run',
     rationale: 'existing',
@@ -487,9 +363,7 @@ describe('mergePartialBaseline', () => {
         jaSourceFingerprint: null,
         missingTokens: null,
         snapshotFingerprint: OTHER_FINGERPRINT,
-        inconclusiveCategory: null,
-        inconclusiveReason: null,
-        reviewAfter: '2026-09-01',
+        priority: 'medium',
       },
       {
         slug: 'other/page',
@@ -502,9 +376,7 @@ describe('mergePartialBaseline', () => {
         jaSourceFingerprint: null,
         missingTokens: null,
         snapshotFingerprint: VALID_FINGERPRINT,
-        inconclusiveCategory: null,
-        inconclusiveReason: null,
-        reviewAfter: '2026-09-01',
+        priority: 'medium',
       },
     ],
   };
@@ -522,9 +394,7 @@ describe('mergePartialBaseline', () => {
         jaSourceFingerprint: null,
         missingTokens: null,
         snapshotFingerprint: VALID_FINGERPRINT,
-        inconclusiveCategory: null,
-        inconclusiveReason: null,
-        reviewAfter: '2026-10-06',
+        priority: 'medium',
       },
     ];
     const merged = mergePartialBaseline(existing, ['overview/example'], newEntriesForSlug, {
@@ -563,19 +433,17 @@ describe('mergePartialBaseline', () => {
 });
 
 // ---------------------------------------------------------------------------
-// buildBaselineFromStatus: structure mismatch / source unusable 対応
+// buildBaselineFromStatus: structure mismatch 対応
 // ---------------------------------------------------------------------------
 
 describe('buildBaselineFromStatus: structure mismatch entry', () => {
   const VALID_SNAPSHOT_FP = 'sha256:' + 'f'.repeat(64);
   const fpMap = new Map([
     ['running-tests/the-command-line-cli', VALID_SNAPSHOT_FP],
-    ['salesforce-testing/faq', VALID_SNAPSHOT_FP],
   ]);
   const baselineMeta = {
     runId: 'baseline-run',
     generatedAt: '2026-04-06T03:00:00Z',
-    reviewAfterOverride: '2026-10-06',
     rationale: 'baseline',
   };
 
@@ -613,6 +481,8 @@ describe('buildBaselineFromStatus: structure mismatch entry', () => {
     assert.equal(entry.sectionPath, 'CLI Installation > Basic CLI command');
     assert.equal(entry.structureCategory, 'kind-multiset');
     assert.match(entry.structureFingerprint, /^sha256:[0-9a-f]{64}$/);
+    // v2: priority field is always populated (default medium)
+    assert.equal(entry.priority, 'medium');
   });
 
   it('structureFingerprint matches computeStructureFingerprint helper', () => {
@@ -652,17 +522,16 @@ describe('buildBaselineFromStatus: structure mismatch entry', () => {
   });
 });
 
-describe('buildBaselineFromStatus: source unusable entry', () => {
+describe('buildBaselineFromStatus: source-unusable / snapshot-incomplete (NOT baseline-able in v2)', () => {
   const VALID_SNAPSHOT_FP = 'sha256:' + 'f'.repeat(64);
   const fpMap = new Map([['salesforce-testing/faq', VALID_SNAPSHOT_FP]]);
   const baselineMeta = {
     runId: 'baseline-run',
     generatedAt: '2026-04-06T03:00:00Z',
-    reviewAfterOverride: '2026-10-06',
     rationale: 'baseline',
   };
 
-  it('emits a source unusable entry with usabilityReason from issue.usabilitySignals.reason', () => {
+  it('does NOT emit a baseline entry for source-unusable (source debt, not baseline-able)', () => {
     const status = {
       summary: { checkedAt: '2026-04-06T03:00:00Z', checkedFiles: 1, totalFiles: 1 },
       files: [
@@ -680,14 +549,10 @@ describe('buildBaselineFromStatus: source unusable entry', () => {
       ],
     };
     const baseline = buildBaselineFromStatus(status, fpMap, baselineMeta);
-    assert.equal(baseline.entries.length, 1);
-    const entry = baseline.entries[0];
-    assert.equal(entry.issueType, 'source-unusable');
-    assert.equal(entry.slug, 'salesforce-testing/faq');
-    assert.equal(entry.usabilityReason, 'escaped-details-residue');
+    assert.equal(baseline.entries.length, 0);
   });
 
-  it('skips a source unusable issue with unknown reason', () => {
+  it('does NOT emit a baseline entry for snapshot-incomplete', () => {
     const status = {
       summary: { checkedAt: '2026-04-06T03:00:00Z', checkedFiles: 1, totalFiles: 1 },
       files: [
@@ -695,9 +560,9 @@ describe('buildBaselineFromStatus: source unusable entry', () => {
           file: 'src/content/docs/salesforce-testing/faq.md',
           issues: [
             {
-              type: 'source-unusable',
+              type: 'snapshot-incomplete',
               severity: 'actionable',
-              usabilitySignals: { reason: 'unknown-reason' },
+              usabilitySignals: { reason: 'shallow-snapshot' },
             },
           ],
         },
@@ -708,7 +573,7 @@ describe('buildBaselineFromStatus: source unusable entry', () => {
   });
 });
 
-describe('sortEntries: structure / source unusable types', () => {
+describe('sortEntries: structure types within slug', () => {
   const VALID_SNAPSHOT_FP = 'sha256:' + 'f'.repeat(64);
   const fpMap = new Map([
     ['some/page', VALID_SNAPSHOT_FP],
@@ -716,7 +581,6 @@ describe('sortEntries: structure / source unusable types', () => {
   const baselineMeta = {
     runId: 'baseline-run',
     generatedAt: '2026-04-06T03:00:00Z',
-    reviewAfterOverride: '2026-10-06',
     rationale: 'baseline',
   };
 
@@ -783,15 +647,15 @@ describe('parseArgs: --types partial mode', () => {
     // CLI validation that this combination is invalid lives in main();
     // here we only check that parseArgs surfaces both flags so main can
     // detect the conflict.
-    const args = parseArgs(['--regenerate', '--types=source-unusable']);
+    const args = parseArgs(['--regenerate', '--types=section-structure-mismatch']);
     assert.equal(args.regenerate, true);
-    assert.deepEqual(args.types, ['source-unusable']);
+    assert.deepEqual(args.types, ['section-structure-mismatch']);
   });
 
   it('treats --types as mutually exclusive with --slug (parsing returns both)', () => {
-    const args = parseArgs(['--slug=overview/foo', '--types=source-unusable']);
+    const args = parseArgs(['--slug=overview/foo', '--types=section-structure-mismatch']);
     assert.deepEqual(args.slugs, ['overview/foo']);
-    assert.deepEqual(args.types, ['source-unusable']);
+    assert.deepEqual(args.types, ['section-structure-mismatch']);
   });
 });
 
@@ -800,7 +664,7 @@ describe('mergePartialBaselineByType', () => {
   const SEG_FP = 'sha256:' + 'c'.repeat(64);
 
   const existing = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt: '2026-03-01T00:00:00Z',
     generatedFromRunId: 'old-run',
     rationale: 'existing baseline',
@@ -816,10 +680,7 @@ describe('mergePartialBaselineByType', () => {
         jaSourceFingerprint: null,
         missingTokens: null,
         snapshotFingerprint: VALID_SNAPSHOT_FP,
-        inconclusiveCategory: null,
-        inconclusiveReason: null,
-        // 重要: 既存 segment-* エントリの reviewAfter は touch 禁止 (§7.4)
-        reviewAfter: '2026-09-01',
+        priority: 'medium',
       },
     ],
   };
@@ -829,7 +690,7 @@ describe('mergePartialBaselineByType', () => {
       slug: 'running-tests/the-command-line-cli',
       issueType: 'section-structure-mismatch',
       snapshotFingerprint: VALID_SNAPSHOT_FP,
-      reviewAfter: '2026-10-06',
+      priority: 'medium',
       sectionIndex: 7,
       sectionPath: 'CLI Installation > Basic CLI command',
       structureCategory: 'kind-multiset',
@@ -846,9 +707,9 @@ describe('mergePartialBaselineByType', () => {
       },
     );
     assert.equal(merged.entries.length, 2);
-    // 既存 segment-* は bit-identical で残る (reviewAfter 含む)
+    // 既存 segment-* は bit-identical で残る (v2: priority も保持)
     const segEntry = merged.entries.find((e) => e.issueType === 'segment-missing');
-    assert.equal(segEntry.reviewAfter, '2026-09-01');
+    assert.equal(segEntry.priority, 'medium');
     // 新 type の entry が追加されている
     const structEntry = merged.entries.find(
       (e) => e.issueType === 'section-structure-mismatch',
@@ -866,7 +727,7 @@ describe('mergePartialBaselineByType', () => {
           slug: 'running-tests/the-command-line-cli',
           issueType: 'section-structure-mismatch',
           snapshotFingerprint: VALID_SNAPSHOT_FP,
-          reviewAfter: '2026-10-06',
+          priority: 'medium',
           sectionIndex: 7,
           sectionPath: 'CLI',
           structureCategory: 'kind-multiset',
@@ -901,12 +762,12 @@ describe('mergePartialBaselineByType', () => {
     );
     assert.equal(merged.entries.length, 1);
     assert.equal(merged.entries[0].issueType, 'segment-missing');
-    assert.equal(merged.entries[0].reviewAfter, '2026-09-01');
+    assert.equal(merged.entries[0].priority, 'medium');
   });
 });
 
 // ---------------------------------------------------------------------------
-// validateTypesArg helper contract
+// validateTypesArg helper contract (v2: 2-type allowlist)
 // ---------------------------------------------------------------------------
 
 describe('validateTypesArg', () => {
@@ -938,12 +799,10 @@ describe('validateTypesArg', () => {
     assert.match(result.error, /foo-bar/);
   });
 
-  it('returns { ok: true } for the 4 allowlisted types', () => {
+  it('returns { ok: true } for the 2 v2-allowlisted types (structure mismatch family)', () => {
     for (const t of [
       'section-structure-mismatch',
       'segment-order-mismatch',
-      'snapshot-incomplete',
-      'source-unusable',
     ]) {
       assert.deepEqual(
         validateTypesArg([t]),
@@ -956,15 +815,19 @@ describe('validateTypesArg', () => {
   it('returns { ok: true } for a combination of allowlisted types', () => {
     const result = validateTypesArg([
       'section-structure-mismatch',
-      'snapshot-incomplete',
+      'segment-order-mismatch',
     ]);
     assert.deepEqual(result, { ok: true });
   });
 
+  it('rejects snapshot-incomplete and source-unusable (no longer in --types allowlist in v2)', () => {
+    for (const t of ['snapshot-incomplete', 'source-unusable']) {
+      const result = validateTypesArg([t]);
+      assert.equal(result.ok, false, `${t} must not be accepted by --types in v2`);
+    }
+  });
+
   it('rejects legacy segment-* types (tightest allowlist)', () => {
-    // segment-missing / segment-extra / segment-shifted / segment-untranslated /
-    // segment-token-gap / segment-inconclusive は --types 経路では扱わない。
-    // これらを書き換えたいときは --regenerate か --slug で処理する。
     for (const t of [
       'segment-missing',
       'segment-extra',
@@ -1011,11 +874,46 @@ describe('parseArgs + validateTypesArg integration', () => {
     assert.match(v.error, /section-structure-misatch/);
   });
 
-  it('parseArgs(["--types=source-unusable"]) round-trips as valid', () => {
-    const args = parseArgs(['--types=source-unusable']);
-    assert.deepEqual(args.types, ['source-unusable']);
+  it('parseArgs(["--types=section-structure-mismatch"]) round-trips as valid', () => {
+    const args = parseArgs(['--types=section-structure-mismatch']);
+    assert.deepEqual(args.types, ['section-structure-mismatch']);
     const v = validateTypesArg(args.types);
     assert.equal(v.ok, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI: --review-after is rejected in v2
+// ---------------------------------------------------------------------------
+
+describe('CLI: --review-after flag is removed in v2', () => {
+  it('exits non-zero when --review-after is passed', () => {
+    const result = spawnSync(
+      process.execPath,
+      [GENERATE_SCRIPT, '--regenerate', '--review-after=2026-12-31'],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+      },
+    );
+    assert.notEqual(result.status, 0, 'must exit non-zero when --review-after is passed');
+    const combined = (result.stderr ?? '') + (result.stdout ?? '');
+    assert.match(combined, /--review-after/);
+    assert.match(combined, /removed|撤去|v2/i);
+  });
+
+  it('exits non-zero when --review-after=<date> is passed with --slug', () => {
+    const result = spawnSync(
+      process.execPath,
+      [GENERATE_SCRIPT, '--slug=overview/example', '--review-after=2026-12-31'],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+      },
+    );
+    assert.notEqual(result.status, 0);
+    const combined = (result.stderr ?? '') + (result.stdout ?? '');
+    assert.match(combined, /--review-after/);
   });
 });
 

--- a/scripts/__tests__/source_parity.test.mjs
+++ b/scripts/__tests__/source_parity.test.mjs
@@ -376,16 +376,15 @@ describe('reportableActive and auditSignal counters', () => {
     assert.equal(summary.auditSignalIssues, 1);
   });
 
-  it('excludes coarse signals from reportableActive* even with expired baseline', () => {
+  it('excludes baselined coarse signals from reportableActive* (coarse never re-fires)', () => {
     const summary = summarizeParityResults([
       {
-        file: 'src/content/docs/expired-baseline-coarse.md',
+        file: 'src/content/docs/baselined-coarse.md',
         issues: [
           {
             type: 'heading-mismatch',
             severity: 'signal',
             baselined: true,
-            baselineExpired: true,
           },
         ],
       },
@@ -395,7 +394,7 @@ describe('reportableActive and auditSignal counters', () => {
     assert.equal(summary.auditSignalFiles, 1);
   });
 
-  it('excludes frozen baseline (non-expired) from reportableActive*', () => {
+  it('excludes frozen baseline from reportableActive* (v2: baselined alone freezes)', () => {
     const summary = summarizeParityResults([
       {
         file: 'src/content/docs/frozen.md',
@@ -404,7 +403,6 @@ describe('reportableActive and auditSignal counters', () => {
             type: 'segment-missing',
             severity: 'actionable',
             baselined: true,
-            baselineExpired: false,
           },
         ],
       },
@@ -609,7 +607,7 @@ describe('structureMismatch and snapshotUnusable counters', () => {
     assert.equal(summary.reportableActiveFiles, 0);
   });
 
-  it('excludes frozen (non-expired) baseline from structureMismatch*', () => {
+  it('excludes frozen baseline from structureMismatch* (v2: baselined alone freezes)', () => {
     const summary = summarizeParityResults([
       {
         file: 'src/content/docs/frozen-structure.md',
@@ -618,7 +616,6 @@ describe('structureMismatch and snapshotUnusable counters', () => {
             type: 'segment-order-mismatch',
             severity: 'actionable',
             baselined: true,
-            baselineExpired: false,
           },
         ],
       },
@@ -646,22 +643,21 @@ describe('structureMismatch and snapshotUnusable counters', () => {
     assert.equal(summary.reportableActiveFiles, 1);
   });
 
-  it('includes expired baseline on source unusable in snapshotUnusable* (counter re-fires)', () => {
+  it('excludes baselined snapshot-incomplete from snapshotUnusable* (v2: frozen = out of counters)', () => {
     const summary = summarizeParityResults([
       {
-        file: 'src/content/docs/expired-baseline-source.md',
+        file: 'src/content/docs/frozen-source.md',
         issues: [
           {
             type: 'snapshot-incomplete',
             severity: 'actionable',
             baselined: true,
-            baselineExpired: true,
           },
         ],
       },
     ]);
-    assert.equal(summary.snapshotUnusableIssues, 1);
-    assert.equal(summary.snapshotUnusableFiles, 1);
+    assert.equal(summary.snapshotUnusableIssues, 0);
+    assert.equal(summary.snapshotUnusableFiles, 0);
     assert.equal(summary.reportableActiveFiles, 0);
   });
 

--- a/scripts/__tests__/source_parity_acknowledgements.test.mjs
+++ b/scripts/__tests__/source_parity_acknowledgements.test.mjs
@@ -739,28 +739,10 @@ describe('summarizeParityResults — baseline accounting', () => {
     });
   });
 
-  it('counts baselined inconclusive entries by category', () => {
-    const results = [
-      {
-        file: 'a.md',
-        sourceUrl: '',
-        category: '',
-        issues: [
-          {
-            type: 'segment-inconclusive',
-            severity: 'actionable',
-            baselined: true,
-            inconclusiveCategory: 'heading-count-mismatch',
-            detail: 'inc',
-          },
-        ],
-      },
-    ];
-    const summary = summarizeParityResults(results);
-    assert.deepEqual(summary.baselinedByInconclusiveCategory, {
-      'heading-count-mismatch': 1,
-    });
-  });
+  // schema v2: segment-inconclusive は BASELINE_ELIGIBLE_TYPES から除外されて
+  // いるため tagIssuesWithBaseline が baselined:true を付けない。
+  // baselinedByInconclusiveCategory counter も撤去済。旧 "counts baselined
+  // inconclusive entries by category" test は v2 では成立しないので削除した。
 
   it('keeps baselined issues frozen (not active)', () => {
     // v2: baseline expiry is gone — baselined:true always freezes the issue.
@@ -800,7 +782,6 @@ describe('summarizeParityResults — baseline accounting', () => {
     assert.equal(summary.baselinedIssues, 0);
     assert.equal(summary.baselinedFiles, 0);
     assert.deepEqual(summary.baselinedByType, {});
-    assert.deepEqual(summary.baselinedByInconclusiveCategory, {});
   });
 });
 

--- a/scripts/__tests__/source_parity_acknowledgements.test.mjs
+++ b/scripts/__tests__/source_parity_acknowledgements.test.mjs
@@ -762,8 +762,8 @@ describe('summarizeParityResults — baseline accounting', () => {
     });
   });
 
-  it('counts expired baseline entries and re-activates them in active accounting', () => {
-    // expired baseline は gate に戻り、non-expired baseline は frozen のまま。
+  it('keeps baselined issues frozen (not active)', () => {
+    // v2: baseline expiry is gone — baselined:true always freezes the issue.
     const results = [
       {
         file: 'a.md',
@@ -774,31 +774,7 @@ describe('summarizeParityResults — baseline accounting', () => {
             type: 'segment-missing',
             severity: 'actionable',
             baselined: true,
-            baselineExpired: true,
-            detail: 'expired baseline',
-          },
-        ],
-      },
-    ];
-    const summary = summarizeParityResults(results);
-    assert.equal(summary.expiredBaselineEntries, 1);
-    // Expired baseline is active — it shows up in the gate
-    assert.equal(summary.activeFiles, 1);
-    assert.equal(summary.activeActionableFiles, 1);
-  });
-
-  it('keeps non-expired baselines frozen (not active)', () => {
-    const results = [
-      {
-        file: 'a.md',
-        sourceUrl: '',
-        category: '',
-        issues: [
-          {
-            type: 'segment-missing',
-            severity: 'actionable',
-            baselined: true,
-            detail: 'non-expired baseline',
+            detail: 'frozen baseline',
           },
         ],
       },
@@ -825,7 +801,6 @@ describe('summarizeParityResults — baseline accounting', () => {
     assert.equal(summary.baselinedFiles, 0);
     assert.deepEqual(summary.baselinedByType, {});
     assert.deepEqual(summary.baselinedByInconclusiveCategory, {});
-    assert.equal(summary.expiredBaselineEntries, 0);
   });
 });
 

--- a/scripts/__tests__/source_parity_advisory_queue.test.mjs
+++ b/scripts/__tests__/source_parity_advisory_queue.test.mjs
@@ -82,7 +82,6 @@ describe('buildAdvisoryReviewQueue', () => {
               swapScore: 1.21,
             },
             baselined: true,
-            baselineReviewAfter: '2026-10-06',
           },
         ],
       },
@@ -116,7 +115,6 @@ describe('buildAdvisoryReviewQueue', () => {
     assert.deepEqual(queue.map((entry) => entry.slug), ['alpha', 'zeta']);
     assert.equal(queue[0].blocking, true);
     assert.equal(queue[1].blocking, false);
-    assert.equal(queue[1].issues[0].baselineReviewAfter, '2026-10-06');
     assert.equal(
       queue[0].issues[0].queueKey,
       'alpha|segment-inconclusive|category=tokenless-near-tie|pair=Alpha A=>Alpha B',

--- a/scripts/__tests__/source_parity_align_runtime.test.mjs
+++ b/scripts/__tests__/source_parity_align_runtime.test.mjs
@@ -236,9 +236,9 @@ describe('summarizeParityResults', () => {
     assert.equal(summary.activeFiles, 0);
     assert.equal(summary.baselinedIssues, 2);
     assert.equal(summary.baselinedFiles, 1);
-    assert.deepEqual(summary.baselinedByInconclusiveCategory, {
-      'heading-count-mismatch': 1,
-    });
+    // schema v2: baselinedByInconclusiveCategory は撤去済 (segment-inconclusive は
+    // BASELINE_ELIGIBLE_TYPES に入らないため tagIssuesWithBaseline が baselined:true を
+    // 付けない。本 fixture は前 schema の挙動確認用に合成された in-memory fixture)
   });
 
 });

--- a/scripts/__tests__/source_parity_baseline.test.mjs
+++ b/scripts/__tests__/source_parity_baseline.test.mjs
@@ -1,10 +1,17 @@
 /**
- * Tests for the frozen baseline mechanism.
+ * Tests for the frozen baseline mechanism (schema v2).
  *
  * Pure-function tests for schema validation, lookup key generation, and
  * page-level invalidation. The integration into check_source_parity.mjs
  * lives in source_parity_acknowledgements.test.mjs (summary accounting)
  * and the runtime tests.
+ *
+ * v2 変更点:
+ * - `reviewAfter` 概念は撤去 (expired / expiringSoon も含む)
+ * - BASELINE_ELIGIBLE_TYPES は JA-actionable 7 type のみ
+ *   (segment-inconclusive / snapshot-incomplete / source-unusable を除外)
+ * - `inconclusiveCategory` / `inconclusiveReason` / `usabilityReason` は entry schema から除去
+ * - `priority` (high/medium/low, required, default 'medium') / `note` (任意, <=500) を追加
  */
 import { before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -14,11 +21,10 @@ import {
   buildBaselineKey,
   buildBaselineKeyFromEntry,
   tagIssuesWithBaseline,
-  isBaselineExpired,
   BASELINE_ELIGIBLE_TYPES,
-  INCONCLUSIVE_CATEGORIES,
   STRUCTURE_CATEGORIES,
-  USABILITY_REASONS,
+  PRIORITY_VALUES,
+  NOTE_MAX_LENGTH,
   computeStructureFingerprint,
 } from '../lib/source_parity_baseline.mjs';
 
@@ -39,9 +45,7 @@ const validMissingEntry = {
   jaSourceFingerprint: null,
   missingTokens: null,
   snapshotFingerprint: VALID_FINGERPRINT,
-  inconclusiveCategory: null,
-  inconclusiveReason: null,
-  reviewAfter: '2026-10-06',
+  priority: 'medium',
 };
 
 const validExtraEntry = {
@@ -55,25 +59,7 @@ const validExtraEntry = {
   jaSourceFingerprint: JA_SEGMENT_FINGERPRINT,
   missingTokens: null,
   snapshotFingerprint: VALID_FINGERPRINT,
-  inconclusiveCategory: null,
-  inconclusiveReason: null,
-  reviewAfter: '2026-10-06',
-};
-
-const validInconclusiveEntry = {
-  slug: 'testops/pull-requests',
-  issueType: 'segment-inconclusive',
-  sectionPath: null,
-  segmentKind: null,
-  enSegmentIndex: null,
-  jaSegmentIndex: null,
-  enSourceFingerprint: null,
-  jaSourceFingerprint: null,
-  missingTokens: null,
-  snapshotFingerprint: VALID_FINGERPRINT,
-  inconclusiveCategory: 'heading-count-mismatch',
-  inconclusiveReason: 'Heading count mismatch: EN has 0 headings, JA has 5',
-  reviewAfter: '2026-10-06',
+  priority: 'medium',
 };
 
 const validTokenGapEntry = {
@@ -87,23 +73,31 @@ const validTokenGapEntry = {
   jaSourceFingerprint: null,
   missingTokens: ['--proxy'],
   snapshotFingerprint: VALID_FINGERPRINT,
-  inconclusiveCategory: null,
-  inconclusiveReason: null,
-  reviewAfter: '2026-10-06',
+  priority: 'medium',
 };
 
 // ---------------------------------------------------------------------------
 // constants
 // ---------------------------------------------------------------------------
 
-describe('BASELINE_ELIGIBLE_TYPES', () => {
-  it('contains all baseline-eligible segment types', () => {
+describe('BASELINE_ELIGIBLE_TYPES (v2 — JA-actionable 7 type)', () => {
+  it('contains all JA-actionable segment types', () => {
     assert.ok(BASELINE_ELIGIBLE_TYPES.has('segment-missing'));
     assert.ok(BASELINE_ELIGIBLE_TYPES.has('segment-extra'));
     assert.ok(BASELINE_ELIGIBLE_TYPES.has('segment-shifted'));
     assert.ok(BASELINE_ELIGIBLE_TYPES.has('segment-untranslated'));
     assert.ok(BASELINE_ELIGIBLE_TYPES.has('segment-token-gap'));
-    assert.ok(BASELINE_ELIGIBLE_TYPES.has('segment-inconclusive'));
+  });
+
+  it('contains structure mismatch types (2)', () => {
+    assert.ok(BASELINE_ELIGIBLE_TYPES.has('section-structure-mismatch'));
+    assert.ok(BASELINE_ELIGIBLE_TYPES.has('segment-order-mismatch'));
+  });
+
+  it('does NOT contain v1-only types (advisory / source debt)', () => {
+    assert.ok(!BASELINE_ELIGIBLE_TYPES.has('segment-inconclusive'));
+    assert.ok(!BASELINE_ELIGIBLE_TYPES.has('snapshot-incomplete'));
+    assert.ok(!BASELINE_ELIGIBLE_TYPES.has('source-unusable'));
   });
 
   it('does NOT contain repo-local issue types', () => {
@@ -112,19 +106,18 @@ describe('BASELINE_ELIGIBLE_TYPES', () => {
     assert.ok(!BASELINE_ELIGIBLE_TYPES.has('untranslated'));
   });
 
-  it('contains structure-mismatch / source-unusable types', () => {
-    for (const type of [
-      'section-structure-mismatch',
-      'segment-order-mismatch',
-      'snapshot-incomplete',
-      'source-unusable',
-    ]) {
-      assert.equal(
-        BASELINE_ELIGIBLE_TYPES.has(type),
-        true,
-        `${type} must be in BASELINE_ELIGIBLE_TYPES`,
-      );
-    }
+  it('has exactly 7 eligible types in v2', () => {
+    assert.equal(BASELINE_ELIGIBLE_TYPES.size, 7);
+  });
+});
+
+describe('PRIORITY_VALUES', () => {
+  it('lists high/medium/low in order', () => {
+    assert.deepEqual([...PRIORITY_VALUES], ['high', 'medium', 'low']);
+  });
+
+  it('is frozen', () => {
+    assert.equal(Object.isFrozen(PRIORITY_VALUES), true);
   });
 });
 
@@ -137,7 +130,7 @@ describe('validateBaseline — structure mismatch entries', () => {
       slug: 'running-tests/the-command-line-cli',
       issueType: 'section-structure-mismatch',
       snapshotFingerprint: VALID_SNAPSHOT_FP,
-      reviewAfter: '2026-10-06',
+      priority: 'medium',
       sectionIndex: 7,
       sectionPath: 'CLI Installation > Basic CLI command',
       structureCategory: 'kind-multiset',
@@ -149,7 +142,7 @@ describe('validateBaseline — structure mismatch entries', () => {
   it('accepts a valid section-structure-mismatch entry (kind-multiset)', () => {
     const entry = baseStructureEntry();
     assert.doesNotThrow(() =>
-      validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      validateBaseline({ schemaVersion: 2, entries: [entry] }),
     );
   });
 
@@ -159,14 +152,14 @@ describe('validateBaseline — structure mismatch entries', () => {
       structureCategory: 'content-order',
     });
     assert.doesNotThrow(() =>
-      validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      validateBaseline({ schemaVersion: 2, entries: [entry] }),
     );
   });
 
   it('accepts a structure entry with empty string sectionPath (preface section)', () => {
     const entry = baseStructureEntry({ sectionPath: '' });
     assert.doesNotThrow(() =>
-      validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      validateBaseline({ schemaVersion: 2, entries: [entry] }),
     );
   });
 
@@ -174,7 +167,7 @@ describe('validateBaseline — structure mismatch entries', () => {
     const entry = baseStructureEntry();
     delete entry.sectionIndex;
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /sectionIndex/,
     );
   });
@@ -182,7 +175,7 @@ describe('validateBaseline — structure mismatch entries', () => {
   it('throws on non-integer sectionIndex', () => {
     const entry = baseStructureEntry({ sectionIndex: 1.5 });
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /sectionIndex/,
     );
   });
@@ -190,7 +183,7 @@ describe('validateBaseline — structure mismatch entries', () => {
   it('throws on negative sectionIndex', () => {
     const entry = baseStructureEntry({ sectionIndex: -1 });
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /sectionIndex/,
     );
   });
@@ -198,7 +191,7 @@ describe('validateBaseline — structure mismatch entries', () => {
   it('throws on string sectionIndex', () => {
     const entry = baseStructureEntry({ sectionIndex: '7' });
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /sectionIndex/,
     );
   });
@@ -207,7 +200,7 @@ describe('validateBaseline — structure mismatch entries', () => {
     const entry = baseStructureEntry();
     delete entry.sectionPath;
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /sectionPath/,
     );
   });
@@ -215,7 +208,7 @@ describe('validateBaseline — structure mismatch entries', () => {
   it('throws on invalid structureCategory enum', () => {
     const entry = baseStructureEntry({ structureCategory: 'unknown' });
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /structureCategory/,
     );
   });
@@ -223,79 +216,9 @@ describe('validateBaseline — structure mismatch entries', () => {
   it('throws on malformed structureFingerprint (not sha256 hex)', () => {
     const entry = baseStructureEntry({ structureFingerprint: 'not-a-hash' });
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /structureFingerprint/,
     );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// validateBaseline — source unusable entries
-//
-// source unusable は page 粒度の issue。identity surface は usabilityReason
-// のみ (§3.3)。sectionPath / structureCategory / structureFingerprint は
-// 持たない。
-// ---------------------------------------------------------------------------
-
-describe('validateBaseline — source unusable entries', () => {
-  const VALID_SNAPSHOT_FP = 'sha256:' + 'f'.repeat(64);
-
-  function baseSourceUnusableEntry(overrides = {}) {
-    return {
-      slug: 'salesforce-testing/faq',
-      issueType: 'source-unusable',
-      snapshotFingerprint: VALID_SNAPSHOT_FP,
-      reviewAfter: '2026-10-06',
-      usabilityReason: 'escaped-details-residue',
-      ...overrides,
-    };
-  }
-
-  it('accepts a valid source-unusable entry (escaped-details-residue)', () => {
-    const entry = baseSourceUnusableEntry();
-    assert.doesNotThrow(() =>
-      validateBaseline({ schemaVersion: 1, entries: [entry] }),
-    );
-  });
-
-  it('accepts a valid snapshot-incomplete entry (shallow-snapshot)', () => {
-    const entry = baseSourceUnusableEntry({
-      issueType: 'snapshot-incomplete',
-      usabilityReason: 'shallow-snapshot',
-    });
-    assert.doesNotThrow(() =>
-      validateBaseline({ schemaVersion: 1, entries: [entry] }),
-    );
-  });
-
-  it('throws on invalid usabilityReason enum', () => {
-    const entry = baseSourceUnusableEntry({ usabilityReason: 'unknown' });
-    assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
-      /usabilityReason/,
-    );
-  });
-
-  it('throws on missing usabilityReason', () => {
-    const entry = baseSourceUnusableEntry();
-    delete entry.usabilityReason;
-    assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
-      /usabilityReason/,
-    );
-  });
-});
-
-describe('INCONCLUSIVE_CATEGORIES', () => {
-  it('contains the three valid categories', () => {
-    assert.ok(INCONCLUSIVE_CATEGORIES.has('heading-count-mismatch'));
-    assert.ok(INCONCLUSIVE_CATEGORIES.has('align-exception'));
-    assert.ok(INCONCLUSIVE_CATEGORIES.has('tokenless-near-tie'));
-  });
-
-  it('does NOT contain unknown categories', () => {
-    assert.ok(!INCONCLUSIVE_CATEGORIES.has('unknown'));
-    assert.ok(!INCONCLUSIVE_CATEGORIES.has('null'));
   });
 });
 
@@ -306,11 +229,11 @@ describe('INCONCLUSIVE_CATEGORIES', () => {
 describe('validateBaseline', () => {
   it('accepts a valid baseline with mixed entry types', () => {
     const parsed = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       generatedAt: '2026-04-06T03:00:00Z',
       generatedFromRunId: '2026-04-06T03:00:00Z#abcd1234',
       rationale: 'preview baseline',
-      entries: [validMissingEntry, validExtraEntry, validInconclusiveEntry],
+      entries: [validMissingEntry, validExtraEntry, validTokenGapEntry],
     };
     const result = validateBaseline(parsed);
     assert.equal(result, parsed);
@@ -320,21 +243,45 @@ describe('validateBaseline', () => {
     assert.throws(() => validateBaseline({ entries: [] }), /schemaVersion/);
   });
 
-  it('throws on unsupported schemaVersion', () => {
+  it('throws on unsupported schemaVersion (v1 rejected after cutover)', () => {
     assert.throws(
-      () => validateBaseline({ schemaVersion: 2, entries: [] }),
+      () => validateBaseline({ schemaVersion: 1, entries: [] }),
       /schemaVersion/,
     );
   });
 
   it('throws on missing entries array', () => {
-    assert.throws(() => validateBaseline({ schemaVersion: 1 }), /entries/);
+    assert.throws(() => validateBaseline({ schemaVersion: 2 }), /entries/);
   });
 
   it('throws on unknown issueType (not in BASELINE_ELIGIBLE_TYPES)', () => {
     const entry = { ...validMissingEntry, issueType: 'paragraph-count-mismatch' };
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
+      /issueType/,
+    );
+  });
+
+  it('rejects segment-inconclusive (not baseline-able in v2)', () => {
+    const entry = { ...validMissingEntry, issueType: 'segment-inconclusive' };
+    assert.throws(
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
+      /issueType/,
+    );
+  });
+
+  it('rejects snapshot-incomplete (source debt — not baseline-able in v2)', () => {
+    const entry = { ...validMissingEntry, issueType: 'snapshot-incomplete' };
+    assert.throws(
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
+      /issueType/,
+    );
+  });
+
+  it('rejects source-unusable (source debt — not baseline-able in v2)', () => {
+    const entry = { ...validMissingEntry, issueType: 'source-unusable' };
+    assert.throws(
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /issueType/,
     );
   });
@@ -342,7 +289,7 @@ describe('validateBaseline', () => {
   it('throws on invalid snapshotFingerprint format', () => {
     const entry = { ...validMissingEntry, snapshotFingerprint: 'not-a-hash' };
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /snapshotFingerprint/,
     );
   });
@@ -350,7 +297,7 @@ describe('validateBaseline', () => {
   it('throws on segment-missing entry without enSegmentIndex', () => {
     const entry = { ...validMissingEntry, enSegmentIndex: null };
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /enSegmentIndex/,
     );
   });
@@ -358,7 +305,7 @@ describe('validateBaseline', () => {
   it('throws on segment-missing entry without enSourceFingerprint', () => {
     const entry = { ...validMissingEntry, enSourceFingerprint: null };
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /enSourceFingerprint/,
     );
   });
@@ -366,7 +313,7 @@ describe('validateBaseline', () => {
   it('throws on segment-extra entry without jaSegmentIndex', () => {
     const entry = { ...validExtraEntry, jaSegmentIndex: null };
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /jaSegmentIndex/,
     );
   });
@@ -374,7 +321,7 @@ describe('validateBaseline', () => {
   it('throws on segment-extra entry without jaSourceFingerprint', () => {
     const entry = { ...validExtraEntry, jaSourceFingerprint: null };
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /jaSourceFingerprint/,
     );
   });
@@ -387,7 +334,7 @@ describe('validateBaseline', () => {
       jaSegmentIndex: null,
     };
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /jaSegmentIndex/,
     );
   });
@@ -401,47 +348,79 @@ describe('validateBaseline', () => {
       enSourceFingerprint: null,
       jaSourceFingerprint: JA_SEGMENT_FINGERPRINT,
     };
-    const parsed = { schemaVersion: 1, entries: [entry] };
+    const parsed = { schemaVersion: 2, entries: [entry] };
     assert.doesNotThrow(() => validateBaseline(parsed));
   });
 
   it('throws on segment-token-gap entry without missingTokens', () => {
     const entry = { ...validTokenGapEntry, missingTokens: null };
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
       /missingTokens/,
     );
   });
 
-  it('throws on segment-inconclusive entry with unknown inconclusiveCategory', () => {
-    const entry = { ...validInconclusiveEntry, inconclusiveCategory: 'unknown' };
+  // ------------------------------------------------------------------
+  // v2: priority (required enum) / note (optional, <=500 chars)
+  // ------------------------------------------------------------------
+
+  it('throws on missing priority', () => {
+    const entry = { ...validMissingEntry };
+    delete entry.priority;
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
-      /inconclusiveCategory/,
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
+      /priority/,
     );
   });
 
-  it('throws on segment-inconclusive entry with null inconclusiveCategory', () => {
-    const entry = { ...validInconclusiveEntry, inconclusiveCategory: null };
+  it('throws on invalid priority enum value', () => {
+    const entry = { ...validMissingEntry, priority: 'urgent' };
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
-      /inconclusiveCategory/,
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
+      /priority/,
     );
   });
 
-  it('throws on reviewAfter that is not strict YYYY-MM-DD', () => {
-    const entry = { ...validMissingEntry, reviewAfter: '2026-10-6' };
-    assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
-      /reviewAfter/,
+  it('accepts priority=high', () => {
+    const entry = { ...validMissingEntry, priority: 'high' };
+    assert.doesNotThrow(() =>
+      validateBaseline({ schemaVersion: 2, entries: [entry] }),
     );
   });
 
-  it('throws on reviewAfter that is an impossible calendar date', () => {
-    const entry = { ...validMissingEntry, reviewAfter: '2026-02-31' };
+  it('accepts priority=low', () => {
+    const entry = { ...validMissingEntry, priority: 'low' };
+    assert.doesNotThrow(() =>
+      validateBaseline({ schemaVersion: 2, entries: [entry] }),
+    );
+  });
+
+  it('accepts optional note (empty or short string)', () => {
+    const entry = { ...validMissingEntry, note: 'awaiting upstream fix' };
+    assert.doesNotThrow(() =>
+      validateBaseline({ schemaVersion: 2, entries: [entry] }),
+    );
+  });
+
+  it('accepts entry without note field (optional)', () => {
+    assert.doesNotThrow(() =>
+      validateBaseline({ schemaVersion: 2, entries: [validMissingEntry] }),
+    );
+  });
+
+  it('throws on note that exceeds NOTE_MAX_LENGTH (500)', () => {
+    const entry = { ...validMissingEntry, note: 'x'.repeat(NOTE_MAX_LENGTH + 1) };
     assert.throws(
-      () => validateBaseline({ schemaVersion: 1, entries: [entry] }),
-      /reviewAfter/,
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
+      /note/,
+    );
+  });
+
+  it('throws on non-string note', () => {
+    const entry = { ...validMissingEntry, note: 123 };
+    assert.throws(
+      () => validateBaseline({ schemaVersion: 2, entries: [entry] }),
+      /note/,
     );
   });
 });
@@ -501,30 +480,13 @@ describe('buildBaselineKey / buildBaselineKeyFromEntry', () => {
       jaSourceFingerprint: JA_SEGMENT_FINGERPRINT,
       missingTokens: null,
       snapshotFingerprint: VALID_FINGERPRINT,
-      inconclusiveCategory: null,
-      inconclusiveReason: null,
-      reviewAfter: '2026-10-06',
+      priority: 'medium',
     };
     const issueKey = buildBaselineKey('overview/example', issue);
     const entryKey = buildBaselineKeyFromEntry(entry);
     assert.equal(issueKey, entryKey);
     assert.ok(issueKey.includes('|ja|'));
     assert.ok(!issueKey.includes('|en|'));
-  });
-
-  it('uses inconclusiveCategory only for segment-inconclusive', () => {
-    const issue = {
-      type: 'segment-inconclusive',
-      sectionPath: null,
-      segmentKind: null,
-      enSegmentIndex: null,
-      jaSegmentIndex: null,
-      inconclusiveCategory: 'heading-count-mismatch',
-    };
-    const issueKey = buildBaselineKey('testops/pull-requests', issue);
-    const entryKey = buildBaselineKeyFromEntry(validInconclusiveEntry);
-    assert.equal(issueKey, entryKey);
-    assert.match(issueKey, /heading-count-mismatch/);
   });
 
   it('uses enSegmentIndex (NOT jaSegmentIndex) for segment-shifted', () => {
@@ -574,12 +536,7 @@ describe('buildBaselineKey / buildBaselineKeyFromEntry', () => {
 });
 
 // ---------------------------------------------------------------------------
-// buildBaselineKey / buildBaselineKeyFromEntry の対称性
-//
-// runtime 側 (buildBaselineKey) は毎回 computeStructureFingerprint を呼んで
-// fingerprint を derive するのに対し、disk 側 (buildBaselineKeyFromEntry) は
-// 事前計算された structureFingerprint を読むだけ。両者が必ず同じ key を
-// 返すことが baseline matching の前提。
+// buildBaselineKey / buildBaselineKeyFromEntry の対称性 (structure mismatch)
 // ---------------------------------------------------------------------------
 
 describe('buildBaselineKey / buildBaselineKeyFromEntry (structure mismatch)', () => {
@@ -602,7 +559,7 @@ describe('buildBaselineKey / buildBaselineKeyFromEntry (structure mismatch)', ()
       slug,
       issueType: issue.type,
       snapshotFingerprint: PAGE_FP,
-      reviewAfter: '2026-10-06',
+      priority: 'medium',
       sectionIndex: issue.sectionIndex,
       sectionPath: issue.sectionPath,
       structureCategory: issue.structureCategory,
@@ -645,10 +602,6 @@ describe('buildBaselineKey / buildBaselineKeyFromEntry (structure mismatch)', ()
     const slug = 'some/page';
     const issueA = makeStructureIssue({ sectionIndex: 3 });
     const issueB = makeStructureIssue({ sectionIndex: 7 });
-    // 同一 slug / 同一 sectionPath / 同一 structureCategory / 同一 kinds
-    // でも sectionIndex が違えば別 key になる必要がある。machine identity
-    // に sectionIndex を必須にすることで、同一ページ内で sectionPath が
-    // 衝突したときに baseline が silently 誤った section を覆うのを防ぐ。
     assert.notEqual(
       buildBaselineKey(slug, issueA),
       buildBaselineKey(slug, issueB),
@@ -673,42 +626,6 @@ describe('buildBaselineKey / buildBaselineKeyFromEntry (structure mismatch)', ()
     const issueB = makeStructureIssue({
       enKinds: ['paragraph', 'heading'],
     });
-    assert.notEqual(
-      buildBaselineKey(slug, issueA),
-      buildBaselineKey(slug, issueB),
-    );
-  });
-});
-
-describe('buildBaselineKey / buildBaselineKeyFromEntry (source unusable)', () => {
-  const PAGE_FP = 'sha256:' + 'f'.repeat(64);
-
-  it('runtime key and entry key match (escaped-details-residue)', () => {
-    const slug = 'salesforce-testing/faq';
-    const issue = {
-      type: 'source-unusable',
-      usabilitySignals: { reason: 'escaped-details-residue' },
-    };
-    const entry = {
-      slug,
-      issueType: 'source-unusable',
-      snapshotFingerprint: PAGE_FP,
-      reviewAfter: '2026-10-06',
-      usabilityReason: 'escaped-details-residue',
-    };
-    assert.equal(buildBaselineKey(slug, issue), buildBaselineKeyFromEntry(entry));
-  });
-
-  it('distinguishes different usabilityReason values', () => {
-    const slug = 'some/page';
-    const issueA = {
-      type: 'snapshot-incomplete',
-      usabilitySignals: { reason: 'shallow-snapshot' },
-    };
-    const issueB = {
-      type: 'snapshot-incomplete',
-      usabilitySignals: { reason: 'extractor-empty' },
-    };
     assert.notEqual(
       buildBaselineKey(slug, issueA),
       buildBaselineKey(slug, issueB),
@@ -822,18 +739,19 @@ describe('tagIssuesWithBaseline', () => {
     assert.equal(result.tagged[0].baselined, undefined);
   });
 
-  it('retains baselined match but annotates expired reviewAfter', () => {
+  it('tagIssuesWithBaseline only adds baselined: true (no expiry tags in v2)', () => {
     const issues = [makeIssue()];
     const result = tagIssuesWithBaseline(
       'overview/example',
       issues,
       [validMissingEntry],
       VALID_FINGERPRINT,
-      '2026-10-07',
     );
     assert.equal(result.tagged[0].baselined, true);
-    assert.equal(result.tagged[0].baselineReviewAfter, '2026-10-06');
-    assert.equal(result.tagged[0].baselineExpired, true);
+    // v2: baselineReviewAfter / baselineExpired / baselineExpiringSoon は付けない
+    assert.equal(result.tagged[0].baselineReviewAfter, undefined);
+    assert.equal(result.tagged[0].baselineExpired, undefined);
+    assert.equal(result.tagged[0].baselineExpiringSoon, undefined);
   });
 
   it('does not mutate input arrays (immutable)', () => {
@@ -879,23 +797,8 @@ describe('tagIssuesWithBaseline', () => {
   });
 });
 
-describe('isBaselineExpired', () => {
-  it('returns false on the reviewAfter date itself', () => {
-    assert.equal(isBaselineExpired(validMissingEntry, '2026-10-06'), false);
-  });
-
-  it('returns true after reviewAfter passes', () => {
-    assert.equal(isBaselineExpired(validMissingEntry, '2026-10-07'), true);
-  });
-});
-
 // ---------------------------------------------------------------------------
 // tagIssuesWithBaseline contract for structure mismatch
-//
-// runtime 側から baseline entry にマッチする挙動を pin する。
-// tagIssuesWithBaseline 本体は generic contract なので新しい分岐は
-// 入らないはずだが、BASELINE_ELIGIBLE_TYPES / buildBaselineKey の拡張が
-// 下流まで波及していることを explicit に pin する。
 // ---------------------------------------------------------------------------
 
 describe('tagIssuesWithBaseline (structure mismatch)', () => {
@@ -920,7 +823,7 @@ describe('tagIssuesWithBaseline (structure mismatch)', () => {
       slug,
       issueType: issue.type,
       snapshotFingerprint: PAGE_FP,
-      reviewAfter: '2026-10-06',
+      priority: 'medium',
       sectionIndex: issue.sectionIndex,
       sectionPath: issue.sectionPath,
       structureCategory: issue.structureCategory,
@@ -963,11 +866,6 @@ describe('tagIssuesWithBaseline (structure mismatch)', () => {
   });
 
   it('two sections with identical path/fingerprint but different sectionIndex are tagged independently', () => {
-    // 同一ページに section A (index=3) と section B (index=7) があり、
-    // 両方が同じ sectionPath + 同じ structureFingerprint を出すケース。
-    // baseline が A にしか付いていないとき、B は untagged のままになる
-    // 必要がある。sectionIndex が identity に含まれていないと、両方が
-    // 同じ key になって A の baseline が B にも silently 被さってしまう。
     const slug = 'some/page';
     const sharedOverrides = {
       sectionPath: 'Shared heading',
@@ -983,58 +881,8 @@ describe('tagIssuesWithBaseline (structure mismatch)', () => {
   });
 });
 
-describe('tagIssuesWithBaseline (source unusable)', () => {
-  const PAGE_FP = 'sha256:' + 'f'.repeat(64);
-
-  it('tags a matching source-unusable issue by usabilityReason', () => {
-    const slug = 'salesforce-testing/faq';
-    const issue = {
-      type: 'source-unusable',
-      severity: 'actionable',
-      detail: 'source snapshot is unusable (escaped-details-residue)',
-      usabilitySignals: { reason: 'escaped-details-residue' },
-    };
-    const entry = {
-      slug,
-      issueType: 'source-unusable',
-      snapshotFingerprint: PAGE_FP,
-      reviewAfter: '2026-10-06',
-      usabilityReason: 'escaped-details-residue',
-    };
-    const result = tagIssuesWithBaseline(slug, [issue], [entry], PAGE_FP);
-    assert.equal(result.tagged[0].baselined, true);
-    assert.equal(result.invalidated, false);
-  });
-
-  it('does NOT tag when usabilityReason mismatches', () => {
-    const slug = 'salesforce-testing/faq';
-    const issue = {
-      type: 'source-unusable',
-      severity: 'actionable',
-      detail: 'source snapshot is unusable',
-      usabilitySignals: { reason: 'extractor-empty' },
-    };
-    const entry = {
-      slug,
-      issueType: 'source-unusable',
-      snapshotFingerprint: PAGE_FP,
-      reviewAfter: '2026-10-06',
-      usabilityReason: 'escaped-details-residue',
-    };
-    const result = tagIssuesWithBaseline(slug, [issue], [entry], PAGE_FP);
-    assert.equal(result.tagged[0].baselined, undefined);
-  });
-});
-
 // ---------------------------------------------------------------------------
-// STRUCTURE_CATEGORIES / USABILITY_REASONS
-//
-// 新 4 type (section-structure-mismatch / segment-order-mismatch /
-// snapshot-incomplete / source-unusable) を baseline 可能にするため、
-// structureCategory / usabilityReason の allowlist を frozen Set で pin する。
-// emitter 側 (source_parity_structure.mjs / source_parity_source_usability.mjs)
-// の出力と同一の enum を参照することで、validateBaseline / buildBaselineKey
-// の identity 検証を decouple する。
+// STRUCTURE_CATEGORIES
 // ---------------------------------------------------------------------------
 
 describe('STRUCTURE_CATEGORIES', () => {
@@ -1056,31 +904,8 @@ describe('STRUCTURE_CATEGORIES', () => {
   });
 });
 
-describe('USABILITY_REASONS', () => {
-  it('contains the 3 known unusable reasons', () => {
-    assert.ok(USABILITY_REASONS.has('shallow-snapshot'));
-    assert.ok(USABILITY_REASONS.has('escaped-details-residue'));
-    assert.ok(USABILITY_REASONS.has('extractor-empty'));
-    assert.equal(USABILITY_REASONS.size, 3);
-  });
-
-  it('is frozen (regression guard against accidental mutation)', () => {
-    assert.equal(Object.isFrozen(USABILITY_REASONS), true);
-  });
-
-  it('does NOT contain unrelated values', () => {
-    assert.ok(!USABILITY_REASONS.has(''));
-    assert.ok(!USABILITY_REASONS.has('unknown'));
-  });
-});
-
 // ---------------------------------------------------------------------------
 // computeStructureFingerprint
-//
-// structure mismatch の baseline identity key 用に、enKinds / jaKinds /
-// structureCategory / contentPermutation を sha256 hex に畳み込む helper。
-// 生の配列を baseline entry に保存すると JSON が肥大化し、downstream の
-// 生データアクセス手段が増えるため、derived fingerprint 1 本に集約する。
 // ---------------------------------------------------------------------------
 
 describe('computeStructureFingerprint', () => {
@@ -1230,9 +1055,6 @@ describe('computeStructureFingerprint', () => {
 
 // ---------------------------------------------------------------------------
 // computeOrphanBaselineEntries helper
-//
-// tagIssuesWithBaseline が返す matchedKeys を使って「runtime に一致しない
-// baseline entry」= orphan を抽出する純粋関数。
 // ---------------------------------------------------------------------------
 
 describe('computeOrphanBaselineEntries', () => {
@@ -1259,9 +1081,7 @@ describe('computeOrphanBaselineEntries', () => {
       jaSourceFingerprint: null,
       missingTokens: null,
       snapshotFingerprint: FP,
-      reviewAfter: '2026-10-01',
-      inconclusiveCategory: null,
-      inconclusiveReason: null,
+      priority: 'medium',
     };
   }
 
@@ -1279,7 +1099,7 @@ describe('computeOrphanBaselineEntries', () => {
   it('returns [] when every entry matched a runtime issue', () => {
     const entries = [segmentMissingEntry(0), segmentMissingEntry(1)];
     const issues = [segmentMissingIssue(0), segmentMissingIssue(1)];
-    const tagResult = tagIssuesWithBaseline2(SLUG, issues, entries, FP, '2026-04-09');
+    const tagResult = tagIssuesWithBaseline2(SLUG, issues, entries, FP);
     const orphans = computeOrphanBaselineEntries(SLUG, entries, tagResult.matchedKeys);
     assert.deepEqual(orphans, []);
   });
@@ -1288,7 +1108,7 @@ describe('computeOrphanBaselineEntries', () => {
     const entries = [segmentMissingEntry(0), segmentMissingEntry(1), segmentMissingEntry(2)];
     // runtime issue は idx=0 のみ
     const issues = [segmentMissingIssue(0)];
-    const tagResult = tagIssuesWithBaseline2(SLUG, issues, entries, FP, '2026-04-09');
+    const tagResult = tagIssuesWithBaseline2(SLUG, issues, entries, FP);
     const orphans = computeOrphanBaselineEntries(SLUG, entries, tagResult.matchedKeys);
     assert.equal(orphans.length, 2);
     assert.deepEqual(
@@ -1303,9 +1123,8 @@ describe('computeOrphanBaselineEntries', () => {
       { ...segmentMissingEntry(0), slug: 'other/page' },
     ];
     const issues = []; // nothing matches
-    const tagResult = tagIssuesWithBaseline2(SLUG, issues, entries, FP, '2026-04-09');
+    const tagResult = tagIssuesWithBaseline2(SLUG, issues, entries, FP);
     const orphans = computeOrphanBaselineEntries(SLUG, entries, tagResult.matchedKeys);
-    // 'other/page' entry は現在の slug の orphan ではない
     assert.equal(orphans.length, 1);
     assert.equal(orphans[0].slug, SLUG);
   });
@@ -1314,12 +1133,9 @@ describe('computeOrphanBaselineEntries', () => {
     const entries = [segmentMissingEntry(0), segmentMissingEntry(1)];
     const issues = [segmentMissingIssue(0), segmentMissingIssue(1)];
     const OTHER_FP = 'sha256:' + '3'.repeat(64);
-    // invalidated === true のケースは matchedKeys === Set() になる
-    const tagResult = tagIssuesWithBaseline2(SLUG, issues, entries, OTHER_FP, '2026-04-09');
+    const tagResult = tagIssuesWithBaseline2(SLUG, issues, entries, OTHER_FP);
     assert.equal(tagResult.invalidated, true);
     assert.equal(tagResult.matchedKeys.size, 0);
-    // helper は invalidated を受け取らないので、呼び出し側が invalidated 時は
-    // orphan 集計をスキップする契約。helper 自体は entries をそのまま返す。
     const orphans = computeOrphanBaselineEntries(SLUG, entries, tagResult.matchedKeys);
     assert.equal(
       orphans.length,
@@ -1331,7 +1147,7 @@ describe('computeOrphanBaselineEntries', () => {
   it('orphan entries retain their original fields (identity preserved)', () => {
     const entries = [segmentMissingEntry(0)];
     const issues = [];
-    const tagResult = tagIssuesWithBaseline2(SLUG, issues, entries, FP, '2026-04-09');
+    const tagResult = tagIssuesWithBaseline2(SLUG, issues, entries, FP);
     const orphans = computeOrphanBaselineEntries(SLUG, entries, tagResult.matchedKeys);
     assert.equal(orphans.length, 1);
     assert.equal(orphans[0].slug, SLUG);
@@ -1374,10 +1190,10 @@ describe('summary orphanBaselineEntries counter', () => {
   it('propagates a provided orphan count + byType breakdown', () => {
     const summary = summarizeParityResults([], {
       orphanBaselineEntries: 3,
-      orphanBaselineByType: { 'segment-inconclusive': 3 },
+      orphanBaselineByType: { 'segment-missing': 3 },
     });
     assert.equal(summary.orphanBaselineEntries, 3);
-    assert.deepEqual(summary.orphanBaselineByType, { 'segment-inconclusive': 3 });
+    assert.deepEqual(summary.orphanBaselineByType, { 'segment-missing': 3 });
   });
 
   it('defaults to 0 / {} when no orphan metadata is passed (backward compat)', () => {

--- a/scripts/__tests__/source_parity_baseline_recall.test.mjs
+++ b/scripts/__tests__/source_parity_baseline_recall.test.mjs
@@ -36,7 +36,7 @@ const BASELINE_ELIGIBLE = new Set([
   'segment-shifted',
   'segment-untranslated',
   'segment-token-gap',
-  'segment-inconclusive',
+  // v2: segment-inconclusive is no longer baseline-able
 ]);
 
 function loadManifest() {
@@ -67,9 +67,8 @@ function buildBaselineEntries(slug, issues, snapshotFingerprint) {
         ? [...new Set(issue.missingTokens)].sort()
         : null,
       snapshotFingerprint,
-      inconclusiveCategory: issue.inconclusiveCategory ?? null,
-      inconclusiveReason: issue.inconclusiveReason ?? null,
-      reviewAfter: '2026-10-06',
+      // v2: priority required; reviewAfter / inconclusive* fields gone.
+      priority: 'medium',
     }));
 }
 
@@ -130,7 +129,6 @@ describe('baseline does not absorb new mutations', () => {
           newIssues,
           baselineEntries,
           snapshotFingerprint,
-          '2026-04-06',
         );
         const activeIssues = tagged.tagged.filter((issue) => issue.baselined !== true);
 

--- a/scripts/__tests__/source_parity_issue_state.test.mjs
+++ b/scripts/__tests__/source_parity_issue_state.test.mjs
@@ -135,7 +135,6 @@ describe('isCoarseAuditSignal', () => {
         type: 'step-count-mismatch',
         severity: 'signal',
         baselined: true,
-        baselineExpired: true,
       }),
       true,
     );
@@ -209,13 +208,12 @@ describe('isReportableParityIssue rejects coarse signals', () => {
     );
   });
 
-  it('rejects coarse signal even when baseline is expired', () => {
+  it('rejects coarse signal even when baselined: true (coarse stays non-reportable)', () => {
     assert.equal(
       isReportableParityIssue({
         type: 'heading-mismatch',
         severity: 'signal',
         baselined: true,
-        baselineExpired: true,
       }),
       false,
     );
@@ -253,27 +251,14 @@ describe('isReportableParityIssue rejects coarse signals', () => {
     );
   });
 
-  it('still rejects non-expired baseline on actionable issues', () => {
+  it('still rejects baselined actionable issues (baselined === frozen in v2)', () => {
     assert.equal(
       isReportableParityIssue({
         type: 'segment-missing',
         severity: 'actionable',
         baselined: true,
-        baselineExpired: false,
       }),
       false,
-    );
-  });
-
-  it('still accepts expired baseline on non-coarse actionable issues (refire)', () => {
-    assert.equal(
-      isReportableParityIssue({
-        type: 'segment-missing',
-        severity: 'actionable',
-        baselined: true,
-        baselineExpired: true,
-      }),
-      true,
     );
   });
 
@@ -301,16 +286,16 @@ describe('isReportableParityIssue rejects coarse signals', () => {
 // existing predicates remain unchanged for non-coarse issues
 
 describe('existing predicates unchanged for non-coarse issues', () => {
-  it('isFrozenByBaseline stays the same', () => {
-    assert.equal(
-      isFrozenByBaseline({ baselined: true, baselineExpired: false }),
-      true,
-    );
+  it('isFrozenByBaseline is a pure baselined-truthy check (no expiry in v2)', () => {
+    assert.equal(isFrozenByBaseline({ baselined: true }), true);
+    // v2: baselineExpired tag is no longer emitted. Legacy stray flags must
+    // not change the result — baselined: true alone freezes the issue.
     assert.equal(
       isFrozenByBaseline({ baselined: true, baselineExpired: true }),
-      false,
+      true,
     );
     assert.equal(isFrozenByBaseline({ baselined: false }), false);
+    assert.equal(isFrozenByBaseline({}), false);
   });
 
   it('isValidAcknowledgedIssue stays the same', () => {
@@ -342,7 +327,7 @@ describe('existing predicates unchanged for non-coarse issues', () => {
 
   it('isNonBlockingParityIssue stays the same', () => {
     assert.equal(
-      isNonBlockingParityIssue({ baselined: true, baselineExpired: false }),
+      isNonBlockingParityIssue({ baselined: true }),
       true,
     );
     assert.equal(
@@ -460,7 +445,6 @@ describe('isStructureMismatchIssue', () => {
         type: 'segment-order-mismatch',
         severity: 'actionable',
         baselined: true,
-        baselineExpired: false,
       }),
       true,
     );
@@ -602,21 +586,8 @@ describe('isReportableParityIssue — structure mismatch / source unusable', () 
         type: 'segment-order-mismatch',
         severity: 'actionable',
         baselined: true,
-        baselineExpired: false,
       }),
       false,
-    );
-  });
-
-  it('expired baseline on a structure mismatch IS reportable', () => {
-    assert.equal(
-      isReportableParityIssue({
-        type: 'section-structure-mismatch',
-        severity: 'actionable',
-        baselined: true,
-        baselineExpired: true,
-      }),
-      true,
     );
   });
 
@@ -650,19 +621,6 @@ describe('isReportableParityIssue — structure mismatch / source unusable', () 
         type: 'snapshot-incomplete',
         severity: 'actionable',
         baselined: true,
-        baselineExpired: false,
-      }),
-      false,
-    );
-  });
-
-  it('expired baseline on a source-unusable is STILL non-reportable', () => {
-    assert.equal(
-      isReportableParityIssue({
-        type: 'source-unusable',
-        severity: 'actionable',
-        baselined: true,
-        baselineExpired: true,
       }),
       false,
     );
@@ -738,7 +696,6 @@ describe('isAdvisoryOnlyParityIssue — source unusable only', () => {
         type: 'snapshot-incomplete',
         severity: 'actionable',
         baselined: true,
-        baselineExpired: false,
       }),
       false,
     );

--- a/scripts/__tests__/source_parity_orphan_integration.test.mjs
+++ b/scripts/__tests__/source_parity_orphan_integration.test.mjs
@@ -82,14 +82,12 @@ before(() => {
     enSourceFingerprint: 'sha256:' + '9'.repeat(64),
     jaSourceFingerprint: null,
     missingTokens: null,
-    inconclusiveCategory: null,
-    inconclusiveReason: null,
     sectionIndex: null,
     structureCategory: null,
     structureFingerprint: null,
-    usabilityReason: null,
     snapshotFingerprint: fp,
-    reviewAfter: '2027-01-01',
+    // v2 schema: priority required, reviewAfter / inconclusive* / usability* gone.
+    priority: 'medium',
   });
   writeFileSync(BASELINE_TMP, JSON.stringify(baseline, null, 2) + '\n');
 });

--- a/scripts/check_source_parity.mjs
+++ b/scripts/check_source_parity.mjs
@@ -338,7 +338,8 @@ export async function checkSourceParity({
     return 1;
   }
   // ack expiry は UTC の `today` で判定する。
-  // CI の timezone 差を消し、`reviewAfter` の YYYY-MM-DD と揃えるため。
+  // CI の timezone 差を消し、ack `reviewAfter` の YYYY-MM-DD と揃えるため。
+  // (baseline v2 は期限概念を持たないので、today は ack 判定専用)
   const today = new Date().toISOString().slice(0, 10);
 
   // frozen baseline をロード。acknowledgement とは別ファイル / 別意味で管理する。
@@ -581,12 +582,12 @@ export async function checkSourceParity({
       today,
     );
 
-    // baseline タグ付け。frozen (非 expired) baseline entries は
+    // baseline タグ付け (schema v2)。`issue.baselined === true` の entry は
     // isFrozenByBaseline / isReportableParityIssue で gate から除外される
-    // (scripts/lib/source_parity_issue_state.mjs を参照)。期限切れ baseline
-    // entries は gate に refire する。
-    // matchedKeys を consumer 側で消費して orphan
-    // baseline entry を集計する。invalidated なページは skip する契約。
+    // (scripts/lib/source_parity_issue_state.mjs を参照)。v2 では期限概念を
+    // 廃止したので baseline は明示削除まで frozen のまま。matchedKeys を
+    // consumer 側で消費して orphan baseline entry を集計する。invalidated
+    // なページは skip する契約。
     {
       const baselineResult = tagIssuesWithBaseline(
         fileSlug,
@@ -813,13 +814,6 @@ export async function checkSourceParity({
       );
       for (const [type, count] of Object.entries(summary.baselinedByType ?? {})) {
         console.log(`  ${type}: ${count} 件`);
-      }
-      const incCats = summary.baselinedByInconclusiveCategory ?? {};
-      if (Object.keys(incCats).length > 0) {
-        console.log('  inconclusiveCategory 別:');
-        for (const [cat, count] of Object.entries(incCats)) {
-          console.log(`    ${cat}: ${count} 件`);
-        }
       }
     }
     if (summary.baselineInvalidatedSlugs && summary.baselineInvalidatedSlugs.length > 0) {

--- a/scripts/check_source_parity.mjs
+++ b/scripts/check_source_parity.mjs
@@ -299,11 +299,11 @@ function loadAcknowledgementsFile(filePath = ACKNOWLEDGEMENTS_PATH) {
 
 /**
  * `parity-baseline.json` を読み込み、validation 済み payload を返す。
- * file が無ければ空の structure を返す。
+ * file が無ければ空の structure (schema v2) を返す。
  */
 function loadBaselineFileSafe(filePath = BASELINE_PATH) {
   if (!fs.existsSync(filePath)) {
-    return { schemaVersion: 1, entries: [] };
+    return { schemaVersion: 2, entries: [] };
   }
   return loadBaselineFile(filePath);
 }
@@ -343,7 +343,7 @@ export async function checkSourceParity({
 
   // frozen baseline をロード。acknowledgement とは別ファイル / 別意味で管理する。
   // テストでは baselinePath を差し替えて隔離実行できる。
-  let baselineData = { schemaVersion: 1, entries: [] };
+  let baselineData = { schemaVersion: 2, entries: [] };
   try {
     baselineData = loadBaselineFileSafe(baselinePath);
   } catch (error) {
@@ -593,7 +593,6 @@ export async function checkSourceParity({
         issues,
         baselineData.entries,
         snapshotFingerprint,
-        today,
       );
       issues = baselineResult.tagged;
       if (baselineResult.invalidated) {
@@ -633,8 +632,7 @@ export async function checkSourceParity({
         const tags = [];
         if (issue.acknowledged && !issue.ackExpired) tags.push('⏸');
         if (issue.acknowledged && issue.ackExpired) tags.push('⚠expired');
-        if (issue.baselined && issue.baselineExpired) tags.push('🧊expired-baseline');
-        else if (issue.baselined) tags.push('🧊baseline');
+        if (issue.baselined) tags.push('🧊baseline');
         const issueTag = tags.length > 0 ? ` ${tags.join(' ')}` : '';
         console.log(
           `   [${issue.type}/${issue.severity}]${location}${issueTag} ${detail}${artifactNote}`,
@@ -650,10 +648,7 @@ export async function checkSourceParity({
           );
         }
         if (issue.baselined) {
-          const baselineState = issue.baselineExpired ? 'expired' : 'active';
-          console.log(
-            `     ↳ baseline: ${baselineState} (review: ${issue.baselineReviewAfter ?? 'n/a'})`,
-          );
+          console.log('     ↳ baseline: frozen');
         }
       }
       console.log('');
@@ -767,6 +762,7 @@ export async function checkSourceParity({
     advisoryQueueScope,
     advisoryQueue,
     debug: {
+      baselineSchemaVersion: baselineData.schemaVersion,
       maskCoverage: maskCoverage.toJSON(),
       artifactCoverage: artifactCoverage.snapshot(),
       patchCoverage: patchCoverage.snapshot(),
@@ -806,14 +802,6 @@ export async function checkSourceParity({
     }
     if (summary.expiredAcknowledgements > 0) {
       console.log(`expired acknowledgements: ${summary.expiredAcknowledgements} 件`);
-    }
-    if (summary.expiredBaselineEntries > 0) {
-      console.log(`expired baseline entries: ${summary.expiredBaselineEntries} 件`);
-    }
-    if (summary.expiringBaselineEntries30d > 0) {
-      console.log(
-        `expiring baseline entries (≤30 日): ${summary.expiringBaselineEntries30d} 件`,
-      );
     }
     console.log('\n問題種別:');
     for (const [type, count] of Object.entries(summary.issuesByType)) {
@@ -893,13 +881,11 @@ export async function checkSourceParity({
         const state = entry.blocking ? 'blocking review' : 'baselined review';
         console.log(`  ${entry.slug ?? entry.file} (${state})`);
         for (const issue of entry.issues) {
-          const review = issue.baselineReviewAfter ? ` review=${issue.baselineReviewAfter}` : '';
-          const expired = issue.baselineExpired ? ' expired-baseline' : '';
           const pair =
             issue.leftSectionPath && issue.rightSectionPath
               ? ` pair="${issue.leftSectionPath}" <-> "${issue.rightSectionPath}"`
               : '';
-          console.log(`    - ${issue.detail}${review}${expired}${pair}`);
+          console.log(`    - ${issue.detail}${pair}`);
         }
       }
     }

--- a/scripts/generate_detection_reports.mjs
+++ b/scripts/generate_detection_reports.mjs
@@ -65,7 +65,7 @@ function main() {
     console.log(`  パリティ結果: ${actionableReport.result ?? '不明'}`);
     const followup = actionableReport.parityFollowup;
     console.log(
-      `  パリティフォローアップ: 期限切れ=${followup.summary.baselineDebt.expiredBaselineEntries} 30日以内期限切れ=${followup.summary.baselineDebt.expiringBaselineEntries30d ?? 0} 無効化=${followup.summary.baselineDebt.baselineInvalidatedSlugCount} ブロッキング=${followup.summary.advisoryQueue.blockingItems}`,
+      `  パリティフォローアップ: ベースライン=${followup.summary.baselineDebt.baselinedIssues ?? 0} 無効化=${followup.summary.baselineDebt.baselineInvalidatedSlugCount ?? 0} ブロッキング=${followup.summary.advisoryQueue.blockingItems ?? 0}`,
     );
     // source-side debt の件数も CLI 出力に含める
     const debt = actionableReport.sourceSyncHealth?.sourceSideDebt;

--- a/scripts/generate_parity_baseline.mjs
+++ b/scripts/generate_parity_baseline.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Generate parity-baseline.json from parity-check-status.json.
+ * Generate parity-baseline.json from parity-check-status.json (schema v2).
  *
  * frozen baseline 機構の生成側。input は直前の `check:parity` 実行
  * 結果 (`parity-check-status.json`) と各 slug の現 EN snapshot fingerprint。
@@ -11,22 +11,27 @@
  * Modes:
  *   --regenerate              既存 parity-baseline.json を完全上書き
  *   --slug=<csv>              指定 slug のエントリのみ削除 → 再生成 → マージ
+ *   --types=<csv>             指定 issueType のエントリのみ再生成 (structure 系のみ許可)
  *   --rationale=<text>        rationale フィールドを明示的に指定
- *   --review-after=<YYYY-MM-DD>  reviewAfter を明示的に指定（省略時は 6 ヶ月後）
+ *
+ * v2 変更点:
+ *   - `--review-after` option 廃止 (reviewAfter field 自体が v2 で削除)
+ *   - 出力 schemaVersion=2
+ *   - segment-inconclusive / snapshot-incomplete / source-unusable は
+ *     baseline 対象外 (BASELINE_ELIGIBLE_TYPES に含まれない)
+ *   - priority: 'medium' default を全 entry に付与
  *
  * @module generate_parity_baseline
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
 import { ROOT_DIR } from './lib/project.mjs';
 import {
   BASELINE_ELIGIBLE_TYPES,
   STRUCTURE_CATEGORIES,
-  USABILITY_REASONS,
   computeStructureFingerprint,
   validateBaseline,
   loadBaselineFile,
@@ -34,7 +39,6 @@ import {
 } from './lib/source_parity_baseline.mjs';
 import {
   STRUCTURE_MISMATCH_TYPES,
-  SOURCE_UNUSABLE_TYPES,
 } from './lib/source_parity_types.mjs';
 import { computeSnapshotFingerprint } from './lib/source_parity_acknowledgements.mjs';
 
@@ -42,82 +46,6 @@ const STATUS_PATH = path.join(ROOT_DIR, 'parity-check-status.json');
 const BASELINE_PATH = path.join(ROOT_DIR, 'parity-baseline.json');
 const SNAPSHOT_DIFF_PATH = path.join(ROOT_DIR, 'snapshot-diff-status.json');
 const SNAPSHOTS_DIR = path.join(ROOT_DIR, 'snapshots', 'en', 'content');
-
-const DEFAULT_REVIEW_MONTHS = 6;
-/**
- * Window over which baseline reviewAfter dates are spread out so that the
- * cliff of mass-expiry never happens. Slug N's reviewAfter is offset by
- * `hash(slug) % STAGGER_WINDOW_DAYS` days from the base date.
- */
-const STAGGER_WINDOW_DAYS = 90;
-
-/**
- * Compute the base reviewAfter date — `monthsAhead` months after `now`.
- * Plain UTC math, format strict YYYY-MM-DD.
- *
- * @param {Date} now
- * @param {number} [monthsAhead]
- * @returns {string}
- */
-export function defaultReviewAfter(now, monthsAhead = DEFAULT_REVIEW_MONTHS) {
-  const d = new Date(
-    Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + monthsAhead, now.getUTCDate()),
-  );
-  return formatYmd(d);
-}
-
-function formatYmd(d) {
-  const yyyy = d.getUTCFullYear().toString();
-  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
-  const dd = String(d.getUTCDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
-}
-
-/**
- * Add `days` days to a strict YYYY-MM-DD date string.
- *
- * @param {string} ymd
- * @param {number} days
- * @returns {string}
- */
-function addDays(ymd, days) {
-  const [year, month, day] = ymd.split('-').map(Number);
-  const utc = Date.UTC(year, month - 1, day) + days * 86400000;
-  return formatYmd(new Date(utc));
-}
-
-/**
- * Deterministic per-slug offset, used to stagger reviewAfter dates so that
- * a single calendar day cannot expire the entire baseline at once.
- *
- * The offset is `sha256(slug)` interpreted as a hex prefix, taken mod
- * `STAGGER_WINDOW_DAYS`. Same input → same offset, no global state.
- *
- * @param {string} slug
- * @returns {number} integer in [0, STAGGER_WINDOW_DAYS)
- */
-export function staggeredOffsetDays(slug) {
-  const hex = createHash('sha256').update(slug).digest('hex').slice(0, 12);
-  const value = Number.parseInt(hex, 16);
-  return value % STAGGER_WINDOW_DAYS;
-}
-
-/**
- * Compute the staggered reviewAfter date for a single slug. Builds the
- * base 6-month date from `now`, then offsets it by the slug's deterministic
- * stagger.
- *
- * @param {string} slug
- * @param {Date} now
- * @param {string} [explicitReviewAfter] — if non-null, returned verbatim
- *   (CLI override)
- * @returns {string}
- */
-export function staggeredReviewAfter(slug, now, explicitReviewAfter = null) {
-  if (explicitReviewAfter) return explicitReviewAfter;
-  const base = defaultReviewAfter(now);
-  return addDays(base, staggeredOffsetDays(slug));
-}
 
 /**
  * Convert a parity-check-status.json file path to a slug.
@@ -286,31 +214,19 @@ export function buildFingerprintMap(snapshotsDir = SNAPSHOTS_DIR) {
 }
 
 /**
- * Build a baseline from a parsed parity-check-status.json object.
+ * Build a baseline from a parsed parity-check-status.json object (schema v2).
  *
  * @param {object} status — parsed parity-check-status.json
  * @param {Map<string, string>} fingerprintMap — slug → sha256
- * @param {{ runId: string, generatedAt: string, reviewAfter: string, rationale: string }} meta
+ * @param {{ runId: string, generatedAt: string, rationale: string }} meta
  * @returns {object} baseline ready for serializeBaseline
  */
 export function buildBaselineFromStatus(status, fingerprintMap, meta) {
   const entries = [];
-  // baseDate drives the staggered reviewAfter computation. When the user
-  // passes --review-after, every entry uses the override verbatim (no
-  // stagger) so they can lock the whole baseline to one day for testing
-  // or planned cutovers. Otherwise we anchor on the run's checkedAt and
-  // offset per slug.
-  const baseDate = new Date(meta.generatedAt);
   for (const file of status.files ?? []) {
     const slug = fileEntryToSlug(file.file);
     const fingerprint = fingerprintMap.get(slug);
     if (!fingerprint) continue; // defensive: no snapshot, skip
-
-    const reviewAfterForSlug = staggeredReviewAfter(
-      slug,
-      baseDate,
-      meta.reviewAfterOverride ?? null,
-    );
 
     for (const issue of file.issues ?? []) {
       if (!BASELINE_ELIGIBLE_TYPES.has(issue.type)) continue;
@@ -319,7 +235,7 @@ export function buildBaselineFromStatus(status, fingerprintMap, meta) {
         slug,
         issueType: issue.type,
         snapshotFingerprint: fingerprint,
-        reviewAfter: reviewAfterForSlug,
+        priority: 'medium',
         sectionPath: null,
         segmentKind: null,
         enSegmentIndex: null,
@@ -327,13 +243,10 @@ export function buildBaselineFromStatus(status, fingerprintMap, meta) {
         enSourceFingerprint: null,
         jaSourceFingerprint: null,
         missingTokens: null,
-        inconclusiveCategory: null,
-        inconclusiveReason: null,
-        // structure mismatch / source unusable 用フィールド
+        // structure mismatch 用フィールド
         sectionIndex: null,
         structureCategory: null,
         structureFingerprint: null,
-        usabilityReason: null,
       };
 
       if (STRUCTURE_MISMATCH_TYPES.has(issue.type)) {
@@ -364,22 +277,8 @@ export function buildBaselineFromStatus(status, fingerprintMap, meta) {
         entries.push(entry);
         continue;
       }
-      if (SOURCE_UNUSABLE_TYPES.has(issue.type)) {
-        // page 粒度の source unusable detector。
-        // identity surface: usabilityReason のみ。
-        const reason = issue.usabilitySignals?.reason ?? null;
-        if (typeof reason !== 'string' || !USABILITY_REASONS.has(reason)) {
-          continue;
-        }
-        entry.usabilityReason = reason;
-        entries.push(entry);
-        continue;
-      }
 
-      if (issue.type === 'segment-inconclusive') {
-        entry.inconclusiveCategory = issue.inconclusiveCategory ?? null;
-        entry.inconclusiveReason = issue.inconclusiveReason ?? null;
-      } else if (issue.type === 'segment-extra' || issue.type === 'segment-untranslated') {
+      if (issue.type === 'segment-extra' || issue.type === 'segment-untranslated') {
         // JA-owned diffs — use jaSegmentIndex as the anchor.
         if (
           typeof issue.jaSegmentIndex !== 'number' ||
@@ -436,7 +335,7 @@ export function buildBaselineFromStatus(status, fingerprintMap, meta) {
   }
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt: meta.generatedAt,
     generatedFromRunId: meta.runId,
     rationale: meta.rationale,
@@ -449,7 +348,7 @@ export function buildGenerationMeta(status, args) {
   const generatedAt = checkedAt;
   let defaultRationale;
   if (args.regenerate) {
-    defaultRationale = 'frozen baseline — regenerated with staggered reviewAfter';
+    defaultRationale = 'frozen baseline — regenerated (schema v2)';
   } else if (args.types) {
     defaultRationale =
       `frozen baseline — partial regeneration by type: ${args.types.join(', ')}`;
@@ -461,10 +360,6 @@ export function buildGenerationMeta(status, args) {
   return {
     runId: `${checkedAt}#parity-check-status`,
     generatedAt,
-    // Per-entry reviewAfter is computed in buildBaselineFromStatus from
-    // (baseDate, slug). The CLI override is forwarded as
-    // reviewAfterOverride and disables the stagger when set.
-    reviewAfterOverride: args.reviewAfter ?? null,
     rationale: args.rationale ?? defaultRationale,
   };
 }
@@ -474,7 +369,6 @@ export function buildGenerationMeta(status, args) {
  *
  * structure mismatch 系は sectionIndex を sectionPath より先に使うことで、
  * 同一ページ内で sectionPath が衝突しても stable に並ぶ。
- * source unusable 系は usabilityReason で補助 sort する。
  */
 function sortEntries(entries) {
   return [...entries].sort((a, b) => {
@@ -491,23 +385,12 @@ function sortEntries(entries) {
       const bFp = b.structureFingerprint ?? '';
       return aFp < bFp ? -1 : aFp > bFp ? 1 : 0;
     }
-    if (SOURCE_UNUSABLE_TYPES.has(a.issueType)) {
-      const aReason = a.usabilityReason ?? '';
-      const bReason = b.usabilityReason ?? '';
-      return aReason < bReason ? -1 : aReason > bReason ? 1 : 0;
-    }
     const aSec = a.sectionPath ?? '';
     const bSec = b.sectionPath ?? '';
     if (aSec !== bSec) return aSec < bSec ? -1 : 1;
     const aKind = a.segmentKind ?? '';
     const bKind = b.segmentKind ?? '';
     if (aKind !== bKind) return aKind < bKind ? -1 : 1;
-    if (a.issueType === 'segment-inconclusive') {
-      const aCat = a.inconclusiveCategory ?? '';
-      const bCat = b.inconclusiveCategory ?? '';
-      if (aCat !== bCat) return aCat < bCat ? -1 : 1;
-      return 0;
-    }
     if (a.issueType === 'segment-extra' || a.issueType === 'segment-untranslated') {
       const aIdx = a.jaSegmentIndex ?? -1;
       const bIdx = b.jaSegmentIndex ?? -1;
@@ -571,7 +454,7 @@ export function mergePartialBaseline(existing, slugsToReplace, newEntries, meta)
   const slugSet = new Set(slugsToReplace);
   const preserved = existing.entries.filter((e) => !slugSet.has(e.slug));
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt: meta.generatedAt,
     generatedFromRunId: meta.generatedFromRunId,
     rationale: meta.rationale,
@@ -583,10 +466,7 @@ export function mergePartialBaseline(existing, slugsToReplace, newEntries, meta)
  * `--types=<csv>` partial mode 用のマージヘルパー。
  *
  * 指定 issueType の既存エントリだけを削除し、新しい entries とマージする。
- * 指定外の issueType のエントリは bit-identical で保持する。これにより、
- * 既存 segment-* エントリの `reviewAfter` を意図せず shift させずに、
- * 新 4 type (structure mismatch / source unusable) のエントリだけを
- * 追加生成できる。
+ * 指定外の issueType のエントリは bit-identical で保持する。
  *
  * @param {object} existing — loadBaselineFile の戻り値
  * @param {string[]} typesToReplace — 置換対象の issueType (例: ['section-structure-mismatch'])
@@ -598,7 +478,7 @@ export function mergePartialBaselineByType(existing, typesToReplace, newEntries,
   const preserved = existing.entries.filter((e) => !typeSet.has(e.issueType));
   const filteredNew = newEntries.filter((e) => typeSet.has(e.issueType));
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt: meta.generatedAt,
     generatedFromRunId: meta.generatedFromRunId,
     rationale: meta.rationale,
@@ -613,21 +493,19 @@ export function mergePartialBaselineByType(existing, typesToReplace, newEntries,
 export function parseArgs(argv) {
   const slugArg = argv.find((arg) => arg.startsWith('--slug='));
   const rationaleArg = argv.find((arg) => arg.startsWith('--rationale='));
-  const reviewAfterArg = argv.find((arg) => arg.startsWith('--review-after='));
   const typesArg = argv.find((arg) => arg.startsWith('--types='));
   return {
     regenerate: argv.includes('--regenerate'),
     slugs: slugArg ? slugArg.slice('--slug='.length).split(',').filter(Boolean) : null,
     types: typesArg ? typesArg.slice('--types='.length).split(',').filter(Boolean) : null,
     rationale: rationaleArg ? rationaleArg.slice('--rationale='.length) : null,
-    reviewAfter: reviewAfterArg ? reviewAfterArg.slice('--review-after='.length) : null,
   };
 }
 
 function printUsage() {
   console.error('Usage:');
   console.error(
-    '  node scripts/generate_parity_baseline.mjs --regenerate [--rationale="..."] [--review-after=YYYY-MM-DD]',
+    '  node scripts/generate_parity_baseline.mjs --regenerate [--rationale="..."]',
   );
   console.error(
     '  node scripts/generate_parity_baseline.mjs --slug=overview/foo,overview/bar [--rationale="..."]',
@@ -640,12 +518,23 @@ function printUsage() {
     '  --types is mutually exclusive with --regenerate and --slug. It re-generates only entries',
   );
   console.error(
-    '  for the specified issue types, leaving other entries (incl. their reviewAfter) untouched.',
+    '  for the specified issue types, leaving other entries untouched.',
   );
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
+  // v2: --review-after was removed entirely. Reject stale invocations to
+  // force callers (scripts, docs) to drop the obsolete flag instead of
+  // silently ignoring it.
+  const obsoleteReviewAfter = process.argv.slice(2).find((a) => a.startsWith('--review-after'));
+  if (obsoleteReviewAfter) {
+    console.error(
+      `❌ --review-after is removed in schema v2 (${obsoleteReviewAfter}). ` +
+        'Drop the flag — baseline entries no longer carry a reviewAfter field.',
+    );
+    return 1;
+  }
   if (!args.regenerate && !args.slugs && !args.types) {
     printUsage();
     return 1;
@@ -699,10 +588,10 @@ async function main() {
     // partial-by-type mode。
     // 指定 issueType の issue だけから entry を生成し、既存 baseline と
     // mergePartialBaselineByType でマージする。指定外 (segment-*) は
-    // bit-identical で残る (reviewAfter 含む)。
+    // bit-identical で残る。
     const newBaseline = buildBaselineFromStatus(status, fingerprintMap, meta);
     let existing = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       generatedAt: meta.generatedAt,
       generatedFromRunId: '',
       rationale: '',
@@ -723,7 +612,7 @@ async function main() {
     };
     const newBaseline = buildBaselineFromStatus(filtered, fingerprintMap, meta);
     let existing = {
-      schemaVersion: 1,
+      schemaVersion: 2,
       generatedAt: meta.generatedAt,
       generatedFromRunId: '',
       rationale: '',

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -700,8 +700,6 @@ function formatAdvisoryQueueScope(scope) {
 
 function buildParityFollowupBody({
   summary,
-  expiredBaselineFiles,
-  expiringBaselineFiles,
   baselineInvalidatedSlugs,
   blockingAdvisoryItems,
   advisoryQueueIssues,

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -642,23 +642,16 @@ function buildTopBaselinedPages(files, maxEntries) {
       const baselinedIssues = (file.issues ?? []).filter((issue) => issue.baselined === true);
       if (baselinedIssues.length === 0) return null;
 
-      const expiredBaselineEntries = baselinedIssues.filter(
-        (issue) => issue.baselineExpired === true,
-      ).length;
-
       return {
         file: file.file,
         slug: fileToSlug(file.file),
         issueCount: baselinedIssues.length,
-        expiredBaselineEntries,
       };
     })
     .filter(Boolean)
     .sort((left, right) => {
       const issueDiff = right.issueCount - left.issueCount;
       if (issueDiff !== 0) return issueDiff;
-      const expiredDiff = right.expiredBaselineEntries - left.expiredBaselineEntries;
-      if (expiredDiff !== 0) return expiredDiff;
       return left.file.localeCompare(right.file);
     })
     .slice(0, maxEntries);
@@ -726,8 +719,6 @@ function buildParityFollowupBody({
     '',
     `- チェック日時: ${summary.checkedAt ?? '不明'}`,
     `- ベースライン済み: ${summary.baselinedIssues ?? 0} 件 (${summary.baselinedFiles ?? 0} ファイル)`,
-    `- 期限切れベースライン: ${summary.expiredBaselineEntries ?? 0}`,
-    `- 30 日以内期限切れ予定: ${summary.expiringBaselineEntries30d ?? 0}`,
     `- 無効化されたベースライン slug: ${baselineInvalidatedSlugs.length}`,
     '',
   ];
@@ -807,36 +798,6 @@ function buildParityFollowupBody({
     );
   }
 
-  if (expiredBaselineFiles.length > 0) {
-    lines.push('## 期限切れベースラインエントリー', '');
-    lines.push(
-      formatList(
-        expiredBaselineFiles.map((f) => {
-          const rv = f.reviewAfter ? ` — reviewAfter: ${f.reviewAfter}` : '';
-          return `\`${f.file}\` (${f.count} 件${rv})`;
-        }),
-      ),
-    );
-    lines.push('');
-  }
-
-  if (expiringBaselineFiles && expiringBaselineFiles.length > 0) {
-    lines.push('## 30 日以内に期限切れ', '');
-    lines.push(
-      '> `reviewAfter` を越えて gate に戻る前に解消 PR を計画してください。',
-      '',
-    );
-    lines.push(
-      formatList(
-        expiringBaselineFiles.map((f) => {
-          const rv = f.reviewAfter ? ` — reviewAfter: ${f.reviewAfter}` : '';
-          return `\`${f.file}\` (${f.count} 件${rv})`;
-        }),
-      ),
-    );
-    lines.push('');
-  }
-
   if (baselineInvalidatedSlugs.length > 0) {
     lines.push('## 無効化されたベースライン slug', '');
     lines.push(
@@ -871,8 +832,6 @@ function buildParityFollowup(parity, options = {}) {
   const advisoryQueue = parity.advisoryQueue ?? [];
   const advisoryQueueScope = parity.advisoryQueueScope ?? null;
 
-  const expiredBaselineEntries = summary.expiredBaselineEntries ?? 0;
-  const expiringBaselineEntries30d = summary.expiringBaselineEntries30d ?? 0;
   const baselineInvalidatedSlugs = summary.baselineInvalidatedSlugs ?? [];
   const advisoryQueueIssues = summary.advisoryQueueIssues ?? 0;
   const advisoryQueueFiles = summary.advisoryQueueFiles ?? 0;
@@ -894,45 +853,9 @@ function buildParityFollowup(parity, options = {}) {
 
   const shouldOpenIssue =
     baselinedIssues > 0 ||
-    expiredBaselineEntries > 0 ||
-    expiringBaselineEntries30d > 0 ||
     baselineInvalidatedSlugs.length > 0 ||
     hasBlockingAdvisory;
 
-  const expiredBaselineFiles = [];
-  const expiringBaselineFiles = [];
-  for (const file of files) {
-    const expired = (file.issues ?? []).filter(
-      (i) => i.baselined === true && i.baselineExpired === true,
-    );
-    if (expired.length > 0) {
-      expiredBaselineFiles.push({
-        file: file.file,
-        count: expired.length,
-        reviewAfter:
-          expired.map((i) => i.baselineReviewAfter).filter(Boolean)[0] ?? null,
-      });
-    }
-    const expiring = (file.issues ?? []).filter(
-      (i) => i.baselined === true && i.baselineExpiringSoon === true,
-    );
-    if (expiring.length > 0) {
-      expiringBaselineFiles.push({
-        file: file.file,
-        count: expiring.length,
-        reviewAfter:
-          expiring.map((i) => i.baselineReviewAfter).filter(Boolean)[0] ?? null,
-      });
-    }
-  }
-  expiredBaselineFiles.sort((a, b) => b.count - a.count);
-  expiringBaselineFiles.sort((a, b) => {
-    // review 期限が近い順に並べ、期限切れの崖を先頭から見えるようにする。
-    if ((a.reviewAfter ?? '') !== (b.reviewAfter ?? '')) {
-      return (a.reviewAfter ?? '') < (b.reviewAfter ?? '') ? -1 : 1;
-    }
-    return b.count - a.count;
-  });
   const reviewHints = {
     topBaselinedPages: buildTopBaselinedPages(files, maxEntries),
     tokenlessNearTieExamples: buildTokenlessNearTieExamples(advisoryQueue, maxEntries),
@@ -944,8 +867,6 @@ function buildParityFollowup(parity, options = {}) {
     ? withFamilyMarker(
         buildParityFollowupBody({
           summary,
-          expiredBaselineFiles: expiredBaselineFiles.slice(0, maxEntries),
-          expiringBaselineFiles: expiringBaselineFiles.slice(0, maxEntries),
           baselineInvalidatedSlugs,
           blockingAdvisoryItems:
             isComplete === true ? blockingAdvisoryItems.slice(0, maxEntries) : [],
@@ -972,10 +893,6 @@ function buildParityFollowup(parity, options = {}) {
       baselineDebt: {
         baselinedIssues: summary.baselinedIssues ?? 0,
         baselinedFiles: summary.baselinedFiles ?? 0,
-        expiredBaselineEntries,
-        expiredBaselineFiles,
-        expiringBaselineEntries30d,
-        expiringBaselineFiles,
         baselineInvalidatedSlugs,
         baselineInvalidatedSlugCount: baselineInvalidatedSlugs.length,
       },
@@ -1317,7 +1234,6 @@ export function renderSummaryMarkdown(_snapshot, parity, actionableReport, audit
     '## パリティフォローアップ',
     '',
     `- ベースライン済み: ${actionableReport.parityFollowup?.summary?.baselineDebt?.baselinedIssues ?? 0} 件 (${actionableReport.parityFollowup?.summary?.baselineDebt?.baselinedFiles ?? 0} ファイル)`,
-    `- 期限切れベースライン: ${actionableReport.parityFollowup?.summary?.baselineDebt?.expiredBaselineEntries ?? 0}`,
     `- 無効化された slug: ${(actionableReport.parityFollowup?.summary?.baselineDebt?.baselineInvalidatedSlugs ?? []).length}`,
     `- アドバイザリキュー: ${actionableReport.parityFollowup?.summary?.advisoryQueue?.issues ?? 0} 件 (${actionableReport.parityFollowup?.summary?.advisoryQueue?.files ?? 0} ファイル, ${actionableReport.parityFollowup?.summary?.advisoryQueue?.blockingItems ?? 0} ブロッキング; ${formatAdvisoryQueueScope(actionableReport.parityFollowup?.summary?.advisoryQueue?.advisoryQueueScope ?? null)})`,
     '',

--- a/scripts/lib/source_parity_advisory_queue.mjs
+++ b/scripts/lib/source_parity_advisory_queue.mjs
@@ -121,8 +121,6 @@ export function buildAdvisoryReviewQueue(results) {
           baselined: issue.baselined === true,
           acknowledged: issue.acknowledged === true,
           ackExpired: issue.ackExpired === true,
-          baselineReviewAfter: issue.baselineReviewAfter ?? null,
-          baselineExpired: issue.baselineExpired === true,
         };
       });
 

--- a/scripts/lib/source_parity_baseline.mjs
+++ b/scripts/lib/source_parity_baseline.mjs
@@ -1,5 +1,5 @@
 /**
- * Frozen baseline mechanism。
+ * Frozen baseline mechanism (schema v2 / Phase 4 final).
  *
  * baseline は cutover 時点の既存 drift を凍結する仕組み。ack は「人がレビュー
  * して了承した例外」、baseline は「cutover 時点の既知 debt」で意味も生成方法
@@ -7,6 +7,14 @@
  *
  * 純粋関数のみ。filesystem I/O は呼び出し側 (check_source_parity.mjs /
  * generate_parity_baseline.mjs) が行う。loadBaselineFile だけ薄い fs wrapper。
+ *
+ * v2 変更点 (Phase 4):
+ * - `reviewAfter` 概念を撤去 (期限切れ / expiringSoon も含めて全廃)
+ * - BASELINE_ELIGIBLE_TYPES を JA-actionable 7 type に縮約
+ *   (segment-inconclusive / snapshot-incomplete / source-unusable を除外)
+ * - `inconclusiveCategory` / `inconclusiveReason` / `usabilityReason` は
+ *   entry schema から除去 (runtime issue 側にのみ保持)
+ * - `priority` (high/medium/low, default medium) / `note` (任意 free-text) を追加
  *
  * @module source_parity_baseline
  */
@@ -16,20 +24,16 @@ import { createHash } from 'node:crypto';
 
 import {
   STRUCTURE_MISMATCH_TYPES,
-  SOURCE_UNUSABLE_TYPES,
 } from './source_parity_types.mjs';
 
 /**
- * frozen baseline 対象になる issue type。
+ * frozen baseline 対象になる issue type (schema v2)。
  *
- * structure mismatch (section-structure-mismatch /
- * segment-order-mismatch) と source unusable (snapshot-incomplete /
- * source-unusable) を baseline 可能にした。identity key は segment-*
- * ファミリとは別系統で、structure 系は sectionIndex + structureCategory +
- * structureFingerprint、source unusable 系は usabilityReason のみで同定
- * する (§3.2 / §3.3)。`source-unusable` / `snapshot-incomplete` は gate
- * には載らないが (翻訳者責任外な source 側 debt)、ack / baseline で人手
- * 管理できる枠を提供する。
+ * JA-actionable な 7 type のみ。期限管理 / advisory の混在を避けるため
+ * segment-inconclusive (advisory) / snapshot-incomplete / source-unusable
+ * (source 側 debt) は eligibility から外した。identity key は
+ * `buildBaselineKey` / `buildBaselineKeyFromEntry` で segment 系 vs
+ * structure 系で分岐する。
  *
  * @type {ReadonlySet<string>}
  */
@@ -40,22 +44,17 @@ export const BASELINE_ELIGIBLE_TYPES = Object.freeze(
     'segment-shifted',
     'segment-untranslated',
     'segment-token-gap',
-    'segment-inconclusive',
     'section-structure-mismatch',
     'segment-order-mismatch',
-    'snapshot-incomplete',
-    'source-unusable',
   ]),
 );
 
 /**
  * `generate_parity_baseline --types` で受け入れる issueType の allowlist。
- * BASELINE_ELIGIBLE_TYPES より狭く、structure/source-unusable migration
- * 対象 (structure mismatch + source unusable) の 4 type のみを許可する。
  *
- * これより広くすると `--types` が既存 segment-* entry を touch できて
- * しまい、reviewAfter の意図しない shift を起こす (§7.4 の意図と反する)。
- * 逆にこれより狭くすると partial migration 自体が不可能になる。
+ * v2 では structure mismatch 2 type のみ。segment-* は `--regenerate` で
+ * 全再構築するのが基本運用で、`--types` による partial regenerate は
+ * structure family の migration 時のみ使う契約。
  *
  * `--types=` を空で渡した場合 (silent no-op が起きる入力パターン) も
  * `validateTypesArg` で reject される。
@@ -66,10 +65,22 @@ export const TYPES_ARG_ALLOWLIST = Object.freeze(
   new Set([
     'section-structure-mismatch',
     'segment-order-mismatch',
-    'snapshot-incomplete',
-    'source-unusable',
   ]),
 );
+
+/**
+ * baseline entry が取りうる priority 値 (schema v2)。
+ * default は `medium`。generator / validator は in order で strict match する。
+ *
+ * @type {readonly ['high', 'medium', 'low']}
+ */
+export const PRIORITY_VALUES = Object.freeze(['high', 'medium', 'low']);
+
+/**
+ * baseline entry に付与できる free-text note の最大長 (v2)。
+ * @type {number}
+ */
+export const NOTE_MAX_LENGTH = 500;
 
 /**
  * `generate_parity_baseline.mjs --types=<csv>` の引数を検証する純粋関数。
@@ -130,18 +141,6 @@ export const STRUCTURE_CATEGORIES = Object.freeze(
 );
 
 /**
- * source unusable baseline 対象の usabilityReason 列。
- * `source_parity_source_usability.mjs::buildIssue` の reason と 1:1 で対応
- * する enum。emitter 側が新しい reason を追加する際はこちらも同期する
- * 必要がある (test で pin)。
- *
- * @type {ReadonlySet<string>}
- */
-export const USABILITY_REASONS = Object.freeze(
-  new Set(['shallow-snapshot', 'escaped-details-residue', 'extractor-empty']),
-);
-
-/**
  * structure mismatch issue の payload から
  * `structureFingerprint` (sha256:<64 hex>) を derive する純粋関数。
  *
@@ -189,21 +188,6 @@ export function computeStructureFingerprint({
   return 'sha256:' + createHash('sha256').update(raw).digest('hex');
 }
 
-/**
- * `segment-inconclusive` の構造化カテゴリ。free text の `inconclusiveReason` は
- * baseline 同定に使わず、必ずこの enum で同定する。
- *
- * @type {ReadonlySet<string>}
- */
-export const INCONCLUSIVE_CATEGORIES = Object.freeze(
-  new Set([
-    'heading-count-mismatch',
-    'align-exception',
-    'tokenless-near-tie',
-  ]),
-);
-
-const REVIEW_AFTER_RE = /^\d{4}-\d{2}-\d{2}$/;
 const FINGERPRINT_RE = /^sha256:[0-9a-f]{64}$/;
 
 function isValidFingerprint(value) {
@@ -224,7 +208,7 @@ function missingTokensSignature(value) {
 }
 
 /**
- * Validate a parsed parity-baseline.json object.
+ * Validate a parsed parity-baseline.json object (schema v2).
  * Throws a descriptive Error on any schema violation.
  *
  * @param {unknown} parsed
@@ -234,8 +218,8 @@ export function validateBaseline(parsed) {
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('Baseline file must be a JSON object');
   }
-  if (parsed.schemaVersion !== 1) {
-    throw new Error(`Unsupported baseline schemaVersion: ${parsed.schemaVersion}`);
+  if (parsed.schemaVersion !== 2) {
+    throw new Error(`Unsupported baseline schemaVersion: ${parsed.schemaVersion} (expected 2)`);
   }
   if (!Array.isArray(parsed.entries)) {
     throw new Error('Baseline must have an "entries" array');
@@ -266,19 +250,21 @@ export function validateBaseline(parsed) {
       throw new Error(`${prefix}: invalid "snapshotFingerprint" — must be sha256:<64 hex>`);
     }
 
-    if (typeof entry.reviewAfter !== 'string' || !REVIEW_AFTER_RE.test(entry.reviewAfter)) {
-      throw new Error(`${prefix}: invalid "reviewAfter" — must be strict YYYY-MM-DD`);
-    }
-    const [year, month, day] = entry.reviewAfter.split('-').map(Number);
-    const roundTrip = new Date(Date.UTC(year, month - 1, day));
-    if (
-      roundTrip.getUTCFullYear() !== year ||
-      roundTrip.getUTCMonth() + 1 !== month ||
-      roundTrip.getUTCDate() !== day
-    ) {
+    // v2: priority (required, enum) / note (optional, <= 500 chars)
+    if (!PRIORITY_VALUES.includes(entry.priority)) {
       throw new Error(
-        `${prefix}: "reviewAfter" "${entry.reviewAfter}" is not a valid calendar date`,
+        `${prefix}: invalid "priority" — must be one of ${PRIORITY_VALUES.join(', ')}`,
       );
+    }
+    if (entry.note !== undefined && entry.note !== null) {
+      if (typeof entry.note !== 'string') {
+        throw new Error(`${prefix}: "note" must be a string when present`);
+      }
+      if (entry.note.length > NOTE_MAX_LENGTH) {
+        throw new Error(
+          `${prefix}: "note" exceeds ${NOTE_MAX_LENGTH} characters (got ${entry.note.length})`,
+        );
+      }
     }
 
     // issueType ごとに、baseline の同定に必要な構造化フィールドを検証する。
@@ -310,27 +296,6 @@ export function validateBaseline(parsed) {
       if (!isValidFingerprint(entry.structureFingerprint)) {
         throw new Error(
           `${prefix}: ${entry.issueType} entry must have valid structureFingerprint (sha256:<64 hex>)`,
-        );
-      }
-    } else if (SOURCE_UNUSABLE_TYPES.has(entry.issueType)) {
-      // page 単位の unusable 判定は usabilityReason だけで同定する。
-      if (
-        typeof entry.usabilityReason !== 'string' ||
-        !USABILITY_REASONS.has(entry.usabilityReason)
-      ) {
-        throw new Error(
-          `${prefix}: ${entry.issueType} entry must have usabilityReason in ` +
-            `${[...USABILITY_REASONS].join(', ')}`,
-        );
-      }
-    } else if (entry.issueType === 'segment-inconclusive') {
-      if (
-        typeof entry.inconclusiveCategory !== 'string' ||
-        !INCONCLUSIVE_CATEGORIES.has(entry.inconclusiveCategory)
-      ) {
-        throw new Error(
-          `${prefix}: segment-inconclusive entry must have inconclusiveCategory in ` +
-            `${[...INCONCLUSIVE_CATEGORIES].join(', ')}`,
         );
       }
     } else if (entry.issueType === 'segment-extra' || entry.issueType === 'segment-untranslated') {
@@ -402,56 +367,15 @@ export function loadBaselineFile(filePath) {
  */
 const JA_OWNED_TYPES = new Set(['segment-extra', 'segment-untranslated']);
 
-export function isBaselineExpired(entry, today) {
-  if (typeof today !== 'string' || !REVIEW_AFTER_RE.test(today)) return false;
-  return today > entry.reviewAfter;
-}
-
-/**
- * baseline 期限の事前警告日数。
- */
-export const BASELINE_EXPIRY_WARNING_DAYS = 30;
-
-/**
- * Returns true when an entry's `reviewAfter` is within
- * `BASELINE_EXPIRY_WARNING_DAYS` of `today` (inclusive of the boundary)
- * but the entry has not yet expired.
- *
- * Both inputs MUST be strict YYYY-MM-DD strings; this function does not
- * accept Date objects so callers cannot accidentally introduce timezone
- * drift.
- *
- * @param {object} entry
- * @param {string} today — strict YYYY-MM-DD
- * @returns {boolean}
- */
-export function isBaselineExpiringSoon(entry, today) {
-  if (typeof today !== 'string' || !REVIEW_AFTER_RE.test(today)) return false;
-  if (typeof entry.reviewAfter !== 'string' || !REVIEW_AFTER_RE.test(entry.reviewAfter)) {
-    return false;
-  }
-  if (today > entry.reviewAfter) return false;
-  const [ty, tm, td] = today.split('-').map(Number);
-  const [ry, rm, rd] = entry.reviewAfter.split('-').map(Number);
-  const todayUtc = Date.UTC(ty, tm - 1, td);
-  const reviewUtc = Date.UTC(ry, rm - 1, rd);
-  const diffDays = Math.floor((reviewUtc - todayUtc) / 86400000);
-  return diffDays >= 0 && diffDays <= BASELINE_EXPIRY_WARNING_DAYS;
-}
-
 /**
  * Build a stable lookup key from an issue object.
  *
- * Key rules:
+ * Key rules (schema v2):
  *   - JA-owned (segment-extra, segment-untranslated):
- *       `slug + issueType + sectionPath + segmentKind + jaSegmentIndex`
+ *       `slug + issueType + sectionPath + segmentKind + jaSegmentIndex + jaSourceFingerprint`
  *   - EN-owned (segment-missing, segment-shifted, segment-token-gap):
- *       `slug + issueType + sectionPath + segmentKind + enSegmentIndex`
- *   - segment-inconclusive: `slug + issueType + inconclusiveCategory`
- *
- * The free-text `inconclusiveReason` is intentionally NOT used as part of
- * the key — it changes with wording tweaks and would silently break the
- * baseline match. Use the structured `inconclusiveCategory` enum instead.
+ *       `slug + issueType + sectionPath + segmentKind + enSegmentIndex + enSourceFingerprint`
+ *   - structure mismatch: `slug + issueType + sectionIndex + structureCategory + structureFingerprint`
  *
  * @param {string} slug
  * @param {object} issue
@@ -470,13 +394,6 @@ export function buildBaselineKey(slug, issue) {
       `${slug}|${issue.type}|idx=${issue.sectionIndex ?? '_null_'}|` +
       `cat=${issue.structureCategory ?? '_null_'}|sfp=${fp}`
     );
-  }
-  if (SOURCE_UNUSABLE_TYPES.has(issue.type)) {
-    const reason = issue.usabilitySignals?.reason ?? '_null_';
-    return `${slug}|${issue.type}|reason=${reason}`;
-  }
-  if (issue.type === 'segment-inconclusive') {
-    return `${slug}|${issue.type}|category=${issue.inconclusiveCategory ?? '_null_'}`;
   }
   if (JA_OWNED_TYPES.has(issue.type)) {
     return (
@@ -519,12 +436,6 @@ export function buildBaselineKeyFromEntry(entry) {
       `cat=${entry.structureCategory ?? '_null_'}|sfp=${entry.structureFingerprint ?? '_null_'}`
     );
   }
-  if (SOURCE_UNUSABLE_TYPES.has(entry.issueType)) {
-    return `${entry.slug}|${entry.issueType}|reason=${entry.usabilityReason ?? '_null_'}`;
-  }
-  if (entry.issueType === 'segment-inconclusive') {
-    return `${entry.slug}|${entry.issueType}|category=${entry.inconclusiveCategory ?? '_null_'}`;
-  }
   if (JA_OWNED_TYPES.has(entry.issueType)) {
     return (
       `${entry.slug}|${entry.issueType}|${entry.sectionPath ?? ''}|${entry.segmentKind ?? ''}|ja|` +
@@ -559,11 +470,14 @@ export function buildBaselineKeyFromEntry(entry) {
  *
  * Returns a fresh array — does not mutate inputs.
  *
+ * v2 契約: `issue.baselined === true` を付与するだけ (期限管理 / tagging
+ * metadata は全廃)。フィルタ側は `isFrozenByBaseline(issue) ≡
+ * issue.baselined === true` で判定する。
+ *
  * @param {string} slug
  * @param {object[]} issues
  * @param {object[]} baselineEntries — full entries array, may include other slugs
  * @param {string|null} currentSnapshotFingerprint
- * @param {string|null} [today]
  * @returns {{ tagged: object[], invalidated: boolean, matchedKeys: Set<string> }}
  */
 export function tagIssuesWithBaseline(
@@ -571,7 +485,6 @@ export function tagIssuesWithBaseline(
   issues,
   baselineEntries,
   currentSnapshotFingerprint,
-  today = null,
 ) {
   const slugEntries = baselineEntries.filter((e) => e.slug === slug);
 
@@ -607,19 +520,8 @@ export function tagIssuesWithBaseline(
     }
     const key = buildBaselineKey(slug, issue);
     if (entryKeyIndex.has(key)) {
-      const entry = entryKeyIndex.get(key);
       matchedKeys.add(key);
-      const taggedIssue = {
-        ...issue,
-        baselined: true,
-        baselineReviewAfter: entry.reviewAfter,
-      };
-      if (isBaselineExpired(entry, today)) {
-        taggedIssue.baselineExpired = true;
-      } else if (isBaselineExpiringSoon(entry, today)) {
-        taggedIssue.baselineExpiringSoon = true;
-      }
-      return taggedIssue;
+      return { ...issue, baselined: true };
     }
     return { ...issue };
   });

--- a/scripts/lib/source_parity_issue_state.mjs
+++ b/scripts/lib/source_parity_issue_state.mjs
@@ -14,7 +14,7 @@ export function isValidAcknowledgedIssue(issue) {
 }
 
 export function isFrozenByBaseline(issue) {
-  return issue.baselined === true && issue.baselineExpired !== true;
+  return issue.baselined === true;
 }
 
 export function isActiveParityIssue(issue) {

--- a/scripts/lib/source_parity_summary.mjs
+++ b/scripts/lib/source_parity_summary.mjs
@@ -66,8 +66,6 @@ export function summarizeParityResults(results, orphanMeta = {}) {
   let expiredAcknowledgements = 0;
   let baselinedIssues = 0;
   let baselinedFiles = 0;
-  let expiredBaselineEntries = 0;
-  let expiringBaselineEntries30d = 0;
   let reportableActiveFiles = 0;
   let reportableActiveActionableFiles = 0;
   let auditSignalIssues = 0;
@@ -98,11 +96,6 @@ export function summarizeParityResults(results, orphanMeta = {}) {
       if (isBaselined) {
         baselinedIssues += 1;
         baselinedByType[issue.type] = (baselinedByType[issue.type] || 0) + 1;
-        if (issue.baselineExpired === true) {
-          expiredBaselineEntries += 1;
-        } else if (issue.baselineExpiringSoon === true) {
-          expiringBaselineEntries30d += 1;
-        }
         if (
           issue.type === 'segment-inconclusive' &&
           typeof issue.inconclusiveCategory === 'string'
@@ -201,8 +194,6 @@ export function summarizeParityResults(results, orphanMeta = {}) {
     baselinedFiles,
     baselinedByType,
     baselinedByInconclusiveCategory,
-    expiredBaselineEntries,
-    expiringBaselineEntries30d,
     // audit / reportable counters
     reportableActiveFiles,
     reportableActiveActionableFiles,

--- a/scripts/lib/source_parity_summary.mjs
+++ b/scripts/lib/source_parity_summary.mjs
@@ -36,11 +36,11 @@ import {
  *     snapshot / source 起因で comparator が成立しないページ用の独立 counter。
  *     翻訳差分と混ぜずに別枠で集計し、gate には載せない。
  *
- *   baselinedIssues / baselinedFiles / baselinedByType /
- *   baselinedByInconclusiveCategory / expiredBaselineEntries
- *     Frozen drift accounting。parity-baseline.json が cutover 前の
- *     segment-* drift を active gate から除外する。期限切れ baseline は
- *     gate に refire する (isFrozenByBaseline / isReportableParityIssue 参照)。
+ *   baselinedIssues / baselinedFiles / baselinedByType
+ *     Frozen drift accounting (schema v2)。parity-baseline.json が cutover
+ *     前の segment-* / structure drift を active gate から除外する。v2 では
+ *     期限概念を廃止し、`isFrozenByBaseline(issue) ≡ issue.baselined === true`
+ *     に縮約している (isReportableParityIssue 参照)。
  *
  * @param {object[]} results
  * @param {object} [orphanMeta] 呼び出し側で集計した orphan baseline entry の情報。
@@ -51,7 +51,6 @@ export function summarizeParityResults(results, orphanMeta = {}) {
   const issuesByType = {};
   const issuesBySeverity = {};
   const baselinedByType = {};
-  const baselinedByInconclusiveCategory = {};
   const auditSignalsByType = {};
   const structureMismatchByType = {};
   const snapshotUnusableByType = {};
@@ -96,13 +95,6 @@ export function summarizeParityResults(results, orphanMeta = {}) {
       if (isBaselined) {
         baselinedIssues += 1;
         baselinedByType[issue.type] = (baselinedByType[issue.type] || 0) + 1;
-        if (
-          issue.type === 'segment-inconclusive' &&
-          typeof issue.inconclusiveCategory === 'string'
-        ) {
-          baselinedByInconclusiveCategory[issue.inconclusiveCategory] =
-            (baselinedByInconclusiveCategory[issue.inconclusiveCategory] || 0) + 1;
-        }
         hasBaselined = true;
       }
 
@@ -193,7 +185,6 @@ export function summarizeParityResults(results, orphanMeta = {}) {
     baselinedIssues,
     baselinedFiles,
     baselinedByType,
-    baselinedByInconclusiveCategory,
     // audit / reportable counters
     reportableActiveFiles,
     reportableActiveActionableFiles,

--- a/scripts/phase4/migrate_baseline_schema.mjs
+++ b/scripts/phase4/migrate_baseline_schema.mjs
@@ -60,7 +60,12 @@ export function migrateEntry(entry) {
   for (const [key, value] of Object.entries(entry)) {
     if (!DROP_FIELDS.has(key)) out[key] = value;
   }
-  if (!out.priority) out.priority = 'medium';
+  // v1 never emits `priority`. We only default the field if it is missing
+  // (undefined) or null — other falsy values are preserved for `validateBaseline`
+  // to reject so we never silently overwrite an explicit caller-supplied value.
+  if (out.priority === undefined || out.priority === null) {
+    out.priority = 'medium';
+  }
   return out;
 }
 
@@ -72,9 +77,17 @@ export function migrateBaseline(baseline) {
   if (!baseline || typeof baseline !== 'object' || Array.isArray(baseline)) {
     throw new Error('migrateBaseline: input must be a baseline object');
   }
-  const entries = Array.isArray(baseline.entries)
-    ? baseline.entries.map(migrateEntry).filter((e) => e !== null)
-    : [];
+  // Fail-closed on malformed entries array (Codex C1 / R1):
+  // silently coercing a non-array to [] would hide data corruption upstream
+  // behind an empty but technically-valid v2 baseline.
+  if (!Array.isArray(baseline.entries)) {
+    throw new Error(
+      `migrateBaseline: baseline.entries must be an array (got ${
+        baseline.entries === null ? 'null' : typeof baseline.entries
+      })`,
+    );
+  }
+  const entries = baseline.entries.map(migrateEntry).filter((e) => e !== null);
   const existingRationale =
     typeof baseline.rationale === 'string' ? baseline.rationale : '';
   const rationale = existingRationale.includes('Phase 4 v2')

--- a/scripts/phase4/migrate_baseline_schema.mjs
+++ b/scripts/phase4/migrate_baseline_schema.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * One-shot migration: parity-baseline.json schema v1 → v2.
+ *
+ * v1 → v2 changes:
+ *   - Drop entry fields: reviewAfter / inconclusiveReason / inconclusiveCategory / usabilityReason
+ *   - Drop entries with issueType: segment-inconclusive / snapshot-incomplete / source-unusable
+ *     (moved out of baseline — these remain as runtime issues only)
+ *   - Default priority: 'medium' (preserved if already set)
+ *   - Root schemaVersion: 1 → 2
+ *   - Rationale gets " / Phase 4 v2" suffix for provenance
+ *
+ * Pure functions (`migrateEntry`, `migrateBaseline`) are exported so tests
+ * and downstream tools can exercise the migration without fs I/O. The CLI
+ * wrapper reads `parity-baseline.json`, applies the migration, validates
+ * against the v2 schema, and writes back.
+ *
+ * @module migrate_baseline_schema
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ROOT_DIR } from '../lib/project.mjs';
+import { validateBaseline } from '../lib/source_parity_baseline.mjs';
+
+const BASELINE_PATH = path.join(ROOT_DIR, 'parity-baseline.json');
+
+/**
+ * Fields removed from v2 baseline entries.
+ * Runtime issues may still carry these (e.g. inconclusiveReason) but the
+ * frozen baseline representation drops them.
+ */
+const DROP_FIELDS = new Set([
+  'reviewAfter',
+  'inconclusiveReason',
+  'inconclusiveCategory',
+  'usabilityReason',
+]);
+
+/**
+ * Issue types removed from BASELINE_ELIGIBLE_TYPES in v2.
+ * Entries of these types are dropped entirely (no longer baseline-able).
+ */
+const DROP_ISSUE_TYPES = new Set([
+  'segment-inconclusive',
+  'snapshot-incomplete',
+  'source-unusable',
+]);
+
+/**
+ * @param {object} entry — a v1 baseline entry
+ * @returns {object|null} migrated v2 entry, or null if entry should be dropped
+ */
+export function migrateEntry(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  if (DROP_ISSUE_TYPES.has(entry.issueType)) return null;
+  const out = {};
+  for (const [key, value] of Object.entries(entry)) {
+    if (!DROP_FIELDS.has(key)) out[key] = value;
+  }
+  if (!out.priority) out.priority = 'medium';
+  return out;
+}
+
+/**
+ * @param {object} baseline — a v1 baseline payload
+ * @returns {object} migrated v2 baseline payload
+ */
+export function migrateBaseline(baseline) {
+  if (!baseline || typeof baseline !== 'object' || Array.isArray(baseline)) {
+    throw new Error('migrateBaseline: input must be a baseline object');
+  }
+  const entries = Array.isArray(baseline.entries)
+    ? baseline.entries.map(migrateEntry).filter((e) => e !== null)
+    : [];
+  const existingRationale =
+    typeof baseline.rationale === 'string' ? baseline.rationale : '';
+  const rationale = existingRationale.includes('Phase 4 v2')
+    ? existingRationale
+    : `${existingRationale} / Phase 4 v2`.trim();
+  return {
+    ...baseline,
+    schemaVersion: 2,
+    generatedAt: new Date().toISOString(),
+    rationale,
+    entries,
+  };
+}
+
+async function main() {
+  if (!fs.existsSync(BASELINE_PATH)) {
+    console.error(`❌ ${BASELINE_PATH} not found — nothing to migrate.`);
+    return 1;
+  }
+  const before = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'));
+  if (before.schemaVersion === 2) {
+    console.log('ℹ parity-baseline.json is already schemaVersion=2 — no changes.');
+    return 0;
+  }
+  const after = migrateBaseline(before);
+  validateBaseline(after);
+  const serialized = JSON.stringify(after, null, 2) + '\n';
+  fs.writeFileSync(BASELINE_PATH, serialized);
+  console.log(
+    `✅ Migrated ${before.entries?.length ?? 0} v1 entries → ${after.entries.length} v2 entries ` +
+      `(dropped: ${(before.entries?.length ?? 0) - after.entries.length})`,
+  );
+  return 0;
+}
+
+const isDirectRun =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isDirectRun) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error('❌ migrate_baseline_schema error:', err);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

Parity burn-down の最終 cutover。**5 counter (baseline.entries, baselinedIssues, advisoryQueueIssues, auditSignalIssues, snapshot-diff)** をすべて 0 に落とし、schema を **v1 → v2 atomic cutover**。

### Task 4.6: schema v1 → v2 atomic cutover
- **4.6.1**: `source_parity_baseline.mjs` を v2 validator に書き換え (priority/note 追加、reviewAfter / inconclusive* / usability* 撤去)。`BASELINE_ELIGIBLE_TYPES` を JA-actionable 7 種に縮約。`TYPES_ARG_ALLOWLIST` を structure 2 種に縮約。`isFrozenByBaseline(issue) ≡ issue.baselined === true`。`check_source_parity.mjs` の empty baseline default を v2 化、`debug.baselineSchemaVersion` を status に露出
- **4.6.2**: `generate_parity_baseline.mjs` を v2 出力化 (`priority: 'medium'` default、`--review-after` option 撤廃して exit 1 で reject)。`scripts/phase4/migrate_baseline_schema.mjs` を新設 (one-shot v1→v2 migration helper、`migrateEntry` / `migrateBaseline` export)
- **4.6.3**: advisory / summary / issue_state / detection_reports / check_source_parity の v2 対応。`baselineReviewAfter` / `baselineExpired` / `baselineExpiringSoon` tagging + 関連 summary counter (`expiredBaselineEntries` / `expiringBaselineEntries30d`) を全撤去

### Task 4.7: 運用ドキュメント最終化
- `docs/OPS_DESIGN.md`: baseline 期限管理から priority-burn-down 運用へ移行
- `docs/PARITY_GUIDE.md`: baseline entry checklist を priority/note 必須に更新
- `scripts/README.md`: generator usage と baseline section を v2 schema に更新 + migrate_baseline_schema.mjs helper 追記

### Task 4.8: 最終 E2E
- `npm run test`: 2150 pass / 0 fail / 1 skip
- `npm run lint` / `npm run build`: green (288 files / 290 pages)
- `npm run check:parity` / `npm run check:snapshots:diff`: green
- `alignSegments()` leak scan: 0 (全 runtime + test call が `{ slug }` 付き)
- deprecated field scope grep: clean (en_source_patches / acknowledgements 側の reviewAfter は別 schema として保持)

## Final state

```
parity-baseline.json:
  schemaVersion: 2
  entries.length: 0

parity-check-status.json.summary:
  reportableActiveFiles: 0
  baselinedIssues: 0
  advisoryQueueIssues: 0
  auditSignalIssues: 0

parity-check-status.json.debug:
  baselineSchemaVersion: 2
  artifactCoverage: { registryEntries, matchedHits, bySlug, byToken }

snapshot-diff-status.json.summary:
  changed: 0, added: 0, removed: 0
```

## Test plan

- [x] `npm run test` green
- [x] `npm run lint` green
- [x] `npm run build` green
- [x] `npm run check:parity` + `npm run check:snapshots:diff` green
- [x] JSON assertion helper (Task 4.8 Step 2) all pass
- [x] alignSegments call-site leak scan: 0
- [x] deprecated field scope grep: clean
- [x] `scripts/phase4/migrate_baseline_schema.mjs` idempotent (already-v2 baseline は no-op)
- [x] v2 empty baseline default が missing file ケースで動作 (`check_source_parity.test.mjs` に assertion 追加済)
- [x] `--review-after` obsolete flag は exit 1 で reject される (`generate_parity_baseline.test.mjs` に smoke test 追加済)

## 参考

- Plan: `docs/superpowers/plans/2026-04-14-parity-phase4-schema-cleanup.md` §Task 4.6 / 4.7 / 4.8
- Final-goal spec: `docs/superpowers/specs/2026-04-14-parity-phase4-final-goal.md`
- Final report: `docs/superpowers/specs/2026-04-14-parity-phase4-report.md` (本 PR で追加)
- Residual inventory: `docs/superpowers/specs/2026-04-14-parity-phase4-residual-inventory.{json,md}` (M2 時点)
- Roadmap: `docs/superpowers/specs/2026-04-14-parity-burndown-roadmap.md`

## 後続 PR (本 PR 完了後)

1. **Phase A** (`claude/upstream-recovery-phase-a`, 並列可) — `check_upstream_recovery.mjs` + test 拡張 + `source_sync_exclusions` reviewAfter parity
2. **Phase B** (`claude/upstream-recovery-phase-b`, PR Z merge **後**必須) — detection_reports への `enPatchRecovery` / `sourceSyncRecovery` section + sticky PR comment + 2-mechanism lifecycle docs
3. **pull-requests.md cleanup** — 別 PR として分離 (seeded pin test との scope 混合回避)

詳細: `docs/superpowers/plans/2026-04-20-upstream-recovery-detection.md`