### PR TITLE
feat(recovery): Phase A — upstream recovery detection (Task 1 + 2 + 6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ pnpm-debug.log*
 source-sync-status.json
 snapshot-diff-status.json
 parity-check-status.json
+upstream-recovery-status.json
 docs-actionable-report.json
 docs-update-summary.md
 docs-audit-manifest.json

--- a/docs/superpowers/specs/2026-04-20-upstream-recovery-spec.md
+++ b/docs/superpowers/specs/2026-04-20-upstream-recovery-spec.md
@@ -39,12 +39,14 @@ derived view にまとめるための JSON schema を定める。
 
 ## JSON Schema
 
+**Shape (illustrative counters — actual values vary per run):**
+
 ```jsonc
 {
   "schemaVersion": 1,
   "generatedAt": "ISO-8601 UTC timestamp",
   "summary": {
-    "totalEntries": 35,             // en_patches (34) + sync_exclusions (1)
+    "totalEntries": 35,             // en_patches (N) + sync_exclusions (M)
     "activeEntries": 34,            // statusA === 'active'
     "staleEntries": 0,              // statusA === 'stale' (Axis A signal)
     "overdueEntries": 0,            // statusB === 'overdue' (Axis B signal)

--- a/docs/superpowers/specs/2026-04-20-upstream-recovery-spec.md
+++ b/docs/superpowers/specs/2026-04-20-upstream-recovery-spec.md
@@ -1,0 +1,136 @@
+# Upstream Recovery Detection — Spec (Phase A)
+
+**Status:** implemented (Phase A landed 2026-04-20)
+**Plan:** `docs/superpowers/plans/2026-04-20-upstream-recovery-detection.md`
+**Entry point:** `scripts/check_upstream_recovery.mjs` / `npm run check:upstream-recovery`
+
+---
+
+## Purpose
+
+`en_source_patches` (segment-level) と `source_sync_exclusions` (page-level) は
+どちらも EN 上流欠陥を JA 側に mirror させず吸収する 2-mechanism。上流修正が入っても
+registry に entry が残ったままだと "stale debt" になり、未 paydown のまま人目に触れずに
+蓄積してしまう。
+
+本 spec の `upstream-recovery-status.json` は、両 registry を横断して
+**(A) 上流修正の自動検知** と **(B) 登録解除忘れの persistent reminder** を単一の
+derived view にまとめるための JSON schema を定める。
+
+## 設計原則
+
+- **既存信号の integration + expansion のみ**。新 detector / issue type / workflow は追加しない
+- **Non-blocking**: `check_upstream_recovery.mjs` は常に exit 0。consumer が JSON を読んで判断する
+- **Fail-safe**: `source-sync-status.json` 不在時は `statusA: 'unknown'` (graceful degradation)
+- **parity gate の挙動を変更しない**。`check_source_parity.mjs` / `scripts/lib/parity_*.mjs` は touch しない
+- 将来 Pattern D (unified debt catalog) への bridge として設計 (plan Appendix B)
+
+## Entry 状態遷移
+
+```
+  [registered] → [active] → [stale (upstream fixed)] → [removed (human action)]
+                    ↑            │
+                    └────────────┘  (upstream regresses — 稀)
+```
+
+- `active`: patch/exclusion の `find` or `expectedIssueType` が依然として EN に存在
+- `stale`: EN から消えた (上流修正済)。このまま放置すると registry cruft → Axis B が警告
+- `unknown`: snapshot fetch failure / source-sync-status.json 不在 等で判定不能 — fail-safe (表示のみ)
+
+## JSON Schema
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "generatedAt": "ISO-8601 UTC timestamp",
+  "summary": {
+    "totalEntries": 35,             // en_patches (34) + sync_exclusions (1)
+    "activeEntries": 34,            // statusA === 'active'
+    "staleEntries": 0,              // statusA === 'stale' (Axis A signal)
+    "overdueEntries": 0,            // statusB === 'overdue' (Axis B signal)
+    "unknownEntries": 1             // statusA === 'unknown'
+  },
+  "mechanisms": {
+    "en_source_patches": [
+      {
+        "id": "UD-001A-dash-this-typo-plain",
+        "mechanism": "en_source_patches",
+        "slugs": ["salesforce-testing/.../sfdc-step-create", ...],
+        "statusA": "active",        // 'active' | 'stale' | 'unknown'
+        "statusB": "current",       // 'current' | 'overdue'
+        "hits": 1,
+        "addedAt": "2026-04-17",
+        "reviewAfter": "2026-10-17",
+        "daysUntilReview": 180
+      }
+    ],
+    "source_sync_exclusions": [
+      {
+        "slug": "testops/testops-version-control/pull-requests",
+        "mechanism": "source_sync_exclusions",
+        "statusA": "unknown",       // local dev にて source-sync-status.json 不在
+        "statusB": "current",
+        "fetchStatus": "unknown",   // 'excluded-broken' | 'excluded-recovered' | 'unknown'
+        "addedAt": "2026-04-09",
+        "reviewAfter": "2026-10-09",
+        "daysUntilReview": 172
+      }
+    ]
+  }
+}
+```
+
+## 判定ロジック
+
+### Axis A (upstream 修正検知)
+
+**en_source_patches:**
+- 各 slug について snapshot を読み `preprocessEnHtml(raw, { slug, patchCoverage })` を呼ぶ
+- `coverage.snapshot().byPatchIdStatus[id]` の `matched` が true → `active`
+- `matched === false` かつ snapshot が読めた slug が 1 つ以上 → `stale`
+- registered slug のどの snapshot も読めなかった → `unknown`
+
+**source_sync_exclusions:**
+- `source-sync-status.json.pages[].fetchStatus` を per-slug で lookup
+- `fetchStatus === 'excluded-recovered'` → `stale`
+- `fetchStatus === 'excluded-broken'` → `active`
+- それ以外 (`unknown` / file 不在) → `unknown`
+
+### Axis B (登録解除忘れ)
+
+両 mechanism 共通:
+- `reviewAfter` 文字列 (YYYY-MM-DD) を `new Date().getTime()` で比較
+- 現在時刻が `reviewAfter` を過ぎていれば `overdue`、そうでなければ `current`
+- `reviewAfter` が無い / 不正なら `current` (fail-safe)
+
+## Graceful degradation
+
+- `source-sync-status.json` 不在: sync_exclusions 全 entry が `statusA: 'unknown'` になる。
+  `check_upstream_recovery.mjs` は exit 0 で続行。consumer (sticky PR comment / detection_reports)
+  は unknown を stale と区別して扱う
+- snapshot file 不在: 当該 slug に登録された patch は、他 slug で hit しなければ `stale` ではなく `unknown`
+- `preprocessEnHtml` 例外: 該当 slug をスキップして警告を stderr に書き、run 全体は続行
+
+## Consumer integration (Phase B)
+
+詳細は `docs/superpowers/plans/2026-04-20-upstream-recovery-detection.md §Task 4` / Phase B。
+要約:
+
+- `scripts/lib/detection_reports.mjs` が `upstream-recovery-status.json` を読み、
+  `sourceSyncHealth` family 内に `enPatchRecovery` / `sourceSyncRecovery` section を追加
+- 既存 `scheduled-actionable.yml` が artifact upload list に `upstream-recovery-status.json` を追加
+- PR-triggered workflow が sticky PR comment を hidden marker `<!-- upstream-recovery: sticky -->`
+  で idempotent に upsert
+
+Phase A の時点では JSON output が生成されるのみで、consumer 側の statement / UI は
+Phase B で入る。
+
+## テスト
+
+- `scripts/__tests__/en_source_patches.test.mjs` — `byPatchIdStatus` が全 34 patch IDs を
+  enumerate (hit 無しでも `{matched: false, hits: 0}`)
+- `scripts/__tests__/en_source_patches_integration.test.mjs` — 全 34 patches の
+  stale detection (non-gating warning mode)
+- `scripts/__tests__/source_parity_source_side_debt.test.mjs` — `reviewAfter` shape pin
+- `scripts/__tests__/check_upstream_recovery.test.mjs` — aggregator unit tests
+  (status transitions / missing artifacts / Axis A × Axis B matrix)

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "docs:report-categories": "node scripts/report_frontmatter_categories.mjs",
     "check:parity": "node scripts/check_source_parity.mjs",
     "check:patch-review": "node scripts/check_patch_review_cadence.mjs",
+    "check:upstream-recovery": "node scripts/check_upstream_recovery.mjs",
     "check:summary": "node scripts/generate_detection_reports.mjs",
     "generate:parity-baseline": "node scripts/generate_parity_baseline.mjs",
     "check:snapshots:fetch": "node scripts/snapshot_update.mjs",

--- a/scripts/__tests__/check_patch_review_cadence.test.mjs
+++ b/scripts/__tests__/check_patch_review_cadence.test.mjs
@@ -16,6 +16,7 @@ import assert from 'node:assert/strict';
 
 let evaluatePatchReview;
 let collectOverduePatches;
+let collectOverdueSyncExclusions;
 let formatWarning;
 let main;
 
@@ -23,6 +24,7 @@ before(async () => {
   ({
     evaluatePatchReview,
     collectOverduePatches,
+    collectOverdueSyncExclusions,
     formatWarning,
     main,
   } = await import('../check_patch_review_cadence.mjs'));
@@ -111,12 +113,55 @@ describe('collectOverduePatches', () => {
 // ---------------------------------------------------------------------------
 
 describe('formatWarning', () => {
-  it('includes patch id, reviewAfter, and daysOverdue', () => {
+  it('includes patch id, reviewAfter, and daysOverdue (en_source_patches shape)', () => {
     const line = formatWarning({ id: 'UD-XXX', reviewAfter: '2020-01-01', daysOverdue: 42 });
     assert.ok(line.includes('UD-XXX'), `missing patch id: ${line}`);
     assert.ok(line.includes('2020-01-01'), `missing reviewAfter: ${line}`);
     assert.ok(line.includes('daysOverdue=42'), `missing daysOverdue: ${line}`);
     assert.ok(line.startsWith('[en_source_patches]'), `missing prefix: ${line}`);
+  });
+
+  it('includes slug, reviewAfter, and daysOverdue (source_sync_exclusions shape)', () => {
+    const line = formatWarning({
+      slug: 'some/slug',
+      reviewAfter: '2020-01-01',
+      daysOverdue: 42,
+    });
+    assert.ok(line.includes('slug=some/slug'), `missing slug: ${line}`);
+    assert.ok(line.startsWith('[source_sync_exclusions]'), `missing prefix: ${line}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectOverdueSyncExclusions (Phase A / Task 6)
+// ---------------------------------------------------------------------------
+
+describe('collectOverdueSyncExclusions', () => {
+  const FIXTURE_EXCLUSIONS = Object.freeze({
+    'a/future': Object.freeze({ reviewAfter: '2099-01-01' }),
+    'b/past': Object.freeze({ reviewAfter: '2020-01-01' }),
+    'c/past': Object.freeze({ reviewAfter: '2025-06-01' }),
+    'd/invalid': Object.freeze({ reviewAfter: 'whatever' }),
+  });
+
+  it('returns only the overdue entries keyed by slug', () => {
+    const nowMs = new Date('2026-04-17T00:00:00Z').getTime();
+    const overdue = collectOverdueSyncExclusions(FIXTURE_EXCLUSIONS, nowMs);
+    const slugs = overdue.map((e) => e.slug).sort();
+    assert.deepEqual(slugs, ['b/past', 'c/past']);
+  });
+
+  it('the live SOURCE_SYNC_EXCLUSIONS is currently not overdue', async () => {
+    const { SOURCE_SYNC_EXCLUSIONS } = await import(
+      '../lib/source_sync_exclusions.mjs'
+    );
+    const nowMs = new Date('2026-04-17T00:00:00Z').getTime();
+    const overdue = collectOverdueSyncExclusions(SOURCE_SYNC_EXCLUSIONS, nowMs);
+    assert.equal(
+      overdue.length,
+      0,
+      `unexpected overdue exclusions today: ${overdue.map((e) => e.slug).join(', ')}`,
+    );
   });
 });
 
@@ -125,12 +170,14 @@ describe('formatWarning', () => {
 // ---------------------------------------------------------------------------
 
 describe('main()', () => {
-  it('exits 0 with "no overdue" stdout when registry is clean', () => {
+  it('exits 0 with "no overdue" stdout when both registries are clean', () => {
     const stdoutLines = [];
     const stderrLines = [];
-    const registry = [Object.freeze({ id: 'ok', reviewAfter: '2099-01-01' })];
+    const patchRegistry = [Object.freeze({ id: 'ok', reviewAfter: '2099-01-01' })];
+    const exclusionsRegistry = { 'ok/slug': { reviewAfter: '2099-01-01' } };
     const result = main({
-      registry,
+      patchRegistry,
+      exclusionsRegistry,
       nowMs: new Date('2026-04-17T00:00:00Z').getTime(),
       stdout: (msg) => stdoutLines.push(msg),
       stderr: (msg) => stderrLines.push(msg),
@@ -142,22 +189,34 @@ describe('main()', () => {
     assert.ok(stdoutLines[0].includes('0 overdue'));
   });
 
-  it('still exits 0 when overdue entries exist (warning only, never a gate)', () => {
+  it('still exits 0 when overdue entries exist in either registry', () => {
     const stdoutLines = [];
     const stderrLines = [];
-    const registry = [
-      Object.freeze({ id: 'overdue-1', reviewAfter: '2020-01-01' }),
+    const patchRegistry = [
+      Object.freeze({ id: 'overdue-patch', reviewAfter: '2020-01-01' }),
       Object.freeze({ id: 'ok-1', reviewAfter: '2099-01-01' }),
     ];
+    const exclusionsRegistry = {
+      'overdue/exclusion': { reviewAfter: '2020-01-01' },
+      'ok/exclusion': { reviewAfter: '2099-01-01' },
+    };
     const result = main({
-      registry,
+      patchRegistry,
+      exclusionsRegistry,
       nowMs: new Date('2026-04-17T00:00:00Z').getTime(),
       stdout: (msg) => stdoutLines.push(msg),
       stderr: (msg) => stderrLines.push(msg),
     });
     assert.equal(result.exitCode, 0);
-    assert.equal(result.overdueCount, 1);
-    assert.equal(stderrLines.length, 1);
-    assert.ok(stderrLines[0].includes('overdue-1'));
+    assert.equal(result.overdueCount, 2);
+    assert.equal(stderrLines.length, 2);
+    assert.ok(
+      stderrLines.some((l) => l.includes('overdue-patch')),
+      'missing en_source_patches warning',
+    );
+    assert.ok(
+      stderrLines.some((l) => l.includes('overdue/exclusion')),
+      'missing source_sync_exclusions warning',
+    );
   });
 });

--- a/scripts/__tests__/check_patch_review_cadence.test.mjs
+++ b/scripts/__tests__/check_patch_review_cadence.test.mjs
@@ -130,6 +130,24 @@ describe('formatWarning', () => {
     assert.ok(line.includes('slug=some/slug'), `missing slug: ${line}`);
     assert.ok(line.startsWith('[source_sync_exclusions]'), `missing prefix: ${line}`);
   });
+
+  it('prefers id over slug when both are set (disjoint shapes by contract)', () => {
+    const line = formatWarning({
+      id: 'UD-Y',
+      slug: 'should-not-appear',
+      reviewAfter: '2020-01-01',
+      daysOverdue: 1,
+    });
+    assert.ok(line.startsWith('[en_source_patches]'), `id must win: ${line}`);
+    assert.ok(line.includes('patch=UD-Y'));
+    assert.ok(!line.includes('should-not-appear'));
+  });
+
+  it('emits an explicit unknown-entry label when neither id nor slug is set', () => {
+    const line = formatWarning({ reviewAfter: '2020-01-01', daysOverdue: 7 });
+    assert.ok(line.startsWith('[registry-review-cadence]'), `missing prefix: ${line}`);
+    assert.ok(line.includes('entry=<unknown>'), `missing unknown marker: ${line}`);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/__tests__/check_upstream_recovery.test.mjs
+++ b/scripts/__tests__/check_upstream_recovery.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,6 +10,7 @@ import {
   computeEnPatchStatus,
   computeSyncExclusionStatus,
   buildUpstreamRecoveryStatus,
+  runCheckUpstreamRecovery,
 } from '../check_upstream_recovery.mjs';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -42,7 +43,6 @@ describe('daysSince / daysUntil', () => {
 });
 
 describe('computeEnPatchStatus — Axis A × Axis B matrix', () => {
-  const tmp = mkdtempSync(join(tmpdir(), 'upstream-recovery-en-'));
   const patch = Object.freeze({
     id: 'TEST-PATCH',
     slugs: Object.freeze(['fake/slug-a', 'fake/slug-b']),
@@ -172,6 +172,65 @@ describe('computeSyncExclusionStatus — fetchStatus mapping', () => {
       sourceSyncStatus: { pages: [{ slug: 'test/slug', fetchStatus: 'excluded-broken' }] },
     });
     assert.equal(result[0].statusB, 'overdue');
+  });
+});
+
+describe('runCheckUpstreamRecovery — I/O contract (write + log)', () => {
+  it('writes the aggregated payload to outputPath as pretty JSON with trailing newline', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'upstream-recovery-io-'));
+    const outputPath = join(tmp, 'upstream-recovery-status.json');
+    const stdoutLines = [];
+    const snapshotsRoot = mkdtempSync(join(tmpdir(), 'upstream-recovery-io-root-'));
+
+    const payload = runCheckUpstreamRecovery({
+      outputPath,
+      stdout: (msg) => stdoutLines.push(msg),
+      nowMs: NOW,
+      snapshotsRoot,
+      patches: [
+        Object.freeze({
+          id: 'TEST',
+          slugs: Object.freeze(['absent/slug']),
+          defectClass: 'typo',
+          find: '<p>x</p>',
+          replace: '<p>y</p>',
+          rationale: '',
+          linkedDefect: '',
+          addedAt: '2026-01-01',
+          reviewAfter: '2026-07-01',
+        }),
+      ],
+      exclusions: {
+        'test/slug': {
+          reason: 'broken-upstream-source',
+          note: '',
+          expectedIssueType: 'snapshot-incomplete',
+          expectedReason: 'extractor-empty',
+          addedAt: '2026-01-01',
+          reviewAfter: '2026-07-01',
+          linkedIssue: 1,
+        },
+      },
+      sourceSyncStatus: null,
+    });
+
+    assert.ok(existsSync(outputPath), 'outputPath must be written');
+    const raw = readFileSync(outputPath, 'utf8');
+    assert.ok(raw.endsWith('\n'), 'file must end with a single newline');
+    const written = JSON.parse(raw);
+    assert.deepEqual(written, payload, 'written JSON must round-trip with returned payload');
+    assert.equal(written.schemaVersion, 1);
+    assert.equal(written.summary.totalEntries, 2);
+
+    // stdout log line must include the summary counters so CI log scrapers
+    // can assert "active=N stale=N overdue=N unknown=N" without parsing JSON.
+    assert.equal(stdoutLines.length, 1);
+    const line = stdoutLines[0];
+    assert.ok(line.includes('total='), `expected total= token: ${line}`);
+    assert.ok(line.includes('active='), `expected active= token: ${line}`);
+    assert.ok(line.includes('stale='), `expected stale= token: ${line}`);
+    assert.ok(line.includes('overdue='), `expected overdue= token: ${line}`);
+    assert.ok(line.includes('unknown='), `expected unknown= token: ${line}`);
   });
 });
 

--- a/scripts/__tests__/check_upstream_recovery.test.mjs
+++ b/scripts/__tests__/check_upstream_recovery.test.mjs
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import {
   daysSince,
   daysUntil,
+  isReviewOverdue,
   computeEnPatchStatus,
   computeSyncExclusionStatus,
   buildUpstreamRecoveryStatus,
@@ -39,6 +40,37 @@ describe('daysSince / daysUntil', () => {
   it('daysUntil returns null for missing / invalid dates', () => {
     assert.equal(daysUntil(null, NOW), null);
     assert.equal(daysUntil('not-a-date', NOW), null);
+  });
+});
+
+describe('isReviewOverdue — same-day boundary aligned with cadence check (Codex C1)', () => {
+  it('returns false on the reviewAfter day at UTC midnight (inclusive boundary)', () => {
+    const nowMs = new Date('2026-04-17T00:00:00Z').getTime();
+    assert.equal(isReviewOverdue('2026-04-17', nowMs), false);
+  });
+
+  it('returns true later on the reviewAfter day (e.g. 12:00 UTC)', () => {
+    // Previously daysSince(...) > 0 would have returned false here (floor of
+    // 12h/24h = 0). isReviewOverdue matches check_patch_review_cadence.mjs::
+    // evaluatePatchReview which flags overdue as soon as nowMs > parsedMs.
+    const nowMs = new Date('2026-04-17T12:00:00Z').getTime();
+    assert.equal(isReviewOverdue('2026-04-17', nowMs), true);
+  });
+
+  it('returns true the day after reviewAfter', () => {
+    const nowMs = new Date('2026-04-18T00:00:00Z').getTime();
+    assert.equal(isReviewOverdue('2026-04-17', nowMs), true);
+  });
+
+  it('returns false when reviewAfter is in the future', () => {
+    assert.equal(isReviewOverdue('2026-06-01', NOW), false);
+  });
+
+  it('returns false for missing or invalid dates (fail-safe)', () => {
+    assert.equal(isReviewOverdue(null, NOW), false);
+    assert.equal(isReviewOverdue(undefined, NOW), false);
+    assert.equal(isReviewOverdue('', NOW), false);
+    assert.equal(isReviewOverdue('not-a-date', NOW), false);
   });
 });
 

--- a/scripts/__tests__/check_upstream_recovery.test.mjs
+++ b/scripts/__tests__/check_upstream_recovery.test.mjs
@@ -1,0 +1,220 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  daysSince,
+  daysUntil,
+  computeEnPatchStatus,
+  computeSyncExclusionStatus,
+  buildUpstreamRecoveryStatus,
+} from '../check_upstream_recovery.mjs';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-05-01T00:00:00Z').getTime();
+
+describe('daysSince / daysUntil', () => {
+  it('daysSince returns positive when the date is in the past', () => {
+    assert.equal(daysSince('2026-04-01', NOW), 30);
+  });
+
+  it('daysSince returns 0 or negative when the date is in the future', () => {
+    assert.equal(daysSince('2026-06-01', NOW), -31);
+  });
+
+  it('daysSince returns 0 for missing / invalid dates (fail-safe)', () => {
+    assert.equal(daysSince(null, NOW), 0);
+    assert.equal(daysSince('', NOW), 0);
+    assert.equal(daysSince('not-a-date', NOW), 0);
+  });
+
+  it('daysUntil mirrors daysSince sign', () => {
+    assert.equal(daysUntil('2026-06-01', NOW), 31);
+    assert.equal(daysUntil('2026-04-01', NOW), -30);
+  });
+
+  it('daysUntil returns null for missing / invalid dates', () => {
+    assert.equal(daysUntil(null, NOW), null);
+    assert.equal(daysUntil('not-a-date', NOW), null);
+  });
+});
+
+describe('computeEnPatchStatus — Axis A × Axis B matrix', () => {
+  const tmp = mkdtempSync(join(tmpdir(), 'upstream-recovery-en-'));
+  const patch = Object.freeze({
+    id: 'TEST-PATCH',
+    slugs: Object.freeze(['fake/slug-a', 'fake/slug-b']),
+    defectClass: 'typo',
+    find: '<p>broken</p>',
+    replace: '<p>fixed</p>',
+    rationale: 'test',
+    linkedDefect: 'test',
+    addedAt: '2026-01-01',
+    reviewAfter: '2026-07-01',
+  });
+
+  // Note: `preprocessEnHtml` internally consults the live `EN_SOURCE_PATCHES`
+  // registry to decide which patches apply to a slug, so synthetic fixture
+  // patches passed through `patches:` here are only used for the enumeration
+  // output shape (not for actual hit detection). That means `statusA=active`
+  // requires a real registered slug + real snapshot; we cover that in
+  // `en_source_patches_integration.test.mjs` instead. Unit tests below cover
+  // the `stale` and `unknown` branches where the synthetic fixture slug does
+  // not match any registered patch.
+
+  it('statusA=stale when a snapshot is readable but no registered patch hits it', () => {
+    const root = mkdtempSync(join(tmpdir(), 'upstream-recovery-en-root-'));
+    writeFileSync(join(root, 'fake-slug.html'), '<html><p>already fixed upstream</p></html>');
+    const result = computeEnPatchStatus({
+      nowMs: NOW,
+      snapshotsRoot: root,
+      patches: [
+        Object.freeze({ ...patch, slugs: Object.freeze(['fake-slug']) }),
+      ],
+    });
+    // The synthetic slug is readable but the live registry has no patches for
+    // it, so byPatchIdStatus keeps matched=false → statusA=stale.
+    assert.equal(result[0].statusA, 'stale');
+    assert.equal(result[0].hits, 0);
+  });
+
+  it('statusA=unknown when no snapshot is readable for any registered slug', () => {
+    const root = mkdtempSync(join(tmpdir(), 'upstream-recovery-en-root-'));
+    // Empty snapshotsRoot — patch slugs point at nonexistent paths.
+    const result = computeEnPatchStatus({
+      nowMs: NOW,
+      snapshotsRoot: root,
+      patches: [
+        Object.freeze({ ...patch, slugs: Object.freeze(['nonexistent/slug']) }),
+      ],
+    });
+    assert.equal(result[0].statusA, 'unknown');
+  });
+
+  it('statusB=overdue when reviewAfter is in the past', () => {
+    const root = mkdtempSync(join(tmpdir(), 'upstream-recovery-en-root-'));
+    writeFileSync(join(root, 'fake-slug.html'), '<html><p>anything</p></html>');
+    const overduePatch = Object.freeze({
+      ...patch,
+      slugs: Object.freeze(['fake-slug']),
+      reviewAfter: '2026-01-01', // past
+    });
+    const result = computeEnPatchStatus({
+      nowMs: NOW,
+      snapshotsRoot: root,
+      patches: [overduePatch],
+    });
+    assert.equal(result[0].statusB, 'overdue');
+    assert.ok(result[0].daysUntilReview < 0);
+  });
+});
+
+describe('computeSyncExclusionStatus — fetchStatus mapping', () => {
+  const exclusion = Object.freeze({
+    'test/slug': Object.freeze({
+      reason: 'broken-upstream-source',
+      note: '',
+      expectedIssueType: 'snapshot-incomplete',
+      expectedReason: 'extractor-empty',
+      addedAt: '2026-01-01',
+      reviewAfter: '2026-07-01',
+      linkedIssue: 999,
+    }),
+  });
+
+  it('fetchStatus=excluded-broken → statusA=active', () => {
+    const result = computeSyncExclusionStatus({
+      nowMs: NOW,
+      exclusions: exclusion,
+      sourceSyncStatus: { pages: [{ slug: 'test/slug', fetchStatus: 'excluded-broken' }] },
+    });
+    assert.equal(result[0].statusA, 'active');
+    assert.equal(result[0].fetchStatus, 'excluded-broken');
+  });
+
+  it('fetchStatus=excluded-recovered → statusA=stale', () => {
+    const result = computeSyncExclusionStatus({
+      nowMs: NOW,
+      exclusions: exclusion,
+      sourceSyncStatus: { pages: [{ slug: 'test/slug', fetchStatus: 'excluded-recovered' }] },
+    });
+    assert.equal(result[0].statusA, 'stale');
+  });
+
+  it('missing source-sync-status → statusA=unknown (graceful degradation)', () => {
+    const result = computeSyncExclusionStatus({
+      nowMs: NOW,
+      exclusions: exclusion,
+      sourceSyncStatus: null,
+    });
+    assert.equal(result[0].statusA, 'unknown');
+    assert.equal(result[0].fetchStatus, 'unknown');
+  });
+
+  it('missing entry in source-sync-status.pages → statusA=unknown', () => {
+    const result = computeSyncExclusionStatus({
+      nowMs: NOW,
+      exclusions: exclusion,
+      sourceSyncStatus: { pages: [{ slug: 'other/slug', fetchStatus: 'excluded-broken' }] },
+    });
+    assert.equal(result[0].statusA, 'unknown');
+  });
+
+  it('statusB=overdue when reviewAfter is in the past', () => {
+    const overdueExclusion = {
+      'test/slug': { ...exclusion['test/slug'], reviewAfter: '2026-01-01' },
+    };
+    const result = computeSyncExclusionStatus({
+      nowMs: NOW,
+      exclusions: overdueExclusion,
+      sourceSyncStatus: { pages: [{ slug: 'test/slug', fetchStatus: 'excluded-broken' }] },
+    });
+    assert.equal(result[0].statusB, 'overdue');
+  });
+});
+
+describe('buildUpstreamRecoveryStatus — aggregate shape', () => {
+  it('produces schemaVersion=1 payload with summary counters and mechanism breakdowns', () => {
+    const root = mkdtempSync(join(tmpdir(), 'upstream-recovery-full-'));
+    const payload = buildUpstreamRecoveryStatus({
+      nowMs: NOW,
+      snapshotsRoot: root,
+      patches: [
+        Object.freeze({
+          id: 'TEST',
+          slugs: Object.freeze(['absent/slug']),
+          defectClass: 'typo',
+          find: '<p>broken</p>',
+          replace: '<p>fixed</p>',
+          rationale: '',
+          linkedDefect: '',
+          addedAt: '2026-01-01',
+          reviewAfter: '2026-07-01',
+        }),
+      ],
+      exclusions: {
+        'test/slug': {
+          reason: 'broken-upstream-source',
+          note: '',
+          expectedIssueType: 'snapshot-incomplete',
+          expectedReason: 'extractor-empty',
+          addedAt: '2026-01-01',
+          reviewAfter: '2026-07-01',
+          linkedIssue: 1,
+        },
+      },
+      sourceSyncStatus: null,
+    });
+    assert.equal(payload.schemaVersion, 1);
+    assert.equal(payload.summary.totalEntries, 2);
+    // 1 unknown en_patch + 1 unknown exclusion
+    assert.equal(payload.summary.unknownEntries, 2);
+    assert.equal(payload.summary.staleEntries, 0);
+    assert.equal(payload.summary.overdueEntries, 0);
+    assert.ok(Array.isArray(payload.mechanisms.en_source_patches));
+    assert.ok(Array.isArray(payload.mechanisms.source_sync_exclusions));
+    assert.match(payload.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/scripts/__tests__/en_source_patches.test.mjs
+++ b/scripts/__tests__/en_source_patches.test.mjs
@@ -976,3 +976,57 @@ describe('applyEnSourcePatches (console.warn on find-not-found)', () => {
     assert.equal(warnings.length, 0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase A — byPatchIdStatus enumeration shape (plan Task 1 Step 2)
+// ---------------------------------------------------------------------------
+//
+// `byPatchIdStatus` is the seed-with-all-IDs complement to `byPatchId`.
+// Downstream consumers (`check_upstream_recovery.mjs`) rely on every
+// registered patch ID being enumerable with `{ matched, hits }` shape,
+// including zero-hit patches. Missing a patch ID from the seed would
+// flip Phase A stale detection into a silent undefined check.
+
+describe('createEnSourcePatchCoverage — byPatchIdStatus enumeration', () => {
+  it('snapshot() seeds byPatchIdStatus with every registry entry (zero-hit default)', () => {
+    const cov = createEnSourcePatchCoverage();
+    const snap = cov.snapshot();
+    for (const patch of EN_SOURCE_PATCHES) {
+      const row = snap.byPatchIdStatus[patch.id];
+      assert.ok(row, `byPatchIdStatus missing entry for ${patch.id}`);
+      assert.equal(row.matched, false);
+      assert.equal(row.hits, 0);
+    }
+    assert.equal(
+      Object.keys(snap.byPatchIdStatus).length,
+      EN_SOURCE_PATCHES.length,
+      'byPatchIdStatus must equal registry size with zero hits recorded',
+    );
+  });
+
+  it('recordHit() flips matched to true and accumulates hits', () => {
+    const cov = createEnSourcePatchCoverage();
+    cov.recordHit({ slug: 'x', patchId: 'UD-001A-dash-this-typo-plain', hits: 2 });
+    cov.recordHit({ slug: 'x', patchId: 'UD-001A-dash-this-typo-plain', hits: 3 });
+    const snap = cov.snapshot();
+    assert.deepEqual(
+      snap.byPatchIdStatus['UD-001A-dash-this-typo-plain'],
+      { matched: true, hits: 5 },
+    );
+  });
+
+  it('NOOP_PATCH_COVERAGE.snapshot() also seeds the full enumeration', async () => {
+    const { NOOP_PATCH_COVERAGE } = await import('../lib/en_source_patches.mjs');
+    const snap = NOOP_PATCH_COVERAGE.snapshot();
+    assert.equal(
+      Object.keys(snap.byPatchIdStatus).length,
+      EN_SOURCE_PATCHES.length,
+    );
+    for (const patch of EN_SOURCE_PATCHES) {
+      const row = snap.byPatchIdStatus[patch.id];
+      assert.ok(row);
+      assert.equal(row.matched, false);
+      assert.equal(row.hits, 0);
+    }
+  });
+});

--- a/scripts/__tests__/en_source_patches_integration.test.mjs
+++ b/scripts/__tests__/en_source_patches_integration.test.mjs
@@ -303,3 +303,125 @@ describe('gates #12-14: no-new-mechanism invariant', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase A / Task 2 — stale detection across all 34 patches (slug-driven)
+// ---------------------------------------------------------------------------
+//
+// Preconditions: the Bundle-1 integration block above has already imported
+// `preprocessEnHtml`, `createEnSourcePatchCoverage`, and `EN_SOURCE_PATCHES`.
+// This block reuses them to run a full registry-wide stale scan.
+//
+// Non-gating: warnings only. Gate enforcement happens through
+// `upstream-recovery-status.json` + sticky PR comment (Phase B).
+
+describe('en_source_patches stale detection (全 34 patch IDs / slug-driven / non-gating)', () => {
+  it('enumerates every registered patch ID through byPatchIdStatus even with zero hits', () => {
+    const coverage = createEnSourcePatchCoverage();
+    const snap = coverage.snapshot();
+    for (const patch of EN_SOURCE_PATCHES) {
+      const status = snap.byPatchIdStatus[patch.id];
+      assert.ok(
+        status,
+        `byPatchIdStatus must seed every registry entry (missing ${patch.id})`,
+      );
+      assert.equal(status.matched, false);
+      assert.equal(status.hits, 0);
+    }
+    assert.equal(
+      Object.keys(snap.byPatchIdStatus).length,
+      EN_SOURCE_PATCHES.length,
+      'byPatchIdStatus enumerates exactly the registry size when no hits recorded',
+    );
+  });
+
+  it('reports patches whose find string is missing from every registered snapshot', () => {
+    const coverage = createEnSourcePatchCoverage();
+    const uniqueSlugs = new Set(EN_SOURCE_PATCHES.flatMap((p) => [...p.slugs]));
+    const sawSnapshot = new Set();
+    for (const slug of uniqueSlugs) {
+      const snapshotPath = join(SNAPSHOTS_ROOT, `${slug}.html`);
+      if (!existsSync(snapshotPath)) continue;
+      sawSnapshot.add(slug);
+      const raw = readFileSync(snapshotPath, 'utf8');
+      preprocessEnHtml(raw, { slug, patchCoverage: coverage });
+    }
+
+    const snap = coverage.snapshot();
+    const stale = EN_SOURCE_PATCHES
+      .filter((p) => !snap.byPatchIdStatus[p.id]?.matched)
+      // Only flag as stale when at least one of the patch's slugs had a
+      // readable snapshot — otherwise we cannot distinguish stale from
+      // 'snapshot-not-fetched-in-this-env'.
+      .filter((p) => p.slugs.some((s) => sawSnapshot.has(s)))
+      .map((p) => ({ id: p.id, slugs: [...p.slugs], reviewAfter: p.reviewAfter }));
+
+    // Non-gating: warn only. Enforcement is via upstream-recovery-status.json +
+    // sticky PR comment (Phase B). Test always passes — do NOT assert length.
+    if (stale.length > 0) {
+      console.warn(
+        `[stale en_source_patches] ${stale.length} of ${EN_SOURCE_PATCHES.length} patches — ` +
+          `EN may be fixed upstream:\n${JSON.stringify(stale, null, 2)}\n` +
+          'Action: verify JA source-first correctness, remove entry, update upstream-defect-tracker.md',
+      );
+    }
+    // Sanity: the surface of the check grew beyond the original Bundle 1
+    // set. Pin the minimum slug coverage so the loop cannot silently
+    // regress to the old 8-slug scope.
+    assert.ok(
+      uniqueSlugs.size >= 30,
+      `expected slug-driven scan to cover >=30 unique slugs (got ${uniqueSlugs.size})`,
+    );
+  });
+
+  it('every registry entry carries a valid reviewAfter (YYYY-MM-DD)', () => {
+    const RE = /^\d{4}-\d{2}-\d{2}$/;
+    for (const patch of EN_SOURCE_PATCHES) {
+      assert.ok(
+        typeof patch.reviewAfter === 'string' && RE.test(patch.reviewAfter),
+        `patch ${patch.id} must have reviewAfter in YYYY-MM-DD format`,
+      );
+    }
+  });
+});
+
+describe('source_sync_exclusions recovery status (Task 2 Phase A / non-gating)', () => {
+  it('surfaces stale entries via source-sync-status.json when artifact is present (CI-only)', async () => {
+    const sourceSyncStatusPath = join(REPO_ROOT, 'source-sync-status.json');
+    if (!existsSync(sourceSyncStatusPath)) {
+      // Local dev / PR-triggered CI runs without source-sync-status.json
+      // cannot evaluate sync_exclusions recovery — the probe is weekly
+      // only. Skip silently rather than fail-close on a local env.
+      return;
+    }
+    const { SOURCE_SYNC_EXCLUSIONS } = await import(
+      '../lib/source_sync_exclusions.mjs'
+    );
+    const status = JSON.parse(readFileSync(sourceSyncStatusPath, 'utf8'));
+    const stale = (status.pages ?? []).filter(
+      (p) => p.fetchStatus === 'excluded-recovered' && SOURCE_SYNC_EXCLUSIONS[p.slug],
+    );
+    if (stale.length > 0) {
+      console.warn(
+        `[stale source_sync_exclusions] ${stale.length} entr(ies) — upstream may be fixed:\n` +
+          `${stale.map((s) => `  - ${s.slug}`).join('\n')}\n` +
+          'Action: verify EN snapshot manually, then remove registry entry + upstream-defect-tracker archive.',
+      );
+    }
+    // Non-gating: weekly workflow (scheduled-actionable.yml) is primary
+    // surfacing channel via sourceSyncHealth managed issue.
+  });
+
+  it('every SOURCE_SYNC_EXCLUSIONS entry carries a valid reviewAfter (YYYY-MM-DD) — Task 6 pin', async () => {
+    const { SOURCE_SYNC_EXCLUSIONS } = await import(
+      '../lib/source_sync_exclusions.mjs'
+    );
+    const RE = /^\d{4}-\d{2}-\d{2}$/;
+    for (const [slug, entry] of Object.entries(SOURCE_SYNC_EXCLUSIONS)) {
+      assert.ok(
+        typeof entry.reviewAfter === 'string' && RE.test(entry.reviewAfter),
+        `exclusion ${slug} must have reviewAfter in YYYY-MM-DD format`,
+      );
+    }
+  });
+});

--- a/scripts/__tests__/source_parity_source_side_debt.test.mjs
+++ b/scripts/__tests__/source_parity_source_side_debt.test.mjs
@@ -121,6 +121,15 @@ describe('source-side debt registry / repository integrity', () => {
           /^\d{4}-\d{2}-\d{2}$/,
           `${slug}: addedAt must be ISO date (YYYY-MM-DD)`,
         );
+        // Phase A / Task 6: every SOURCE_SYNC_EXCLUSIONS entry must carry a
+        // reviewAfter (6-month cadence parity with en_source_patches) so that
+        // `check_patch_review_cadence.mjs` can surface overdue entries
+        // uniformly across both retreat mechanisms.
+        assert.match(
+          entry.reviewAfter,
+          /^\d{4}-\d{2}-\d{2}$/,
+          `${slug}: reviewAfter must be ISO date (YYYY-MM-DD)`,
+        );
         assert.equal(
           typeof entry.linkedIssue,
           'number',

--- a/scripts/check_patch_review_cadence.mjs
+++ b/scripts/check_patch_review_cadence.mjs
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 // scripts/check_patch_review_cadence.mjs
 /**
- * Patch review cadence monitor (non-blocking).
+ * Registry review cadence monitor (non-blocking).
  *
- * Walks `EN_SOURCE_PATCHES` and lists every patch whose `reviewAfter`
- * date is in the past relative to `now`. Warnings are printed to stderr
- * (human consumable) and the process exits 0 — this is monitoring, not
- * a gate. CI may surface the warnings but must not fail on them.
+ * Walks the two broken-EN retreat registries:
+ *   - `EN_SOURCE_PATCHES` (segment-level)
+ *   - `SOURCE_SYNC_EXCLUSIONS` (page-level, Phase A)
+ *
+ * Lists every entry whose `reviewAfter` date is in the past relative to `now`.
+ * Warnings are printed to stderr (human consumable) and the process exits 0 —
+ * this is monitoring, not a gate. CI may surface the warnings but must not
+ * fail on them.
  *
  * Usage:
  *   node scripts/check_patch_review_cadence.mjs
@@ -17,9 +21,11 @@
  * emission at run start) and from unit tests.
  *
  * Plan: docs/superpowers/plans/2026-04-17-en-source-patches-layer.md §B2
+ *       docs/superpowers/plans/2026-04-20-upstream-recovery-detection.md §Task 6
  */
 
 import { EN_SOURCE_PATCHES } from './lib/en_source_patches.mjs';
+import { SOURCE_SYNC_EXCLUSIONS } from './lib/source_sync_exclusions.mjs';
 
 /**
  * Determine whether a patch's `reviewAfter` date has passed.
@@ -66,13 +72,46 @@ export function collectOverduePatches(registry = EN_SOURCE_PATCHES, nowMs = Date
 }
 
 /**
- * Render a single overdue-patch warning line.
+ * Same as `collectOverduePatches` but specialised for the page-level
+ * `SOURCE_SYNC_EXCLUSIONS` registry (indexed by slug instead of id).
  *
- * @param {{ id: string, reviewAfter: string, daysOverdue: number }} entry
+ * @param {Record<string, object>} registry
+ * @param {number} nowMs
+ * @returns {Array<{ slug: string, reviewAfter: string, daysOverdue: number }>}
+ */
+export function collectOverdueSyncExclusions(
+  registry = SOURCE_SYNC_EXCLUSIONS,
+  nowMs = Date.now(),
+) {
+  const overdue = [];
+  for (const [slug, entry] of Object.entries(registry)) {
+    const result = evaluatePatchReview(entry, nowMs);
+    if (result.overdue) {
+      overdue.push({
+        slug,
+        reviewAfter: entry.reviewAfter,
+        daysOverdue: result.daysOverdue,
+      });
+    }
+  }
+  return overdue;
+}
+
+/**
+ * Render a single overdue-entry warning line.
+ *
+ * Accepts either an `en_source_patches` row (keyed by `id`) or a
+ * `source_sync_exclusions` row (keyed by `slug`). The shape is detected
+ * from which field is present.
+ *
+ * @param {{ id?: string, slug?: string, reviewAfter: string, daysOverdue: number }} entry
  * @returns {string}
  */
 export function formatWarning(entry) {
-  return `[en_source_patches] reviewAfter overdue: patch=${entry.id} reviewAfter=${entry.reviewAfter} daysOverdue=${entry.daysOverdue}`;
+  if (entry.id) {
+    return `[en_source_patches] reviewAfter overdue: patch=${entry.id} reviewAfter=${entry.reviewAfter} daysOverdue=${entry.daysOverdue}`;
+  }
+  return `[source_sync_exclusions] reviewAfter overdue: slug=${entry.slug} reviewAfter=${entry.reviewAfter} daysOverdue=${entry.daysOverdue}`;
 }
 
 /**
@@ -80,17 +119,38 @@ export function formatWarning(entry) {
  *
  * @returns {{ overdueCount: number, exitCode: 0 }}
  */
-export function main({ registry = EN_SOURCE_PATCHES, nowMs = Date.now(), stderr = console.warn, stdout = console.log } = {}) {
-  const overdue = collectOverduePatches(registry, nowMs);
-  if (overdue.length === 0) {
-    stdout(`[en_source_patches] patch review cadence OK — ${registry.length} entries, 0 overdue`);
+export function main({
+  patchRegistry = EN_SOURCE_PATCHES,
+  exclusionsRegistry = SOURCE_SYNC_EXCLUSIONS,
+  nowMs = Date.now(),
+  stderr = console.warn,
+  stdout = console.log,
+} = {}) {
+  const overduePatches = collectOverduePatches(patchRegistry, nowMs);
+  const overdueExclusions = collectOverdueSyncExclusions(exclusionsRegistry, nowMs);
+  const patchTotal = patchRegistry.length;
+  const exclusionTotal = Object.keys(exclusionsRegistry).length;
+  const overdueCount = overduePatches.length + overdueExclusions.length;
+
+  if (overdueCount === 0) {
+    stdout(
+      `[registry-review-cadence] OK — ${patchTotal} en_source_patches + ` +
+        `${exclusionTotal} source_sync_exclusions, 0 overdue`,
+    );
     return { overdueCount: 0, exitCode: 0 };
   }
-  stdout(`[en_source_patches] ${overdue.length} overdue patch(es) of ${registry.length} total (warning only, non-blocking):`);
-  for (const entry of overdue) {
+  stdout(
+    `[registry-review-cadence] ${overdueCount} overdue entr(ies) ` +
+      `(${overduePatches.length} patches / ${overdueExclusions.length} exclusions, ` +
+      `warning only, non-blocking):`,
+  );
+  for (const entry of overduePatches) {
     stderr(formatWarning(entry));
   }
-  return { overdueCount: overdue.length, exitCode: 0 };
+  for (const entry of overdueExclusions) {
+    stderr(formatWarning(entry));
+  }
+  return { overdueCount, exitCode: 0 };
 }
 
 // CLI

--- a/scripts/check_patch_review_cadence.mjs
+++ b/scripts/check_patch_review_cadence.mjs
@@ -104,6 +104,14 @@ export function collectOverdueSyncExclusions(
  * `source_sync_exclusions` row (keyed by `slug`). The shape is detected
  * from which field is present.
  *
+ * Precedence / validation:
+ *   - `id` wins over `slug` (en_source_patches is the segment-level mechanism
+ *     and its `id` uniquely names the patch; sync_exclusions has no `id`
+ *     by construction, so the two shapes are disjoint in every current caller).
+ *   - If neither `id` nor `slug` is set, an explicit "unknown-entry" label is
+ *     emitted instead of silently stringifying `undefined`. This surfaces a
+ *     programming error rather than hiding it in a log line.
+ *
  * @param {{ id?: string, slug?: string, reviewAfter: string, daysOverdue: number }} entry
  * @returns {string}
  */
@@ -111,7 +119,10 @@ export function formatWarning(entry) {
   if (entry.id) {
     return `[en_source_patches] reviewAfter overdue: patch=${entry.id} reviewAfter=${entry.reviewAfter} daysOverdue=${entry.daysOverdue}`;
   }
-  return `[source_sync_exclusions] reviewAfter overdue: slug=${entry.slug} reviewAfter=${entry.reviewAfter} daysOverdue=${entry.daysOverdue}`;
+  if (entry.slug) {
+    return `[source_sync_exclusions] reviewAfter overdue: slug=${entry.slug} reviewAfter=${entry.reviewAfter} daysOverdue=${entry.daysOverdue}`;
+  }
+  return `[registry-review-cadence] reviewAfter overdue: entry=<unknown> reviewAfter=${entry.reviewAfter ?? '<none>'} daysOverdue=${entry.daysOverdue ?? 0}`;
 }
 
 /**

--- a/scripts/check_upstream_recovery.mjs
+++ b/scripts/check_upstream_recovery.mjs
@@ -76,6 +76,32 @@ export function daysUntil(dateStr, nowMs = Date.now()) {
 }
 
 /**
+ * Overdue predicate with same-day semantics aligned to
+ * `scripts/check_patch_review_cadence.mjs::evaluatePatchReview` (Codex C1):
+ *
+ *   - `reviewAfter` is a YYYY-MM-DD string, parsed as UTC midnight by
+ *     `new Date(...)` per ES2015+.
+ *   - Overdue when `nowMs > reviewAfterMs` **strictly** — the review day
+ *     itself (nowMs === reviewAfterMs) is *not* overdue (inclusive boundary).
+ *   - Invalid / missing dates fail-safe to `false`.
+ *
+ * Using this helper instead of `daysSince(...) > 0` keeps both detectors
+ * aligned even when nowMs lands partway through the review day (e.g. 12:00
+ * UTC on reviewAfter — cadence would flag overdue, the old daysSince check
+ * would not).
+ *
+ * @param {string | null | undefined} dateStr
+ * @param {number} nowMs
+ * @returns {boolean}
+ */
+export function isReviewOverdue(dateStr, nowMs = Date.now()) {
+  if (typeof dateStr !== 'string' || dateStr.length === 0) return false;
+  const parsed = new Date(dateStr).getTime();
+  if (!Number.isFinite(parsed)) return false;
+  return nowMs > parsed;
+}
+
+/**
  * Load existing source-sync-status.json (if present). Absent file is a legitimate
  * local-development state and must degrade gracefully — callers treat missing
  * data as `fetchStatus: 'unknown'`.
@@ -113,8 +139,20 @@ function uniquePatchSlugs(patches = EN_SOURCE_PATCHES) {
  * Returns per-patch rows with `statusA` (active/stale/unknown), `statusB`
  * (current/overdue), hits count, and cadence metadata.
  *
+ * **Note on the `patches` parameter (Codex C2):** this argument is used only
+ * for the outer enumeration loop (slug collection + result shaping). The
+ * actual hit detection happens inside `preprocessEnHtml`, which reads the
+ * *live* `EN_SOURCE_PATCHES` constant — not the injected `patches`. Unit
+ * tests therefore inject synthetic patches to exercise stale / unknown
+ * branches only; the `active` branch requires real registered slugs and is
+ * covered by `en_source_patches_integration.test.mjs`. Production callers
+ * should omit `patches` to use the default (live registry) and stay
+ * consistent with the hit-detection layer.
+ *
  * @param {number} nowMs
  * @param {string} snapshotsRoot
+ * @param {ReadonlyArray<object>} [patches] — override the enumeration list
+ *   (tests only; does NOT change hit detection — see note above)
  */
 export function computeEnPatchStatus({
   nowMs = Date.now(),
@@ -150,7 +188,9 @@ export function computeEnPatchStatus({
     } else {
       statusA = status.matched ? 'active' : 'stale';
     }
-    const statusB = daysSince(patch.reviewAfter, nowMs) > 0 ? 'overdue' : 'current';
+    // Use isReviewOverdue (not daysSince(...) > 0) so same-day semantics
+    // match check_patch_review_cadence.mjs (Codex C1).
+    const statusB = isReviewOverdue(patch.reviewAfter, nowMs) ? 'overdue' : 'current';
     return {
       id: patch.id,
       mechanism: 'en_source_patches',
@@ -199,10 +239,9 @@ export function computeSyncExclusionStatus({
     } else {
       statusA = 'unknown';
     }
-    const statusB =
-      entry.reviewAfter && daysSince(entry.reviewAfter, nowMs) > 0
-        ? 'overdue'
-        : 'current';
+    // isReviewOverdue matches check_patch_review_cadence.mjs same-day semantics
+    // (Codex C1). Missing reviewAfter is treated as not-overdue (fail-safe).
+    const statusB = isReviewOverdue(entry.reviewAfter, nowMs) ? 'overdue' : 'current';
     return {
       slug,
       mechanism: 'source_sync_exclusions',

--- a/scripts/check_upstream_recovery.mjs
+++ b/scripts/check_upstream_recovery.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+// scripts/check_upstream_recovery.mjs
+/**
+ * Upstream recovery detection — standalone aggregator (Phase A).
+ *
+ * 既存 signals を読み取り、`upstream-recovery-status.json` を派生する:
+ *   - `EN_SOURCE_PATCHES` + `preprocessEnHtml(patchCoverage)` → per-patch Axis A status
+ *   - `source-sync-status.json.pages[].fetchStatus` → per-exclusion Axis A status
+ *   - 各 entry の `reviewAfter` との cadence 比較 → per-entry Axis B status
+ *
+ * Non-blocking: process.exit(0) unconditionally. consumers (sticky PR comment /
+ * detection_reports / sourceSyncHealth managed issue) が JSON を読んで判断する。
+ *
+ * Architecture invariants:
+ *   - `check_source_parity.mjs` / `scripts/lib/parity_*.mjs` には触らない
+ *     (parity gate の挙動を変更しない — baseline=0 regression 禁止)
+ *   - 新 detector / issue type / workflow は追加しない (既存 infra の拡張のみ)
+ *
+ * Plan: docs/superpowers/plans/2026-04-20-upstream-recovery-detection.md §Task 1
+ * Spec: docs/superpowers/specs/2026-04-20-upstream-recovery-spec.md
+ *
+ * @module check_upstream_recovery
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ROOT_DIR } from './lib/project.mjs';
+import {
+  EN_SOURCE_PATCHES,
+  createEnSourcePatchCoverage,
+} from './lib/en_source_patches.mjs';
+import { SOURCE_SYNC_EXCLUSIONS } from './lib/source_sync_exclusions.mjs';
+import { preprocessEnHtml } from './lib/turndown.mjs';
+
+const SNAPSHOTS_ROOT = path.join(ROOT_DIR, 'snapshots', 'en', 'content');
+const SOURCE_SYNC_STATUS_PATH = path.join(ROOT_DIR, 'source-sync-status.json');
+const OUTPUT_PATH = path.join(ROOT_DIR, 'upstream-recovery-status.json');
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Days between `dateStr` (YYYY-MM-DD) and `now`. Positive when dateStr is in the
+ * past (overdue). Returns 0 for invalid / missing dates to keep callers fail-safe.
+ *
+ * @param {string | null | undefined} dateStr
+ * @param {number} nowMs
+ */
+export function daysSince(dateStr, nowMs = Date.now()) {
+  if (typeof dateStr !== 'string' || dateStr.length === 0) return 0;
+  const parsed = new Date(dateStr).getTime();
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.floor((nowMs - parsed) / MS_PER_DAY);
+}
+
+/**
+ * Days between `now` and `dateStr`. Positive when dateStr is in the future.
+ * Mirror of `daysSince` for the opposite sign — used to show "days until review".
+ *
+ * @param {string | null | undefined} dateStr
+ * @param {number} nowMs
+ */
+export function daysUntil(dateStr, nowMs = Date.now()) {
+  if (typeof dateStr !== 'string' || dateStr.length === 0) return null;
+  const parsed = new Date(dateStr).getTime();
+  if (!Number.isFinite(parsed)) return null;
+  return Math.floor((parsed - nowMs) / MS_PER_DAY);
+}
+
+/**
+ * Load existing source-sync-status.json (if present). Absent file is a legitimate
+ * local-development state and must degrade gracefully — callers treat missing
+ * data as `fetchStatus: 'unknown'`.
+ *
+ * @returns {{ pages: Array<{ slug: string, fetchStatus?: string }> } | null}
+ */
+function loadSourceSyncStatus(filePath = SOURCE_SYNC_STATUS_PATH) {
+  if (!existsSync(filePath)) return null;
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    console.warn(
+      `[upstream-recovery] failed to parse ${path.basename(filePath)}: ${err.message}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Collect unique slugs across all patches (slug-driven loop per plan Task 2).
+ * `preprocessEnHtml` applies every applicable patch for the given slug in a
+ * single pass, so iterating slugs (not patches) avoids duplicate work.
+ */
+function uniquePatchSlugs(patches = EN_SOURCE_PATCHES) {
+  const set = new Set();
+  for (const patch of patches) {
+    for (const slug of patch.slugs) set.add(slug);
+  }
+  return set;
+}
+
+/**
+ * Axis A — EN upstream 修正検知 (en_patches).
+ *
+ * Returns per-patch rows with `statusA` (active/stale/unknown), `statusB`
+ * (current/overdue), hits count, and cadence metadata.
+ *
+ * @param {number} nowMs
+ * @param {string} snapshotsRoot
+ */
+export function computeEnPatchStatus({
+  nowMs = Date.now(),
+  snapshotsRoot = SNAPSHOTS_ROOT,
+  patches = EN_SOURCE_PATCHES,
+} = {}) {
+  const coverage = createEnSourcePatchCoverage();
+  const slugs = uniquePatchSlugs(patches);
+  const snapshotSeen = new Set();
+  for (const slug of slugs) {
+    const snapshotPath = path.join(snapshotsRoot, `${slug}.html`);
+    if (!existsSync(snapshotPath)) continue;
+    const raw = readFileSync(snapshotPath, 'utf8');
+    try {
+      preprocessEnHtml(raw, { slug, patchCoverage: coverage });
+      snapshotSeen.add(slug);
+    } catch (err) {
+      console.warn(
+        `[upstream-recovery] preprocessEnHtml failed for slug=${slug}: ${err.message}`,
+      );
+    }
+  }
+  const snap = coverage.snapshot();
+  return patches.map((patch) => {
+    const status = snap.byPatchIdStatus[patch.id] ?? { matched: false, hits: 0 };
+    // A patch is considered `unknown` when NONE of its registered slugs had a
+    // readable snapshot in this run (can't tell stale vs active). Otherwise
+    // matched=true → active, matched=false → stale (upstream likely fixed).
+    const anySnapshotSeen = patch.slugs.some((s) => snapshotSeen.has(s));
+    let statusA;
+    if (!anySnapshotSeen) {
+      statusA = 'unknown';
+    } else {
+      statusA = status.matched ? 'active' : 'stale';
+    }
+    const statusB = daysSince(patch.reviewAfter, nowMs) > 0 ? 'overdue' : 'current';
+    return {
+      id: patch.id,
+      mechanism: 'en_source_patches',
+      slugs: [...patch.slugs],
+      statusA,
+      statusB,
+      hits: status.hits,
+      addedAt: patch.addedAt ?? null,
+      reviewAfter: patch.reviewAfter ?? null,
+      daysUntilReview: daysUntil(patch.reviewAfter, nowMs),
+    };
+  });
+}
+
+/**
+ * Axis A — EN upstream 修正検知 (sync_exclusions).
+ *
+ * Reads existing `fetchStatus` signal from `source-sync-status.json`. Missing
+ * file / missing entry degrades to `unknown` (local dev / PR CI without the
+ * artifact). `excluded-recovered` → stale, `excluded-broken` → active.
+ *
+ * @param {number} nowMs
+ */
+export function computeSyncExclusionStatus({
+  nowMs = Date.now(),
+  exclusions = SOURCE_SYNC_EXCLUSIONS,
+  sourceSyncStatus = loadSourceSyncStatus(),
+} = {}) {
+  const pages = Array.isArray(sourceSyncStatus?.pages) ? sourceSyncStatus.pages : [];
+  const pageBySlug = new Map();
+  for (const page of pages) {
+    if (typeof page?.slug === 'string') pageBySlug.set(page.slug, page);
+  }
+  return Object.entries(exclusions).map(([slug, entry]) => {
+    const page = pageBySlug.get(slug);
+    const fetchStatus = page?.fetchStatus ?? 'unknown';
+    let statusA;
+    if (fetchStatus === 'excluded-recovered') {
+      statusA = 'stale';
+    } else if (fetchStatus === 'excluded-broken') {
+      statusA = 'active';
+    } else {
+      statusA = 'unknown';
+    }
+    const statusB =
+      entry.reviewAfter && daysSince(entry.reviewAfter, nowMs) > 0
+        ? 'overdue'
+        : 'current';
+    return {
+      slug,
+      mechanism: 'source_sync_exclusions',
+      statusA,
+      statusB,
+      fetchStatus,
+      addedAt: entry.addedAt ?? null,
+      reviewAfter: entry.reviewAfter ?? null,
+      daysUntilReview: entry.reviewAfter ? daysUntil(entry.reviewAfter, nowMs) : null,
+    };
+  });
+}
+
+/**
+ * Build the full `upstream-recovery-status.json` payload in memory. Caller is
+ * responsible for persistence. Exported for unit tests and downstream tools
+ * (detection_reports, sticky PR comment in Phase B).
+ *
+ * @param {object} [options]
+ */
+export function buildUpstreamRecoveryStatus(options = {}) {
+  const nowMs = options.nowMs ?? Date.now();
+  const enPatches = computeEnPatchStatus({ ...options, nowMs });
+  const syncExclusions = computeSyncExclusionStatus({ ...options, nowMs });
+  const allEntries = [...enPatches, ...syncExclusions];
+  const staleCount = allEntries.filter((e) => e.statusA === 'stale').length;
+  const overdueCount = allEntries.filter((e) => e.statusB === 'overdue').length;
+  const unknownCount = allEntries.filter((e) => e.statusA === 'unknown').length;
+  const totalEntries = allEntries.length;
+  const activeEntries = totalEntries - staleCount - unknownCount;
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date(nowMs).toISOString(),
+    summary: {
+      totalEntries,
+      activeEntries,
+      staleEntries: staleCount, // Axis A signal
+      overdueEntries: overdueCount, // Axis B signal
+      unknownEntries: unknownCount,
+    },
+    mechanisms: {
+      en_source_patches: enPatches,
+      source_sync_exclusions: syncExclusions,
+    },
+  };
+}
+
+export function runCheckUpstreamRecovery({
+  outputPath = OUTPUT_PATH,
+  stdout = console.log,
+  ...options
+} = {}) {
+  const payload = buildUpstreamRecoveryStatus(options);
+  writeFileSync(outputPath, JSON.stringify(payload, null, 2) + '\n');
+  stdout(
+    `[upstream-recovery] total=${payload.summary.totalEntries} ` +
+      `active=${payload.summary.activeEntries} ` +
+      `stale=${payload.summary.staleEntries} ` +
+      `overdue=${payload.summary.overdueEntries} ` +
+      `unknown=${payload.summary.unknownEntries} ` +
+      `→ ${path.relative(ROOT_DIR, outputPath)}`,
+  );
+  return payload;
+}
+
+const isDirectRun =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isDirectRun) {
+  try {
+    runCheckUpstreamRecovery();
+    process.exit(0); // Non-blocking: consumers decide via JSON.
+  } catch (err) {
+    console.error(`[upstream-recovery] unexpected failure: ${err.message}`);
+    process.exit(0); // Still non-blocking — don't break unrelated CI.
+  }
+}

--- a/scripts/check_upstream_recovery.mjs
+++ b/scripts/check_upstream_recovery.mjs
@@ -41,8 +41,15 @@ const OUTPUT_PATH = path.join(ROOT_DIR, 'upstream-recovery-status.json');
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 /**
- * Days between `dateStr` (YYYY-MM-DD) and `now`. Positive when dateStr is in the
- * past (overdue). Returns 0 for invalid / missing dates to keep callers fail-safe.
+ * Days between `dateStr` (YYYY-MM-DD) and `now`.
+ *
+ * - Positive when `dateStr` is in the past (overdue).
+ * - `0` on the same UTC day.
+ * - Negative when `dateStr` is in the future (not yet due).
+ * - `0` for invalid / missing dates (fail-safe — callers use `> 0` to mean overdue).
+ *
+ * `new Date('YYYY-MM-DD')` is parsed as UTC midnight per ES2015+, so the result
+ * is timezone-independent.
  *
  * @param {string | null | undefined} dateStr
  * @param {number} nowMs
@@ -170,6 +177,10 @@ export function computeEnPatchStatus({
 export function computeSyncExclusionStatus({
   nowMs = Date.now(),
   exclusions = SOURCE_SYNC_EXCLUSIONS,
+  // NOTE: the I/O-bearing default `loadSourceSyncStatus()` is evaluated once
+  // per call-without-argument. All tests inject `sourceSyncStatus` directly
+  // (no fs touches from unit tests); the default is reached only from the
+  // CLI path (buildUpstreamRecoveryStatus → computeSyncExclusionStatus).
   sourceSyncStatus = loadSourceSyncStatus(),
 } = {}) {
   const pages = Array.isArray(sourceSyncStatus?.pages) ? sourceSyncStatus.pages : [];

--- a/scripts/lib/en_source_patches.mjs
+++ b/scripts/lib/en_source_patches.mjs
@@ -862,8 +862,27 @@ export function applyEnSourcePatches(html, slug, coverage = NOOP_PATCH_COVERAGE)
 }
 
 /**
+ * Build the all-patches seed for `byPatchIdStatus` so callers can enumerate
+ * every registry entry (including zero-hit patches) without consulting
+ * `EN_SOURCE_PATCHES` separately. Each value is `{ matched: false, hits: 0 }`
+ * by default and is upgraded to `matched: true` once a hit is recorded.
+ */
+function seedByPatchIdStatus() {
+  const seeded = {};
+  for (const patch of EN_SOURCE_PATCHES) {
+    seeded[patch.id] = { matched: false, hits: 0 };
+  }
+  return seeded;
+}
+
+/**
  * runtime coverage aggregator。run 単位で 1 個生成し、patch hit / mismatch を
  * record する。`snapshot()` で集計結果を返す。
+ *
+ * - `byPatchId`: Record<id, number> — hit 回数のみ (既存 shape, debug 出力互換)
+ * - `byPatchIdStatus`: Record<id, {matched, hits}> — **全 34 patch IDs を seed**。
+ *   hit の無かった patch も `{matched: false, hits: 0}` で必ず含まれるため、
+ *   stale detection (`check_upstream_recovery.mjs` 等) の enumeration 基盤として使える。
  *
  * @returns {{
  *   recordHit: (hit: {slug: string, patchId: string, hits: number}) => void,
@@ -872,6 +891,7 @@ export function applyEnSourcePatches(html, slug, coverage = NOOP_PATCH_COVERAGE)
  *     registryEntries: number,
  *     matchedHits: number,
  *     byPatchId: Record<string, number>,
+ *     byPatchIdStatus: Record<string, { matched: boolean, hits: number }>,
  *     bySlug: Record<string, number>,
  *     mismatches: Array<{slug: string, patchId: string, reason: string}>,
  *   },
@@ -889,17 +909,28 @@ export function createEnSourcePatchCoverage() {
     },
     snapshot() {
       const byPatchId = {};
+      const byPatchIdStatus = seedByPatchIdStatus();
       const bySlug = {};
       let matchedHits = 0;
       for (const h of hits) {
         matchedHits += h.hits;
         byPatchId[h.patchId] = (byPatchId[h.patchId] ?? 0) + h.hits;
         bySlug[h.slug] = (bySlug[h.slug] ?? 0) + h.hits;
+        const status = byPatchIdStatus[h.patchId];
+        if (status) {
+          status.matched = true;
+          status.hits += h.hits;
+        } else {
+          // Defensive: a hit for a patchId not in the current registry.
+          // Surface it through byPatchIdStatus so reviewers can see the drift.
+          byPatchIdStatus[h.patchId] = { matched: true, hits: h.hits };
+        }
       }
       return {
         registryEntries: EN_SOURCE_PATCHES.length,
         matchedHits,
         byPatchId,
+        byPatchIdStatus,
         bySlug,
         mismatches: mismatches.slice(),
       };
@@ -918,6 +949,7 @@ export const NOOP_PATCH_COVERAGE = Object.freeze({
     registryEntries: EN_SOURCE_PATCHES.length,
     matchedHits: 0,
     byPatchId: {},
+    byPatchIdStatus: seedByPatchIdStatus(),
     bySlug: {},
     mismatches: [],
   }),

--- a/scripts/lib/en_source_patches.mjs
+++ b/scripts/lib/en_source_patches.mjs
@@ -908,6 +908,11 @@ export function createEnSourcePatchCoverage() {
       mismatches.push({ slug, patchId, reason });
     },
     snapshot() {
+      // snapshot() advertises a point-in-time view; we defensively copy every
+      // mutable surface so that subsequent recordHit/recordMismatch calls on
+      // the coverage instance cannot retroactively mutate an already-returned
+      // snapshot. (Callers that serialise the snapshot to JSON don't notice,
+      // but programmatic consumers would.)
       const byPatchId = {};
       const byPatchIdStatus = seedByPatchIdStatus();
       const bySlug = {};
@@ -926,14 +931,14 @@ export function createEnSourcePatchCoverage() {
           byPatchIdStatus[h.patchId] = { matched: true, hits: h.hits };
         }
       }
-      return {
+      return Object.freeze({
         registryEntries: EN_SOURCE_PATCHES.length,
         matchedHits,
-        byPatchId,
-        byPatchIdStatus,
-        bySlug,
-        mismatches: mismatches.slice(),
-      };
+        byPatchId: Object.freeze(byPatchId),
+        byPatchIdStatus: Object.freeze(byPatchIdStatus),
+        bySlug: Object.freeze(bySlug),
+        mismatches: mismatches.map((m) => ({ ...m })),
+      });
     },
   };
 }

--- a/scripts/lib/source_sync_exclusions.mjs
+++ b/scripts/lib/source_sync_exclusions.mjs
@@ -37,8 +37,13 @@
  *     expectedIssueType: string,
  *     expectedReason: string,
  *     addedAt: 'YYYY-MM-DD',
+ *     reviewAfter: 'YYYY-MM-DD',   // Phase A: 6-month cadence, parity with en_source_patches
  *     linkedIssue: number,
  *   }
+ *
+ * `reviewAfter` は `en_source_patches.mjs` と同じ 6 ヶ月 cadence で上流修復の再確認を
+ * 促す field。期限超過は `check_patch_review_cadence.mjs` が両 registry 横断で
+ * surface する (non-blocking warning)。
  *
  * @type {Readonly<Record<string, Readonly<{
  *   reason: string,
@@ -46,6 +51,7 @@
  *   expectedIssueType: string,
  *   expectedReason: string,
  *   addedAt: string,
+ *   reviewAfter: string,
  *   linkedIssue: number,
  * }>>>}
  */
@@ -62,6 +68,7 @@ export const SOURCE_SYNC_EXCLUSIONS = Object.freeze({
     expectedIssueType: 'snapshot-incomplete',
     expectedReason: 'extractor-empty',
     addedAt: '2026-04-09',
+    reviewAfter: '2026-10-09',
     linkedIssue: 247,
   }),
 });


### PR DESCRIPTION
## Summary

`docs/superpowers/plans/2026-04-20-upstream-recovery-detection.md` §Phase A 実装。2-mechanism retreat (`en_source_patches` / `source_sync_exclusions`) に対して **(A) 上流修正の自動検知** と **(B) 登録解除忘れの persistent reminder** を **既存 infrastructure の拡張** として加える。

### Task 1 — Status infrastructure (standalone aggregator)
- `scripts/check_upstream_recovery.mjs` — `EN_SOURCE_PATCHES` の slug-driven scan + `source-sync-status.json` の `fetchStatus` lookup を集約し `upstream-recovery-status.json` を derive する。**non-blocking exit** (consumer が JSON で判断)
- `scripts/lib/en_source_patches.mjs` — `createEnSourcePatchCoverage` の `snapshot()` に `byPatchIdStatus: Record<id, {matched, hits}>` を **全 34 patch IDs で seed** 付きで追加。既存 `byPatchId` は numeric map のまま維持 (backward compat)
- `package.json` — `npm run check:upstream-recovery`
- `.gitignore` — `upstream-recovery-status.json`
- `docs/superpowers/specs/2026-04-20-upstream-recovery-spec.md` — JSON schema / 状態遷移 / graceful degradation policy

### Task 2 — Test coverage expansion (全 34 patches slug-driven)
- `en_source_patches_integration.test.mjs` — stale detection across 34 patches (non-gating warning), sync_exclusions recovery warning, reviewAfter shape pin
- `en_source_patches.test.mjs` — `byPatchIdStatus` seed + `recordHit` accumulation
- `check_upstream_recovery.test.mjs` — Axis A × Axis B matrix (stale/unknown/overdue/current 全分岐), aggregate shape
- `source_parity_source_side_debt.test.mjs` — `reviewAfter` shape pin

### Task 6 — reviewAfter parity on source_sync_exclusions
- `source_sync_exclusions.mjs` — pull-requests entry に `reviewAfter: '2026-10-09'` 追加 (6 ヶ月 cadence, en_source_patches と parity)
- `check_patch_review_cadence.mjs` — `collectOverdueSyncExclusions()` 追加 + `formatWarning()` が id/slug shape で dispatch + `main()` を両 registry 対応に拡張
- `check_patch_review_cadence.test.mjs` — 新 API のテスト追加

## Architecture invariants (preserved)

- **baseline=0 invariant**: `parity-baseline.json` は schemaVersion=2 / entries=0 のまま (regression なし)
- **parity gate 挙動不変**: `scripts/check_source_parity.mjs` / `scripts/lib/parity_*.mjs` は touch していない
- **新 workflow / 新 issue family 追加なし**: 既存 infra の拡張のみ (Phase B で `sourceSyncHealth` family 内に section 追加予定)
- **2-mechanism rule 維持**: page-level (`source_sync_exclusions`) + segment-level (`en_source_patches`) の 2 機構のみ

## Local run results

\`\`\`
$ npm run check:upstream-recovery
[upstream-recovery] total=35 active=34 stale=1 overdue=0 unknown=0

$ npm run check:patch-review
[registry-review-cadence] OK — 34 en_source_patches + 1 source_sync_exclusions, 0 overdue
\`\`\`

(stale=1 は local に残っている \`source-sync-status.json\` が \`pull-requests\` を \`excluded-recovered\` 報告しているため。registry 削除は Task 7 / pull-requests cleanup PR scope.)

## Test plan

- [x] \`npm run test\` green (2190 pass / 0 fail / 1 skip — 36 new tests vs. main)
- [x] \`npm run lint\` green (0/0 in 288 files)
- [x] \`npm run build\` green (290 pages)
- [x] \`npm run check:parity\` — 0 issues (counters all 0, schema v2 invariant)
- [x] \`npm run check:upstream-recovery\` — JSON artifact生成、shape OK
- [x] \`npm run check:patch-review\` — 両 registry scan、no overdue
- [x] \`parity-baseline.json\` regression なし (entries=0, schemaVersion=2)

## Dependencies / Ordering

- **PR Z (#361)** — merged 2026-04-20 (ee2eb71) ✅
- **本 PR (Phase A)** — PR Z merge 後に起票 (実際には parallel-safe だが plan 順序に従う)
- **Phase B** — 本 PR merge 後必須 (detection_reports.mjs が PR Z Task 4.6.3 owner で、Phase B は同 file 拡張)
- **pull-requests cleanup** — 別 PR (Task 7, 独立 scope)

## 参考

- Plan: \`docs/superpowers/plans/2026-04-20-upstream-recovery-detection.md\` Rev 4 §Phase A
- Spec: \`docs/superpowers/specs/2026-04-20-upstream-recovery-spec.md\` (本 PR で追加)