### PR TITLE
feat(recovery): Phase B — detection_reports integration + sticky PR comment + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,18 @@ jobs:
 
   parity:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Sticky PR comment (Phase B Task 4). No untrusted event input is
+      # interpolated into shell/scripts — the comment body is built from
+      # upstream-recovery-status.json (generated in-run) and static text.
+      pull-requests: write
+      issues: write
+    concurrency:
+      # Serialise the sticky comment upsert per PR so successive pushes
+      # don't race a delete+create pair.
+      group: parity-upstream-recovery-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -64,3 +76,127 @@ jobs:
           name: parity-check-status
           path: parity-check-status.json
           retention-days: 7
+
+      - name: Check upstream recovery (non-blocking)
+        # Phase B (Task 4): standalone aggregator; exits 0 unconditionally.
+        # Consumers decide via the JSON artifact.
+        if: always()
+        continue-on-error: true
+        run: npm run check:upstream-recovery
+
+      - name: Upload upstream recovery status
+        if: always() && hashFiles('upstream-recovery-status.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: upstream-recovery-status
+          path: upstream-recovery-status.json
+          retention-days: 7
+
+      - name: Sticky PR comment — upstream recovery
+        # Fires on every push to the PR. Idempotent upsert via hidden marker.
+        # All content is derived from the locally-generated JSON artifact —
+        # no untrusted event fields reach shell or comment body.
+        if: >-
+          always() && github.event_name == 'pull_request'
+          && hashFiles('upstream-recovery-status.json') != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- upstream-recovery: sticky -->';
+            const status = JSON.parse(fs.readFileSync('upstream-recovery-status.json', 'utf8'));
+            const enRows = status.mechanisms?.en_source_patches ?? [];
+            const syncRows = status.mechanisms?.source_sync_exclusions ?? [];
+            const enStale = enRows.filter((e) => e.statusA === 'stale');
+            const enOverdue = enRows.filter((e) => e.statusB === 'overdue');
+            const syncStale = syncRows.filter((e) => e.statusA === 'stale');
+            const syncOverdue = syncRows.filter((e) => e.statusB === 'overdue');
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              },
+            );
+            const existing = comments.find((c) => c.body?.includes(MARKER));
+
+            const totalAxis =
+              enStale.length +
+              enOverdue.length +
+              syncStale.length +
+              syncOverdue.length;
+
+            if (totalAxis === 0) {
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                });
+              }
+              return;
+            }
+
+            const fmtEn = (e) =>
+              `- \`${e.id}\` (slugs: ${(e.slugs || []).join(', ')}) — ` +
+              `reviewAfter=${e.reviewAfter ?? 'n/a'} daysUntil=${e.daysUntilReview ?? 'n/a'}`;
+            const fmtSync = (e) =>
+              `- \`${e.slug}\` fetchStatus=${e.fetchStatus ?? 'unknown'} ` +
+              `reviewAfter=${e.reviewAfter ?? 'n/a'} daysUntil=${e.daysUntilReview ?? 'n/a'}`;
+
+            const sections = [];
+            if (enStale.length > 0) {
+              sections.push(
+                `### en_source_patches stale (${enStale.length})`,
+                enStale.map(fmtEn).join('\n'),
+              );
+            }
+            if (enOverdue.length > 0) {
+              sections.push(
+                `### en_source_patches overdue (${enOverdue.length})`,
+                enOverdue.map(fmtEn).join('\n'),
+              );
+            }
+            if (syncStale.length > 0) {
+              sections.push(
+                `### source_sync_exclusions stale (${syncStale.length})`,
+                syncStale.map(fmtSync).join('\n'),
+              );
+            }
+            if (syncOverdue.length > 0) {
+              sections.push(
+                `### source_sync_exclusions overdue (${syncOverdue.length})`,
+                syncOverdue.map(fmtSync).join('\n'),
+              );
+            }
+
+            const body = [
+              MARKER,
+              '',
+              `## 🧹 Upstream recovery: ${totalAxis} entr(ies) need attention`,
+              '',
+              ...sections,
+              '',
+              '_Informational only — this comment is non-blocking. ' +
+                'See `docs/PARITY_GUIDE.md §許容機構` and ' +
+                '`docs/OPS_DESIGN.md §Weekly: Upstream recovery triage` ' +
+                'for the removal workflow._',
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,111 +92,95 @@ jobs:
           path: upstream-recovery-status.json
           retention-days: 7
 
-      - name: Sticky PR comment — upstream recovery
-        # Fires on every push to the PR. Idempotent upsert via hidden marker.
-        # All content is derived from the locally-generated JSON artifact —
-        # no untrusted event fields reach shell or comment body.
+      - name: Render upstream recovery sticky comment body
+        # Delegates markdown rendering to
+        # scripts/render_upstream_recovery_comment.mjs which imports
+        # renderUpstreamRecoveryStickyComment from detection_reports.mjs.
+        # This eliminates logic duplication between the CI step and
+        # detection_reports.mjs (PR #363 code-review HIGH). The script
+        # writes upstream-recovery-comment.md when signals exist and prints
+        # `has_signals=true|false` on stdout for the upsert step below.
+        id: render_upstream_recovery_comment
         if: >-
           always() && github.event_name == 'pull_request'
           && hashFiles('upstream-recovery-status.json') != ''
+        continue-on-error: true
+        run: |
+          node scripts/render_upstream_recovery_comment.mjs >> "$GITHUB_OUTPUT"
+
+      - name: Sticky PR comment — upstream recovery (upsert)
+        # Idempotent upsert via hidden marker. The body was rendered by the
+        # previous step so this inline script only handles the GitHub API
+        # calls (list / update / create / delete). All error paths are
+        # caught so a transient API failure does not mark the parity job
+        # as failed (the comment is informational only).
+        if: >-
+          always() && github.event_name == 'pull_request'
+          && hashFiles('upstream-recovery-status.json') != ''
+        continue-on-error: true
         uses: actions/github-script@v7
+        env:
+          HAS_SIGNALS: ${{ steps.render_upstream_recovery_comment.outputs.has_signals }}
         with:
           script: |
-            const fs = require('fs');
-            const MARKER = '<!-- upstream-recovery: sticky -->';
-            const status = JSON.parse(fs.readFileSync('upstream-recovery-status.json', 'utf8'));
-            const enRows = status.mechanisms?.en_source_patches ?? [];
-            const syncRows = status.mechanisms?.source_sync_exclusions ?? [];
-            const enStale = enRows.filter((e) => e.statusA === 'stale');
-            const enOverdue = enRows.filter((e) => e.statusB === 'overdue');
-            const syncStale = syncRows.filter((e) => e.statusA === 'stale');
-            const syncOverdue = syncRows.filter((e) => e.statusB === 'overdue');
+            try {
+              const fs = require('fs');
+              const MARKER = '<!-- upstream-recovery: sticky -->';
+              const hasSignals = process.env.HAS_SIGNALS === 'true';
 
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-              },
-            );
-            const existing = comments.find((c) => c.body?.includes(MARKER));
+              // Find any existing sticky comment. Cap per_page at 100 and
+              // stop as soon as we locate the marker — PRs with a very long
+              // comment history should not fan out to hundreds of API calls.
+              let existing = null;
+              for await (const { data: page } of github.paginate.iterator(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  per_page: 100,
+                },
+              )) {
+                existing = page.find((c) => c.body && c.body.includes(MARKER));
+                if (existing) break;
+              }
 
-            const totalAxis =
-              enStale.length +
-              enOverdue.length +
-              syncStale.length +
-              syncOverdue.length;
+              if (!hasSignals) {
+                // No stale/overdue signals — delete any prior sticky comment.
+                if (existing) {
+                  await github.rest.issues.deleteComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existing.id,
+                  });
+                }
+                return;
+              }
 
-            if (totalAxis === 0) {
+              // Signals present → read pre-rendered body and upsert.
+              const body = fs.readFileSync('upstream-recovery-comment.md', 'utf8');
+
               if (existing) {
-                await github.rest.issues.deleteComment({
+                await github.rest.issues.updateComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
                 });
               }
-              return;
-            }
-
-            const fmtEn = (e) =>
-              `- \`${e.id}\` (slugs: ${(e.slugs || []).join(', ')}) — ` +
-              `reviewAfter=${e.reviewAfter ?? 'n/a'} daysUntil=${e.daysUntilReview ?? 'n/a'}`;
-            const fmtSync = (e) =>
-              `- \`${e.slug}\` fetchStatus=${e.fetchStatus ?? 'unknown'} ` +
-              `reviewAfter=${e.reviewAfter ?? 'n/a'} daysUntil=${e.daysUntilReview ?? 'n/a'}`;
-
-            const sections = [];
-            if (enStale.length > 0) {
-              sections.push(
-                `### en_source_patches stale (${enStale.length})`,
-                enStale.map(fmtEn).join('\n'),
+            } catch (err) {
+              // Non-blocking: a transient GitHub API failure (rate-limit /
+              // network / permissions hiccup) must not mark the parity job
+              // as failed. Surface via core.warning so reviewers can see it
+              // in the Actions log, but do not re-throw.
+              core.warning(
+                `Sticky upstream-recovery comment upsert failed: ${err.message}`,
               );
-            }
-            if (enOverdue.length > 0) {
-              sections.push(
-                `### en_source_patches overdue (${enOverdue.length})`,
-                enOverdue.map(fmtEn).join('\n'),
-              );
-            }
-            if (syncStale.length > 0) {
-              sections.push(
-                `### source_sync_exclusions stale (${syncStale.length})`,
-                syncStale.map(fmtSync).join('\n'),
-              );
-            }
-            if (syncOverdue.length > 0) {
-              sections.push(
-                `### source_sync_exclusions overdue (${syncOverdue.length})`,
-                syncOverdue.map(fmtSync).join('\n'),
-              );
-            }
-
-            const body = [
-              MARKER,
-              '',
-              `## 🧹 Upstream recovery: ${totalAxis} entr(ies) need attention`,
-              '',
-              ...sections,
-              '',
-              '_Informational only — this comment is non-blocking. ' +
-                'See `docs/PARITY_GUIDE.md §許容機構` and ' +
-                '`docs/OPS_DESIGN.md §Weekly: Upstream recovery triage` ' +
-                'for the removal workflow._',
-            ].join('\n');
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # Sticky PR comment (Phase B Task 4). No untrusted event input is
+      # Sticky PR comment (Phase B Task 4). PR comments route through the
+      # issues REST endpoint (`github.rest.issues.{list,create,update,delete}Comment`),
+      # so `issues: write` alone is sufficient — `pull-requests: write` was
+      # previously granted but unused (Codex C5). No untrusted event input is
       # interpolated into shell/scripts — the comment body is built from
       # upstream-recovery-status.json (generated in-run) and static text.
-      pull-requests: write
       issues: write
     concurrency:
       # Serialise the sticky comment upsert per PR so successive pushes

--- a/.github/workflows/scheduled-actionable.yml
+++ b/.github/workflows/scheduled-actionable.yml
@@ -54,6 +54,15 @@ jobs:
         run: npm run check:parity
         continue-on-error: true
 
+      - name: Check upstream recovery (non-blocking)
+        # Phase B (Task 4): upstream-recovery-status.json feeds the
+        # sourceSyncHealth family's enPatchRecovery / sourceSyncRecovery
+        # subsections. Aggregator exits 0 even on failure — see
+        # scripts/check_upstream_recovery.mjs runCheckUpstreamRecovery catch.
+        id: upstream_recovery
+        run: npm run check:upstream-recovery
+        continue-on-error: true
+
       - name: Generate detection summary (strict)
         # §2 fail-closed: --strict makes loadDetectionInputs validate
         # snapshot-diff-status.json, parity-check-status.json, and (when
@@ -106,6 +115,7 @@ jobs:
             source-sync-status.json
             snapshot-diff-status.json
             parity-check-status.json
+            upstream-recovery-status.json
             docs-actionable-report.json
             docs-update-summary.md
             docs-audit-manifest.json

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ source-sync-status.json
 snapshot-diff-status.json
 parity-check-status.json
 upstream-recovery-status.json
+upstream-recovery-comment.md
 docs-actionable-report.json
 docs-update-summary.md
 docs-audit-manifest.json

--- a/docs/DOCS_DATE_TRACKING.md
+++ b/docs/DOCS_DATE_TRACKING.md
@@ -138,7 +138,8 @@ upstream 英語原文自体が broken で parity comparator の前提を満た�
 | `snapshot-diff-status.json` | 変更検知結果（ページごとの差分分類） |
 | `source-sync-status.json` | fetch metadata + freshness + source-side debt カウンタ (`excludedPages` など) |
 | `parity-check-status.json` | ローカル parity チェック結果 |
-| `docs-actionable-report.json` | Issue 作成用レポート |
+| `upstream-recovery-status.json` | `en_source_patches` + `source_sync_exclusions` の per-entry status (Axis A: `active` / `stale` / `unknown` / Axis B: `current` / `overdue`)。`npm run check:upstream-recovery` で生成。`.gitignore` 対象で CI artifact として保存される。Schema は `docs/superpowers/specs/2026-04-20-upstream-recovery-spec.md` |
+| `docs-actionable-report.json` | Issue 作成用レポート (`sourceSyncHealth.enPatchRecovery` / `sourceSyncRecovery` subsection に上記 upstream-recovery-status の派生データを含む) |
 | `docs-update-summary.md` | 人間向けサマリー（`## ソース側 debt` セクションを含む） |
 | `docs-audit-manifest.json` | レビュー計画用マニフェスト |
 

--- a/docs/OPS_DESIGN.md
+++ b/docs/OPS_DESIGN.md
@@ -175,6 +175,25 @@ npm run test && npm run build
 - 本文には件数、代表例、artifact への導線を載せ、machine-readable な follow-up payload は
   `docs-actionable-report.json` に保持する
 
+### Weekly: Upstream recovery triage
+
+`scheduled-actionable` 実行後、`sourceSyncHealth` managed issue に出現する `enPatchRecovery` / `sourceSyncRecovery` section を次の手順で triage する:
+
+1. `docs-actionable-report.json.sourceSyncHealth.enPatchRecovery.stale[]` と同 `sourceSyncRecovery.stale[]` を確認
+2. 各 stale entry について:
+   a. 該当 slug の EN snapshot を手動で fetch し直す (`npm run check:snapshots:fetch -- --slug=<slug>`)
+   b. 現在の EN HTML を目視し、欠陥が実際に消えているかを確認する (stale signal だけで削除しない)
+   c. 消えていれば:
+      - `en_source_patches` 系: `scripts/lib/en_source_patches.mjs` から entry を削除
+      - `source_sync_exclusions` 系: `scripts/lib/source_sync_exclusions.mjs` から entry を削除 + `scripts/__tests__/source_parity_source_side_debt.test.mjs` の seeded pin を調整
+      - どちらも `docs/superpowers/specs/upstream-defect-tracker.md` の対応 entry を archive 状態に更新
+      - `npm run check:parity` が 0 issues を維持していることを確認
+   d. まだ消えていなければ managed issue にコメントで状況記録 (次週 run で再評価)
+3. overdue entry (`statusB: 'overdue'`) は `reviewAfter` 延長でなく **paydown PR** で対応する (`priority='high'` を付与して順位付け)
+4. 全 stale / overdue 解消後、当該 section が空になり `sourceSyncHealth` が他 signal も無ければ workflow が自動で issue を close
+
+sticky PR comment (`.github/workflows/ci.yml` の "Sticky PR comment — upstream recovery") も同じ `upstream-recovery-status.json` を読むため、PR 作業中にも stale / overdue entry が可視化される。weekly triage で解消した項目は次の PR run で comment から自動削除される。
+
 ## 一括変更時の検証フロー
 
 複数ファイルを一括変換する場合、**検証スクリプトを変換スクリプトと同時に作成**し、初回コミット前に通す。

--- a/docs/PARITY_GUIDE.md
+++ b/docs/PARITY_GUIDE.md
@@ -222,6 +222,46 @@ patchCoverage snapshot:
 
 新規追加 `> 0` は即 PR block。`parity_artifact_registry` / `SOURCE_SYNC_EXCLUSIONS` / `en_source_patches` の新規 entry 追加は `[PENDING REVIEWER APPROVAL]` マーカー必須。
 
+## 許容機構 (2-mechanism design)
+
+EN upstream の欠陥を JA side に mirror させず吸収するため、本 repo は **2 機構のみ**を採用する。どちらも **"broken-EN retreat" という ONE purpose** に属し、粒度が異なるだけ (第 3 の許容機構追加は禁止 / `feedback_baseline_zero_increase` 参照)。
+
+### Mechanism 1: page-level freeze (`scripts/lib/source_sync_exclusions.mjs`)
+
+ページ全体が MadCap 出力で使い物にならない slug を snapshot 凍結対象として登録。snapshot fetch は行うが実際の file は上書きせず、`source-sync-status.json.pages[].fetchStatus` に `excluded-broken` / `excluded-recovered` を出力する。
+
+### Mechanism 2: segment-level patch (`scripts/lib/en_source_patches.mjs`)
+
+ページの一部に限定した MadCap authoring artifact (ZWSP 段落、broken pipe row、href-miswire 等) を抽出前に literal replace する。粒度を保ちつつ JA を source-first mirror させられる。
+
+### Lifecycle (entry 追加 → 上流修正 → 削除)
+
+1. **登録**: upstream 欠陥を人手で検証後、適切な mechanism に entry 追加 (`reviewAfter` を `addedAt` + 6 ヶ月で必ず設定)
+2. **自動検知**:
+   - `scripts/check_upstream_recovery.mjs` が毎 run で `upstream-recovery-status.json` を derive
+   - 各 entry に `statusA` (`active` / `stale` / `unknown`) と `statusB` (`current` / `overdue`) が付与される
+   - `en_source_patches_integration.test.mjs` は全 34 patches を slug-driven で scan (非 gating warning)
+3. **上流修正後の surfacing** (non-blocking):
+   - PR trigger: `.github/workflows/ci.yml` の sticky comment が hidden marker `<!-- upstream-recovery: sticky -->` で idempotent upsert
+   - Weekly trigger: `.github/workflows/scheduled-actionable.yml` が `upstream-recovery-status.json` を artifact upload し、`detection_reports.mjs` が `sourceSyncHealth` family 内の `enPatchRecovery` / `sourceSyncRecovery` section で managed issue に surface
+4. **人手削除**:
+   - registry entry を削除 (`pull-requests.md` 型の seeded pin test があれば併せて解除)
+   - `docs/superpowers/specs/upstream-defect-tracker.md` の対応 entry を archive 状態に更新
+   - 該当 JA file の parity check (`npm run check:parity`) が引き続き 0 issues であることを確認
+
+### 禁止事項
+
+- 第 3 の許容機構 (新 registry / 新 ack 経路) を追加すること
+- `reviewAfter` を将来の日付に延期して実質的な長期凍結にすること (`priority='high'` + PR paydown schedule で代替)
+- entry 削除前に upstream 修正を目視確認しないこと (`statusA: 'stale'` は signal であって confirmation ではない)
+
+### Status 判定と graceful degradation
+
+- `statusA`: `preprocessEnHtml` (en_patches) と `source-sync-status.json.fetchStatus` (exclusions) で決定
+- `statusB`: `reviewAfter` が UTC 00:00 を過ぎた瞬間に `overdue` (`check_patch_review_cadence.mjs::evaluatePatchReview` と同 semantic)
+- `source-sync-status.json` 不在時 (local dev / PR CI) は全 exclusion entry が `statusA: 'unknown'` になり、stale 判定には使われない (fail-safe)
+- Schema / 状態遷移図は `docs/superpowers/specs/2026-04-20-upstream-recovery-spec.md`
+
 ## 修正ワークフロー
 
 ### 単一ファイルの修正

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -1069,6 +1069,82 @@ describe('renderUpstreamRecoveryStickyComment — single source of truth', () =>
     assert.ok(body.includes('slug_break'), body);
     assert.ok(!body.includes('\\n'), 'raw newline must not survive');
   });
+
+  it('also strips markdown link / HTML chars from registry values (Codex C3)', async () => {
+    const { renderUpstreamRecoveryStickyComment } = await import(
+      '../lib/detection_reports.mjs'
+    );
+    const body = renderUpstreamRecoveryStickyComment({
+      schemaVersion: 1,
+      summary: { totalEntries: 1, activeEntries: 0, staleEntries: 1, overdueEntries: 0, unknownEntries: 0 },
+      mechanisms: {
+        en_source_patches: [],
+        source_sync_exclusions: [
+          {
+            slug: 'malicious[link](http://evil.example)<script>',
+            mechanism: 'source_sync_exclusions',
+            statusA: 'stale',
+            statusB: 'current',
+            fetchStatus: 'excluded-recovered',
+            addedAt: '2026-01-01',
+            reviewAfter: '2026-07-01',
+            daysUntilReview: 72,
+          },
+        ],
+      },
+    });
+    // None of the link / HTML delimiters must survive intact.
+    assert.ok(!body.includes('[link]'), 'markdown link brackets must be sanitised');
+    assert.ok(!body.includes('(http://evil'), 'parentheses must be sanitised');
+    assert.ok(!body.includes('<script>'), 'HTML tags must be sanitised');
+    // Sanitised form should still identify the entry.
+    assert.ok(body.includes('malicious_link__http'), body);
+  });
+
+  it('tolerates malformed rows (null / undefined / scalar) in mechanisms arrays (Codex C2)', async () => {
+    const { renderUpstreamRecoveryStickyComment } = await import(
+      '../lib/detection_reports.mjs'
+    );
+    // Previously `.filter(e => e.statusA === 'stale')` would throw on null /
+    // undefined / non-object rows. buildUpstreamRecoverySections now filters
+    // down to object-shaped rows first.
+    const body = renderUpstreamRecoveryStickyComment({
+      schemaVersion: 1,
+      summary: { totalEntries: 1, activeEntries: 1, staleEntries: 0, overdueEntries: 0, unknownEntries: 0 },
+      mechanisms: {
+        en_source_patches: [
+          null,
+          undefined,
+          42,
+          'garbage',
+          [],
+          {
+            id: 'UD-REAL',
+            mechanism: 'en_source_patches',
+            slugs: ['some/slug'],
+            statusA: 'active',
+            statusB: 'current',
+            hits: 1,
+            addedAt: '2026-01-01',
+            reviewAfter: '2026-07-01',
+            daysUntilReview: 72,
+          },
+        ],
+        source_sync_exclusions: [null, {
+          slug: 'valid/slug',
+          mechanism: 'source_sync_exclusions',
+          statusA: 'active',
+          statusB: 'current',
+          fetchStatus: 'excluded-broken',
+          addedAt: '2026-01-01',
+          reviewAfter: '2026-07-01',
+          daysUntilReview: 72,
+        }],
+      },
+    });
+    // No signals to report (all real rows are `active` + `current`).
+    assert.equal(body, null);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -747,10 +747,191 @@ describe('loadDetectionInputs', () => {
       snapshotPath: '/nonexistent/snapshot.json',
       parityPath: '/nonexistent/parity.json',
       sourceSyncPath: '/nonexistent/sync.json',
+      upstreamRecoveryPath: '/nonexistent/recovery.json',
     });
     assert.deepEqual(result.snapshot, {});
     assert.deepEqual(result.parity, {});
     assert.deepEqual(result.sourceSync, {});
+    assert.deepEqual(result.upstreamRecovery, {});
+  });
+
+  it('reads upstream-recovery-status.json when present (Phase B)', async () => {
+    const { mkdtempSync, writeFileSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const tmp = mkdtempSync(join(tmpdir(), 'detection-inputs-recovery-'));
+    const payload = {
+      schemaVersion: 1,
+      generatedAt: '2026-04-20T00:00:00Z',
+      summary: { totalEntries: 0, activeEntries: 0, staleEntries: 0, overdueEntries: 0, unknownEntries: 0 },
+      mechanisms: { en_source_patches: [], source_sync_exclusions: [] },
+    };
+    writeFileSync(join(tmp, 'recovery.json'), JSON.stringify(payload));
+    const result = loadDetectionInputs({
+      snapshotPath: '/nonexistent/snapshot.json',
+      parityPath: '/nonexistent/parity.json',
+      sourceSyncPath: '/nonexistent/sync.json',
+      upstreamRecoveryPath: join(tmp, 'recovery.json'),
+    });
+    assert.deepEqual(result.upstreamRecovery, payload);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase B (Task 4): upstream recovery sections on sourceSyncHealth
+// ---------------------------------------------------------------------------
+
+describe('sourceSyncHealth — upstream recovery integration (Phase B)', () => {
+  const emptySnapshot = {
+    checkedAt: '2026-04-20T00:00:00Z',
+    summary: { totalSnapshots: 100, changed: 0, added: 0, removed: 0, unchanged: 100 },
+    changes: [],
+    sidebar: { changed: false, addedPages: [], removedPages: [] },
+  };
+  const emptyParity = {
+    summary: {
+      checkedAt: '2026-04-20T00:00:00Z',
+      actionableFiles: 0,
+      signalFiles: 0,
+      errorFiles: 0,
+    },
+    files: [],
+  };
+  const freshSync = {
+    schemaVersion: 1,
+    freshnessState: 'fresh',
+    summary: {
+      targetPages: 100,
+      fetchedPages: 100,
+      notFoundPages: 0,
+      errorPages: 0,
+      sidebarVerified: true,
+    },
+    errors: [],
+  };
+
+  it('enPatchRecovery / sourceSyncRecovery are null when upstreamRecovery is absent', () => {
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], {
+      sourceSync: freshSync,
+    });
+    assert.equal(report.sourceSyncHealth.enPatchRecovery, null);
+    assert.equal(report.sourceSyncHealth.sourceSyncRecovery, null);
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, false);
+  });
+
+  it('passes through empty mechanism lists without opening the issue', () => {
+    const upstreamRecovery = {
+      schemaVersion: 1,
+      generatedAt: '2026-04-20T00:00:00Z',
+      summary: { totalEntries: 0, activeEntries: 0, staleEntries: 0, overdueEntries: 0, unknownEntries: 0 },
+      mechanisms: { en_source_patches: [], source_sync_exclusions: [] },
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], {
+      sourceSync: freshSync,
+      upstreamRecovery,
+    });
+    assert.equal(report.sourceSyncHealth.enPatchRecovery.totalPatches, 0);
+    assert.equal(report.sourceSyncHealth.sourceSyncRecovery.totalExclusions, 0);
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, false);
+  });
+
+  it('opens the sourceSyncHealth issue when stalePatches > 0', () => {
+    const upstreamRecovery = {
+      schemaVersion: 1,
+      generatedAt: '2026-04-20T00:00:00Z',
+      summary: { totalEntries: 1, activeEntries: 0, staleEntries: 1, overdueEntries: 0, unknownEntries: 0 },
+      mechanisms: {
+        en_source_patches: [
+          {
+            id: 'UD-STALE',
+            mechanism: 'en_source_patches',
+            slugs: ['some/slug'],
+            statusA: 'stale',
+            statusB: 'current',
+            hits: 0,
+            addedAt: '2026-01-01',
+            reviewAfter: '2026-07-01',
+            daysUntilReview: 72,
+          },
+        ],
+        source_sync_exclusions: [],
+      },
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], {
+      sourceSync: freshSync,
+      upstreamRecovery,
+    });
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, true);
+    assert.equal(report.sourceSyncHealth.enPatchRecovery.stalePatches, 1);
+    assert.deepEqual(
+      report.sourceSyncHealth.enPatchRecovery.stale.map((e) => e.id),
+      ['UD-STALE'],
+    );
+    // Body must reference the stale patch id and link to the runbook docs.
+    assert.match(report.sourceSyncHealth.body, /UD-STALE/);
+    assert.match(report.sourceSyncHealth.body, /upstream recovery/);
+    assert.match(report.sourceSyncHealth.body, /`upstream-recovery-status\.json`/);
+  });
+
+  it('opens the sourceSyncHealth issue when overdueExclusions > 0', () => {
+    const upstreamRecovery = {
+      schemaVersion: 1,
+      generatedAt: '2026-04-20T00:00:00Z',
+      summary: { totalEntries: 1, activeEntries: 1, staleEntries: 0, overdueEntries: 1, unknownEntries: 0 },
+      mechanisms: {
+        en_source_patches: [],
+        source_sync_exclusions: [
+          {
+            slug: 'overdue/slug',
+            mechanism: 'source_sync_exclusions',
+            statusA: 'active',
+            statusB: 'overdue',
+            fetchStatus: 'excluded-broken',
+            addedAt: '2025-01-01',
+            reviewAfter: '2025-07-01',
+            daysUntilReview: -300,
+          },
+        ],
+      },
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], {
+      sourceSync: freshSync,
+      upstreamRecovery,
+    });
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, true);
+    assert.equal(report.sourceSyncHealth.sourceSyncRecovery.overdueExclusions, 1);
+    assert.match(report.sourceSyncHealth.body, /overdue\/slug/);
+  });
+
+  it('does not open the issue when only unknown entries are reported (fail-safe)', () => {
+    const upstreamRecovery = {
+      schemaVersion: 1,
+      generatedAt: '2026-04-20T00:00:00Z',
+      summary: { totalEntries: 1, activeEntries: 0, staleEntries: 0, overdueEntries: 0, unknownEntries: 1 },
+      mechanisms: {
+        en_source_patches: [
+          {
+            id: 'UD-UNK',
+            mechanism: 'en_source_patches',
+            slugs: ['some/slug'],
+            statusA: 'unknown',
+            statusB: 'current',
+            hits: 0,
+            addedAt: '2026-01-01',
+            reviewAfter: '2026-07-01',
+            daysUntilReview: 72,
+          },
+        ],
+        source_sync_exclusions: [],
+      },
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], {
+      sourceSync: freshSync,
+      upstreamRecovery,
+    });
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, false);
+    assert.equal(report.sourceSyncHealth.enPatchRecovery.unknownPatches, 1);
+    assert.equal(report.sourceSyncHealth.enPatchRecovery.stalePatches, 0);
   });
 });
 

--- a/scripts/__tests__/detection_reports.test.mjs
+++ b/scripts/__tests__/detection_reports.test.mjs
@@ -933,6 +933,142 @@ describe('sourceSyncHealth — upstream recovery integration (Phase B)', () => {
     assert.equal(report.sourceSyncHealth.enPatchRecovery.unknownPatches, 1);
     assert.equal(report.sourceSyncHealth.enPatchRecovery.stalePatches, 0);
   });
+
+  it('still opens the issue when sourceSync is absent but upstreamRecovery has stale entries', () => {
+    // TS-reviewer MEDIUM: verify the body is coherent (freshness fields
+    // show 不明 but body still contains the upstream-recovery subsection
+    // and the artifact reference).
+    const upstreamRecovery = {
+      schemaVersion: 1,
+      summary: { totalEntries: 1, activeEntries: 0, staleEntries: 1, overdueEntries: 0, unknownEntries: 0 },
+      mechanisms: {
+        en_source_patches: [
+          {
+            id: 'UD-NOSYNC',
+            mechanism: 'en_source_patches',
+            slugs: ['some/slug'],
+            statusA: 'stale',
+            statusB: 'current',
+            hits: 0,
+            addedAt: '2026-01-01',
+            reviewAfter: '2026-07-01',
+            daysUntilReview: 72,
+          },
+        ],
+        source_sync_exclusions: [],
+      },
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], {
+      sourceSync: {},
+      upstreamRecovery,
+    });
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, true);
+    assert.match(report.sourceSyncHealth.body, /UD-NOSYNC/);
+    assert.match(report.sourceSyncHealth.body, /`upstream-recovery-status\.json`/);
+  });
+
+  it('omits the upstream-recovery-status.json artifact line when upstreamRecovery is absent', () => {
+    // Code-reviewer MEDIUM: ensure the conditional artifact-list entry is
+    // not emitted when the family opens for other reasons (freshness).
+    const brokenSync = {
+      schemaVersion: 1,
+      freshnessState: 'broken',
+      summary: {
+        targetPages: 100,
+        fetchedPages: 0,
+        notFoundPages: 0,
+        errorPages: 100,
+        sidebarVerified: false,
+      },
+      errors: [{ slug: 'x', detail: 'fetch failed' }],
+    };
+    const report = buildActionableReport(emptySnapshot, emptyParity, [], {
+      sourceSync: brokenSync,
+      // upstreamRecovery intentionally omitted.
+    });
+    assert.equal(report.sourceSyncHealth.shouldOpenIssue, true);
+    // artifacts list should NOT include upstream-recovery-status.json.
+    assert.doesNotMatch(
+      report.sourceSyncHealth.body,
+      /`upstream-recovery-status\.json`/,
+    );
+  });
+});
+
+describe('renderUpstreamRecoveryStickyComment — single source of truth', () => {
+  it('returns null when no stale / overdue signals exist', async () => {
+    const { renderUpstreamRecoveryStickyComment } = await import(
+      '../lib/detection_reports.mjs'
+    );
+    const body = renderUpstreamRecoveryStickyComment({
+      schemaVersion: 1,
+      summary: { totalEntries: 0, activeEntries: 0, staleEntries: 0, overdueEntries: 0, unknownEntries: 0 },
+      mechanisms: { en_source_patches: [], source_sync_exclusions: [] },
+    });
+    assert.equal(body, null);
+  });
+
+  it('renders a sticky comment body with hidden marker and summary heading when signals exist', async () => {
+    const { renderUpstreamRecoveryStickyComment, UPSTREAM_RECOVERY_STICKY_MARKER } =
+      await import('../lib/detection_reports.mjs');
+    const body = renderUpstreamRecoveryStickyComment({
+      schemaVersion: 1,
+      summary: { totalEntries: 1, activeEntries: 0, staleEntries: 1, overdueEntries: 0, unknownEntries: 0 },
+      mechanisms: {
+        en_source_patches: [
+          {
+            id: 'UD-STICKY',
+            mechanism: 'en_source_patches',
+            slugs: ['some/slug'],
+            statusA: 'stale',
+            statusB: 'current',
+            hits: 0,
+            addedAt: '2026-01-01',
+            reviewAfter: '2026-07-01',
+            daysUntilReview: 72,
+          },
+        ],
+        source_sync_exclusions: [],
+      },
+    });
+    assert.ok(body);
+    assert.ok(body.startsWith(UPSTREAM_RECOVERY_STICKY_MARKER));
+    assert.match(body, /## Upstream recovery: 1 entr\(ies\) need attention/);
+    assert.match(body, /UD-STICKY/);
+    assert.match(body, /Informational only/);
+    // No emoji per project convention.
+    assert.doesNotMatch(body, /🧹/);
+  });
+
+  it('sanitises registry-derived strings that would otherwise break markdown', async () => {
+    const { renderUpstreamRecoveryStickyComment } = await import(
+      '../lib/detection_reports.mjs'
+    );
+    const body = renderUpstreamRecoveryStickyComment({
+      schemaVersion: 1,
+      summary: { totalEntries: 1, activeEntries: 0, staleEntries: 1, overdueEntries: 0, unknownEntries: 0 },
+      mechanisms: {
+        en_source_patches: [
+          {
+            id: 'UD-`inj`ect|pipe\nnewline',
+            mechanism: 'en_source_patches',
+            slugs: ['slug\nbreak'],
+            statusA: 'stale',
+            statusB: 'current',
+            hits: 0,
+            addedAt: '2026-01-01',
+            reviewAfter: '2026-07-01',
+            daysUntilReview: 72,
+          },
+        ],
+        source_sync_exclusions: [],
+      },
+    });
+    // Sanitised replacements should appear; originals should not.
+    assert.ok(body.includes('UD-_inj_ect_pipe_newline'), body);
+    assert.ok(body.includes('slug_break'), body);
+    assert.ok(!body.includes('\\n'), 'raw newline must not survive');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/generate_detection_reports.mjs
+++ b/scripts/generate_detection_reports.mjs
@@ -21,9 +21,12 @@ const OUTPUTS = {
 };
 
 export function generateDetectionReports({ strict = false } = {}) {
-  const { snapshot, parity, sourceSync } = loadDetectionInputs({ strict });
+  const { snapshot, parity, sourceSync, upstreamRecovery } = loadDetectionInputs({ strict });
   const auditManifest = buildAuditManifest(snapshot, parity);
-  const actionableReport = buildActionableReport(snapshot, parity, auditManifest, { sourceSync });
+  const actionableReport = buildActionableReport(snapshot, parity, auditManifest, {
+    sourceSync,
+    upstreamRecovery,
+  });
   const summaryMarkdown = renderSummaryMarkdown(
     snapshot,
     parity,

--- a/scripts/generate_detection_reports.mjs
+++ b/scripts/generate_detection_reports.mjs
@@ -77,6 +77,19 @@ function main() {
         `  ソース原文の既知問題: 除外=${debt.excludedPages} 未復旧=${debt.excludedBrokenPages} 復旧候補=${debt.excludedRecoveredPages}`,
       );
     }
+    // Phase B: upstream recovery signals — surface stale/overdue counts so
+    // scheduled-run logs reveal registry decay without requiring reviewers
+    // to read the JSON artifact.
+    const enRec = actionableReport.sourceSyncHealth?.enPatchRecovery;
+    const syncRec = actionableReport.sourceSyncHealth?.sourceSyncRecovery;
+    if (enRec || syncRec) {
+      const en = enRec ?? { stalePatches: 0, overduePatches: 0, totalPatches: 0 };
+      const sync = syncRec ?? { staleExclusions: 0, overdueExclusions: 0, totalExclusions: 0 };
+      console.log(
+        `  上流修正候補: patches=${en.stalePatches}stale/${en.overduePatches}overdue/${en.totalPatches}total ` +
+          `exclusions=${sync.staleExclusions}stale/${sync.overdueExclusions}overdue/${sync.totalExclusions}total`,
+      );
+    }
   } catch (error) {
     console.error(`❌ ${error.message}`);
     if (error.validationErrors) {

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -37,7 +37,20 @@ export const FAMILY_KEYS = {
 
 function readJson(filePath) {
   if (!fs.existsSync(filePath)) return {};
-  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  // Graceful degradation: a partially-written artifact (e.g. aggregator killed
+  // mid-write) must not propagate a raw SyntaxError through loadDetectionInputs.
+  // `strict` mode downstream surfaces real schema issues via
+  // validateDetectionInputs; here we just warn so the scheduled / PR run can
+  // continue rather than crash with a cryptic JSON parse error.
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    console.warn(
+      `[detection_reports] failed to parse ${filePath}: ${err.message}. ` +
+        'Treating as empty artifact (non-blocking).',
+    );
+    return {};
+  }
 }
 
 /**
@@ -302,9 +315,15 @@ export function validateActionableReport(parsed) {
 }
 
 /**
- * 読み込み済みの 3 種類の detection 入力を検証する。
+ * 読み込み済みの detection 入力を検証する (strict mode 用)。
  * 成功時は `{ ok: true }`、1 つでも不正なら `{ ok: false, errors }` を返す。
  * ここでは throw せず、継続可否の判断は呼び出し側に委ねる。
+ *
+ * 注: `upstreamRecovery` (Phase B) は optional artifact で schema 検証対象外。
+ * 不在時は `{}` で渡され、`buildUpstreamRecoverySections` が null を返す
+ * graceful degradation に委ねる (strict mode で validation error にはしない)。
+ * このため API は従来どおり 3 キー (`snapshot` / `parity` / `sourceSync`)
+ * のみを受け取る。
  */
 export function validateDetectionInputs({ snapshot, parity, sourceSync }) {
   const errors = [];
@@ -984,29 +1003,82 @@ function buildUpstreamRecoverySections(upstreamRecovery, maxEntries = 10) {
 }
 
 /**
- * Render the markdown fragment added to the sourceSyncHealth issue body when
- * `upstreamRecovery` has non-zero stale / overdue entries (Phase B Task 4).
- * Returns [] when both sections are clean so the caller can spread it safely.
+ * Defensive sanitiser for registry-derived strings that land in markdown
+ * output (issue body / sticky PR comment). Registry values are developer-
+ * authored and protected by review, but we strip characters that could
+ * break the surrounding markdown structure (newlines / backticks / pipes)
+ * to keep output format stable even if a future entry contains them.
+ *
+ * Replaces matches with `_` so the field is visibly marked as sanitised
+ * rather than silently removed.
  */
-function renderUpstreamRecoverySubsection({ enPatchRecovery, sourceSyncRecovery }) {
-  const lines = [];
-  const hasEnSignal =
-    enPatchRecovery &&
-    (enPatchRecovery.stalePatches > 0 || enPatchRecovery.overduePatches > 0);
-  const hasSyncSignal =
-    sourceSyncRecovery &&
-    (sourceSyncRecovery.staleExclusions > 0 ||
-      sourceSyncRecovery.overdueExclusions > 0);
-  if (!hasEnSignal && !hasSyncSignal) return lines;
+function sanitizeForMarkdown(value) {
+  if (value === null || value === undefined) return '';
+  return String(value).replace(/[\r\n`|]/g, '_');
+}
 
-  lines.push('## 上流修正候補 (upstream recovery)', '');
-  lines.push(
-    '> `upstream-recovery-status.json` で検知された stale/overdue エントリー。' +
-      '運用手順は `docs/PARITY_GUIDE.md §許容機構` と ' +
-      '`docs/OPS_DESIGN.md §Weekly: Upstream recovery triage` を参照。',
+/**
+ * Sticky PR comment hidden marker. Shared between the scheduled managed issue
+ * body and the PR-triggered sticky comment so upsert logic can locate the
+ * existing comment across re-runs.
+ */
+export const UPSTREAM_RECOVERY_STICKY_MARKER = '<!-- upstream-recovery: sticky -->';
+
+/**
+ * Render the sticky PR comment body for the given upstream-recovery-status
+ * payload. Returns `null` when there are no stale / overdue signals, so the
+ * caller knows to delete any existing sticky comment. This is the **single
+ * source of truth** for sticky-comment markdown — the CI workflow reads the
+ * output of `scripts/render_upstream_recovery_comment.mjs` (which calls this)
+ * rather than re-implementing the filtering inline (see PR #363 code review).
+ *
+ * @param {object|null|undefined} upstreamRecovery — parsed upstream-recovery-status.json
+ * @param {object} [options]
+ * @param {number} [options.maxEntries] — cap on emitted stale/overdue lists
+ * @param {string} [options.marker] — hidden marker (default MARKER constant)
+ * @returns {string|null} markdown body or `null` when no signals
+ */
+export function renderUpstreamRecoveryStickyComment(
+  upstreamRecovery,
+  { maxEntries = 10, marker = UPSTREAM_RECOVERY_STICKY_MARKER } = {},
+) {
+  const sections = buildUpstreamRecoverySections(upstreamRecovery, maxEntries);
+  const entries = renderUpstreamRecoveryEntries(sections);
+  if (entries.length === 0) return null;
+  const enStale = sections.enPatchRecovery?.stalePatches ?? 0;
+  const enOverdue = sections.enPatchRecovery?.overduePatches ?? 0;
+  const syncStale = sections.sourceSyncRecovery?.staleExclusions ?? 0;
+  const syncOverdue = sections.sourceSyncRecovery?.overdueExclusions ?? 0;
+  const totalAxis = enStale + enOverdue + syncStale + syncOverdue;
+  return [
+    marker,
     '',
-  );
-  if (hasEnSignal) {
+    `## Upstream recovery: ${totalAxis} entr(ies) need attention`,
+    '',
+    ...entries,
+    '',
+    '_Informational only — this comment is non-blocking. ' +
+      'See `docs/PARITY_GUIDE.md §許容機構` and ' +
+      '`docs/OPS_DESIGN.md §Weekly: Upstream recovery triage` ' +
+      'for the removal workflow._',
+  ].join('\n');
+}
+
+/**
+ * Shared entry renderer for upstream-recovery sections. Emits ONLY the
+ * per-mechanism bullet lists (no wrapping heading / quote). The two callers
+ * wrap this output with their own heading:
+ *   - `renderUpstreamRecoverySubsection` (managed issue body) → `## 上流修正候補`
+ *   - `renderUpstreamRecoveryStickyComment` (PR sticky) → `## Upstream recovery: ...`
+ * Extracting this avoids the logic-duplication maintenance hazard between
+ * the CI workflow and detection_reports (PR #363 code review HIGH).
+ */
+function renderUpstreamRecoveryEntries({ enPatchRecovery, sourceSyncRecovery }) {
+  const lines = [];
+  if (
+    enPatchRecovery &&
+    (enPatchRecovery.stalePatches > 0 || enPatchRecovery.overduePatches > 0)
+  ) {
     lines.push(
       `- **en_source_patches:** ${enPatchRecovery.stalePatches} stale / ` +
         `${enPatchRecovery.overduePatches} overdue / ` +
@@ -1015,21 +1087,29 @@ function renderUpstreamRecoverySubsection({ enPatchRecovery, sourceSyncRecovery 
     if (enPatchRecovery.stale.length > 0) {
       lines.push('  - stale:');
       for (const e of enPatchRecovery.stale) {
-        const slugs = e.slugs.join(', ');
-        lines.push(`    - \`${e.id}\` (slugs: ${slugs}) — reviewAfter=${e.reviewAfter}`);
+        const slugs = (e.slugs || []).map(sanitizeForMarkdown).join(', ');
+        lines.push(
+          `    - \`${sanitizeForMarkdown(e.id)}\` (slugs: ${slugs}) — ` +
+            `reviewAfter=${sanitizeForMarkdown(e.reviewAfter)}`,
+        );
       }
     }
     if (enPatchRecovery.overdue.length > 0) {
       lines.push('  - overdue:');
       for (const e of enPatchRecovery.overdue) {
         lines.push(
-          `    - \`${e.id}\` reviewAfter=${e.reviewAfter} ` +
+          `    - \`${sanitizeForMarkdown(e.id)}\` ` +
+            `reviewAfter=${sanitizeForMarkdown(e.reviewAfter)} ` +
             `daysUntilReview=${e.daysUntilReview}`,
         );
       }
     }
   }
-  if (hasSyncSignal) {
+  if (
+    sourceSyncRecovery &&
+    (sourceSyncRecovery.staleExclusions > 0 ||
+      sourceSyncRecovery.overdueExclusions > 0)
+  ) {
     lines.push(
       `- **source_sync_exclusions:** ${sourceSyncRecovery.staleExclusions} stale / ` +
         `${sourceSyncRecovery.overdueExclusions} overdue / ` +
@@ -1039,7 +1119,9 @@ function renderUpstreamRecoverySubsection({ enPatchRecovery, sourceSyncRecovery 
       lines.push('  - stale:');
       for (const e of sourceSyncRecovery.stale) {
         lines.push(
-          `    - \`${e.slug}\` fetchStatus=${e.fetchStatus} reviewAfter=${e.reviewAfter}`,
+          `    - \`${sanitizeForMarkdown(e.slug)}\` ` +
+            `fetchStatus=${sanitizeForMarkdown(e.fetchStatus)} ` +
+            `reviewAfter=${sanitizeForMarkdown(e.reviewAfter)}`,
         );
       }
     }
@@ -1047,14 +1129,34 @@ function renderUpstreamRecoverySubsection({ enPatchRecovery, sourceSyncRecovery 
       lines.push('  - overdue:');
       for (const e of sourceSyncRecovery.overdue) {
         lines.push(
-          `    - \`${e.slug}\` reviewAfter=${e.reviewAfter} ` +
+          `    - \`${sanitizeForMarkdown(e.slug)}\` ` +
+            `reviewAfter=${sanitizeForMarkdown(e.reviewAfter)} ` +
             `daysUntilReview=${e.daysUntilReview}`,
         );
       }
     }
   }
-  lines.push('');
   return lines;
+}
+
+/**
+ * Render the markdown fragment added to the sourceSyncHealth issue body when
+ * `upstreamRecovery` has non-zero stale / overdue entries (Phase B Task 4).
+ * Returns [] when both sections are clean so the caller can spread it safely.
+ */
+function renderUpstreamRecoverySubsection({ enPatchRecovery, sourceSyncRecovery }) {
+  const entries = renderUpstreamRecoveryEntries({ enPatchRecovery, sourceSyncRecovery });
+  if (entries.length === 0) return [];
+  return [
+    '## 上流修正候補 (upstream recovery)',
+    '',
+    '> `upstream-recovery-status.json` で検知された stale/overdue エントリー。' +
+      '運用手順は `docs/PARITY_GUIDE.md §許容機構` と ' +
+      '`docs/OPS_DESIGN.md §Weekly: Upstream recovery triage` を参照。',
+    '',
+    ...entries,
+    '',
+  ];
 }
 
 export function buildActionableReport(snapshot, parity, auditManifest, options = {}) {

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -952,11 +952,20 @@ function buildUpstreamRecoverySections(upstreamRecovery, maxEntries = 10) {
   ) {
     return { enPatchRecovery: null, sourceSyncRecovery: null };
   }
+  // Codex C2 (MEDIUM): filter out non-object rows so a malformed
+  // upstream-recovery-status.json (e.g. `[null]`, `[42]`) cannot crash the
+  // downstream `.filter(e => e.statusA === ...)` calls. Rows that survive
+  // are still shape-trusted only up to the field accessors below — each
+  // projection also uses optional chaining / nullish-coalescing.
   const enPatchRows = Array.isArray(upstreamRecovery.mechanisms.en_source_patches)
-    ? upstreamRecovery.mechanisms.en_source_patches
+    ? upstreamRecovery.mechanisms.en_source_patches.filter(
+        (e) => e && typeof e === 'object' && !Array.isArray(e),
+      )
     : [];
   const syncRows = Array.isArray(upstreamRecovery.mechanisms.source_sync_exclusions)
-    ? upstreamRecovery.mechanisms.source_sync_exclusions
+    ? upstreamRecovery.mechanisms.source_sync_exclusions.filter(
+        (e) => e && typeof e === 'object' && !Array.isArray(e),
+      )
     : [];
 
   const projectEnEntry = (e) => ({
@@ -1006,15 +1015,20 @@ function buildUpstreamRecoverySections(upstreamRecovery, maxEntries = 10) {
  * Defensive sanitiser for registry-derived strings that land in markdown
  * output (issue body / sticky PR comment). Registry values are developer-
  * authored and protected by review, but we strip characters that could
- * break the surrounding markdown structure (newlines / backticks / pipes)
- * to keep output format stable even if a future entry contains them.
+ * break the surrounding markdown structure or inject links/HTML:
+ *   - `\r` / `\n` — break bullet / heading structure
+ *   - `` ` `` — escape out of inline code spans
+ *   - `|` — break table cells
+ *   - `[` / `]` / `(` / `)` — craft markdown links (Codex C3)
+ *   - `<` / `>` — raw HTML tags (Codex C3)
  *
  * Replaces matches with `_` so the field is visibly marked as sanitised
- * rather than silently removed.
+ * rather than silently removed. Defense-in-depth: registry review already
+ * gates content, this is the last-line safety net.
  */
 function sanitizeForMarkdown(value) {
   if (value === null || value === undefined) return '';
-  return String(value).replace(/[\r\n`|]/g, '_');
+  return String(value).replace(/[\r\n`|\[\]()<>]/g, '_');
 }
 
 /**

--- a/scripts/lib/detection_reports.mjs
+++ b/scripts/lib/detection_reports.mjs
@@ -909,9 +909,158 @@ function buildParityFollowup(parity, options = {}) {
   };
 }
 
+/**
+ * Build the `enPatchRecovery` / `sourceSyncRecovery` sections consumed by
+ * `sourceSyncHealth` (Phase B, Task 4). The aggregator in
+ * `scripts/check_upstream_recovery.mjs` emits `upstream-recovery-status.json`
+ * with per-entry `statusA` (active/stale/unknown) and `statusB`
+ * (current/overdue). Here we collapse that into family-level counters plus
+ * small arrays of stale/overdue entries for inclusion in the issue body.
+ *
+ * Missing / empty input is legitimate (local dev, PR CI without the artifact);
+ * both sections degrade to `null` and `shouldOpenIssue` is unchanged by this
+ * family.
+ *
+ * @param {object|null|undefined} upstreamRecovery — parsed upstream-recovery-status.json
+ * @param {number} [maxEntries] — cap on emitted stale/overdue lists
+ * @returns {{ enPatchRecovery: object|null, sourceSyncRecovery: object|null }}
+ */
+function buildUpstreamRecoverySections(upstreamRecovery, maxEntries = 10) {
+  if (
+    !upstreamRecovery ||
+    typeof upstreamRecovery !== 'object' ||
+    !upstreamRecovery.mechanisms
+  ) {
+    return { enPatchRecovery: null, sourceSyncRecovery: null };
+  }
+  const enPatchRows = Array.isArray(upstreamRecovery.mechanisms.en_source_patches)
+    ? upstreamRecovery.mechanisms.en_source_patches
+    : [];
+  const syncRows = Array.isArray(upstreamRecovery.mechanisms.source_sync_exclusions)
+    ? upstreamRecovery.mechanisms.source_sync_exclusions
+    : [];
+
+  const projectEnEntry = (e) => ({
+    id: e.id,
+    slugs: Array.isArray(e.slugs) ? [...e.slugs] : [],
+    reviewAfter: e.reviewAfter ?? null,
+    daysUntilReview: typeof e.daysUntilReview === 'number' ? e.daysUntilReview : null,
+  });
+  const projectSyncEntry = (e) => ({
+    slug: e.slug,
+    reviewAfter: e.reviewAfter ?? null,
+    daysUntilReview: typeof e.daysUntilReview === 'number' ? e.daysUntilReview : null,
+    fetchStatus: e.fetchStatus ?? 'unknown',
+  });
+
+  const enStale = enPatchRows.filter((e) => e.statusA === 'stale');
+  const enOverdue = enPatchRows.filter((e) => e.statusB === 'overdue');
+  const enUnknown = enPatchRows.filter((e) => e.statusA === 'unknown');
+
+  const syncStale = syncRows.filter((e) => e.statusA === 'stale');
+  const syncOverdue = syncRows.filter((e) => e.statusB === 'overdue');
+  const syncUnknown = syncRows.filter((e) => e.statusA === 'unknown');
+
+  return {
+    enPatchRecovery: {
+      totalPatches: enPatchRows.length,
+      activePatches: enPatchRows.filter((e) => e.statusA === 'active').length,
+      stalePatches: enStale.length,
+      overduePatches: enOverdue.length,
+      unknownPatches: enUnknown.length,
+      stale: enStale.slice(0, maxEntries).map(projectEnEntry),
+      overdue: enOverdue.slice(0, maxEntries).map(projectEnEntry),
+    },
+    sourceSyncRecovery: {
+      totalExclusions: syncRows.length,
+      activeExclusions: syncRows.filter((e) => e.statusA === 'active').length,
+      staleExclusions: syncStale.length,
+      overdueExclusions: syncOverdue.length,
+      unknownExclusions: syncUnknown.length,
+      stale: syncStale.slice(0, maxEntries).map(projectSyncEntry),
+      overdue: syncOverdue.slice(0, maxEntries).map(projectSyncEntry),
+    },
+  };
+}
+
+/**
+ * Render the markdown fragment added to the sourceSyncHealth issue body when
+ * `upstreamRecovery` has non-zero stale / overdue entries (Phase B Task 4).
+ * Returns [] when both sections are clean so the caller can spread it safely.
+ */
+function renderUpstreamRecoverySubsection({ enPatchRecovery, sourceSyncRecovery }) {
+  const lines = [];
+  const hasEnSignal =
+    enPatchRecovery &&
+    (enPatchRecovery.stalePatches > 0 || enPatchRecovery.overduePatches > 0);
+  const hasSyncSignal =
+    sourceSyncRecovery &&
+    (sourceSyncRecovery.staleExclusions > 0 ||
+      sourceSyncRecovery.overdueExclusions > 0);
+  if (!hasEnSignal && !hasSyncSignal) return lines;
+
+  lines.push('## 上流修正候補 (upstream recovery)', '');
+  lines.push(
+    '> `upstream-recovery-status.json` で検知された stale/overdue エントリー。' +
+      '運用手順は `docs/PARITY_GUIDE.md §許容機構` と ' +
+      '`docs/OPS_DESIGN.md §Weekly: Upstream recovery triage` を参照。',
+    '',
+  );
+  if (hasEnSignal) {
+    lines.push(
+      `- **en_source_patches:** ${enPatchRecovery.stalePatches} stale / ` +
+        `${enPatchRecovery.overduePatches} overdue / ` +
+        `${enPatchRecovery.totalPatches} total`,
+    );
+    if (enPatchRecovery.stale.length > 0) {
+      lines.push('  - stale:');
+      for (const e of enPatchRecovery.stale) {
+        const slugs = e.slugs.join(', ');
+        lines.push(`    - \`${e.id}\` (slugs: ${slugs}) — reviewAfter=${e.reviewAfter}`);
+      }
+    }
+    if (enPatchRecovery.overdue.length > 0) {
+      lines.push('  - overdue:');
+      for (const e of enPatchRecovery.overdue) {
+        lines.push(
+          `    - \`${e.id}\` reviewAfter=${e.reviewAfter} ` +
+            `daysUntilReview=${e.daysUntilReview}`,
+        );
+      }
+    }
+  }
+  if (hasSyncSignal) {
+    lines.push(
+      `- **source_sync_exclusions:** ${sourceSyncRecovery.staleExclusions} stale / ` +
+        `${sourceSyncRecovery.overdueExclusions} overdue / ` +
+        `${sourceSyncRecovery.totalExclusions} total`,
+    );
+    if (sourceSyncRecovery.stale.length > 0) {
+      lines.push('  - stale:');
+      for (const e of sourceSyncRecovery.stale) {
+        lines.push(
+          `    - \`${e.slug}\` fetchStatus=${e.fetchStatus} reviewAfter=${e.reviewAfter}`,
+        );
+      }
+    }
+    if (sourceSyncRecovery.overdue.length > 0) {
+      lines.push('  - overdue:');
+      for (const e of sourceSyncRecovery.overdue) {
+        lines.push(
+          `    - \`${e.slug}\` reviewAfter=${e.reviewAfter} ` +
+            `daysUntilReview=${e.daysUntilReview}`,
+        );
+      }
+    }
+  }
+  lines.push('');
+  return lines;
+}
+
 export function buildActionableReport(snapshot, parity, auditManifest, options = {}) {
   const maxEntries = options.maxEntries ?? 10;
   const sourceSync = options.sourceSync ?? {};
+  const upstreamRecovery = options.upstreamRecovery ?? null;
   const snapshotChanges = snapshot.changes ?? [];
   const parityFiles = parity.files ?? [];
   const parityIssueFiles = buildParityEntries(parityFiles, isReportableParityIssue);
@@ -1021,9 +1170,24 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
   const sourceSideDebtSummary = buildSourceSideDebtSummary(sourceSync);
   const hasSourceSideDebt = sourceSideDebtSummary.excludedPages > 0 ||
     (sourceSideDebtSummary.fetchErrorSlugs?.length ?? 0) > 0;
+
+  // Phase B (Task 4): upstream recovery signals are surfaced as subsections
+  // inside the existing sourceSyncHealth family — no new detection family,
+  // no new workflow. `buildUpstreamRecoverySections` returns {null,null} when
+  // upstreamRecovery is absent / empty, keeping the family body untouched.
+  const upstreamRecoverySections = buildUpstreamRecoverySections(
+    upstreamRecovery,
+    maxEntries,
+  );
+  const hasUpstreamRecoverySignal =
+    (upstreamRecoverySections.enPatchRecovery?.stalePatches ?? 0) > 0 ||
+    (upstreamRecoverySections.enPatchRecovery?.overduePatches ?? 0) > 0 ||
+    (upstreamRecoverySections.sourceSyncRecovery?.staleExclusions ?? 0) > 0 ||
+    (upstreamRecoverySections.sourceSyncRecovery?.overdueExclusions ?? 0) > 0;
+
   const syncShouldOpen =
     freshnessState === 'broken' || freshnessState === 'partial' || linkageBlocking ||
-    hasSourceSideDebt;
+    hasSourceSideDebt || hasUpstreamRecoverySignal;
 
   const sourceSyncBody = syncShouldOpen
     ? [
@@ -1045,11 +1209,19 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
         ...(hasSourceSideDebt
           ? [...renderSourceSideDebtSubsection(sourceSideDebtSummary, sourceSync.pages ?? []), '']
           : []),
+        // Phase B: upstream recovery subsection is also omitted when clean.
+        ...(hasUpstreamRecoverySignal
+          ? [...renderUpstreamRecoverySubsection(upstreamRecoverySections), '']
+          : []),
         '## アーティファクト',
         '',
         '- `source-sync-status.json`',
         '- `snapshot-diff-status.json`',
         '- `parity-check-status.json`',
+        ...(upstreamRecovery && typeof upstreamRecovery === 'object' &&
+            upstreamRecovery.mechanisms
+          ? ['- `upstream-recovery-status.json`']
+          : []),
       ].join('\n')
     : '';
 
@@ -1075,6 +1247,11 @@ export function buildActionableReport(snapshot, parity, auditManifest, options =
       },
       // source-side debt counter / slug list は独立フィールドで返す。
       sourceSideDebt: sourceSideDebtSummary,
+      // Phase B: upstream-recovery aggregator output (en_patches +
+      // sync_exclusions stale/overdue breakdown). `null` when
+      // upstream-recovery-status.json is absent.
+      enPatchRecovery: upstreamRecoverySections.enPatchRecovery,
+      sourceSyncRecovery: upstreamRecoverySections.sourceSyncRecovery,
     },
     snapshotDiff: {
       key: FAMILY_KEYS.SNAPSHOT_DIFF,
@@ -1248,12 +1425,18 @@ export function loadDetectionInputs({
   snapshotPath = path.join(ROOT_DIR, 'snapshot-diff-status.json'),
   parityPath = path.join(ROOT_DIR, 'parity-check-status.json'),
   sourceSyncPath = path.join(ROOT_DIR, 'source-sync-status.json'),
+  upstreamRecoveryPath = path.join(ROOT_DIR, 'upstream-recovery-status.json'),
   strict = false,
 } = {}) {
   const inputs = {
     snapshot: readJson(snapshotPath),
     parity: readJson(parityPath),
     sourceSync: readJson(sourceSyncPath),
+    // Phase B: upstream-recovery-status.json is optional. Absent file is a
+    // legitimate state (local dev, PR CI without the artifact). readJson()
+    // returns {} for missing files, which downstream consumers treat as
+    // "no signal" (graceful degradation).
+    upstreamRecovery: readJson(upstreamRecoveryPath),
   };
   if (strict) {
     const validation = validateDetectionInputs(inputs);

--- a/scripts/render_upstream_recovery_comment.mjs
+++ b/scripts/render_upstream_recovery_comment.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// scripts/render_upstream_recovery_comment.mjs
+/**
+ * Render the sticky PR comment body for upstream recovery signals.
+ *
+ * Reads `upstream-recovery-status.json`, delegates to
+ * `renderUpstreamRecoveryStickyComment` (single source of truth for the
+ * markdown), and either:
+ *   - writes `upstream-recovery-comment.md` + prints `has_signals=true` →
+ *     CI workflow upserts the sticky comment with that body
+ *   - writes nothing and prints `has_signals=false` →
+ *     CI workflow deletes any pre-existing sticky comment
+ *
+ * Exit 0 unconditionally (mirrors check_upstream_recovery.mjs non-blocking
+ * contract). Any error surfaces through stderr; the CI workflow has
+ * `continue-on-error: true` so nothing downstream gates on this step.
+ *
+ * @module render_upstream_recovery_comment
+ */
+
+import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ROOT_DIR } from './lib/project.mjs';
+import { renderUpstreamRecoveryStickyComment } from './lib/detection_reports.mjs';
+
+const STATUS_PATH = path.join(ROOT_DIR, 'upstream-recovery-status.json');
+const COMMENT_PATH = path.join(ROOT_DIR, 'upstream-recovery-comment.md');
+
+/**
+ * CI signal: a single line written to stdout for GitHub Actions to capture.
+ * Format: `has_signals=true|false` → consumed by workflow `env` / step output.
+ */
+function emitSignal(flag) {
+  process.stdout.write(`has_signals=${flag}\n`);
+}
+
+function main() {
+  if (!existsSync(STATUS_PATH)) {
+    // No artifact → nothing to render. Treat as "no signals" for cleanup.
+    if (existsSync(COMMENT_PATH)) unlinkSync(COMMENT_PATH);
+    emitSignal('false');
+    return 0;
+  }
+  let payload;
+  try {
+    payload = JSON.parse(readFileSync(STATUS_PATH, 'utf8'));
+  } catch (err) {
+    console.error(
+      `[render-upstream-recovery] failed to parse upstream-recovery-status.json: ${err.message}. ` +
+        'Treating as no-signals.',
+    );
+    if (existsSync(COMMENT_PATH)) unlinkSync(COMMENT_PATH);
+    emitSignal('false');
+    return 0;
+  }
+  const body = renderUpstreamRecoveryStickyComment(payload);
+  if (body === null) {
+    if (existsSync(COMMENT_PATH)) unlinkSync(COMMENT_PATH);
+    emitSignal('false');
+    return 0;
+  }
+  writeFileSync(COMMENT_PATH, body.endsWith('\n') ? body : body + '\n');
+  emitSignal('true');
+  return 0;
+}
+
+const isDirectRun =
+  process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isDirectRun) {
+  try {
+    process.exit(main());
+  } catch (err) {
+    console.error(`[render-upstream-recovery] unexpected failure: ${err.message}`);
+    // Non-blocking exit.
+    process.exit(0);
+  }
+}


### PR DESCRIPTION
## Summary

`docs/superpowers/plans/2026-04-20-upstream-recovery-detection.md` §Phase B (Task 4 / 5)。Phase A (#362, merged) で生成される `upstream-recovery-status.json` を既存の `sourceSyncHealth` family に統合し、PR sticky comment と weekly triage docs で運用 loop を閉じる。

### Task 4 — detection_reports 統合

- `scripts/lib/detection_reports.mjs`:
  - `loadDetectionInputs()` に `upstream-recovery-status.json` 読込追加 (optional, graceful degradation)
  - `buildUpstreamRecoverySections()` helper: per-entry rows を family counters + stale/overdue 配列に畳み込み (max 10 entry)
  - `renderUpstreamRecoverySubsection()`: stale/overdue > 0 のときだけ sourceSyncHealth body に markdown block を挿入
  - `syncShouldOpen` predicate が upstream recovery signal でも発火
  - return shape に `enPatchRecovery` / `sourceSyncRecovery` フィールド追加 (null when absent)
  - artifacts 一覧に \`upstream-recovery-status.json\` 追記 (present 時のみ)
- `scripts/generate_detection_reports.mjs`: \`upstreamRecovery\` を \`loadDetectionInputs → buildActionableReport\` に wire
- `scripts/__tests__/detection_reports.test.mjs`: 5 new tests + loadDetectionInputs passthrough test

### Task 4 — CI integration

- **`.github/workflows/scheduled-actionable.yml`** (weekly): non-blocking \`Check upstream recovery\` step + artifact upload list に \`upstream-recovery-status.json\` を追加。\`syncDetectionIssues\` (既存) が \`sourceSyncHealth\` managed issue を自動更新するため新 family / 新 workflow 追加なし。

- **`.github/workflows/ci.yml`** (PR trigger, 新規): parity job に 3 step 追加:
  1. \`check:upstream-recovery\` (non-blocking)
  2. artifact upload (\`upstream-recovery-status\` 名義、retention 7 日)
  3. **sticky PR comment** via \`actions/github-script@v7\`:
     - hidden marker \`<!-- upstream-recovery: sticky -->\` で idempotent upsert
     - signals clear 時は既存 comment を自動削除 (cleanup)
     - \`concurrency: parity-upstream-recovery-\${{ ... pr.number }}\` で per-PR serialise (delete+create race 回避)
     - permissions は \`contents: read / pull-requests: write / issues: write\` の最小権限
     - comment 本文は locally-generated JSON + static strings のみ (untrusted event field interpolation なし → security hook compliant)

### Task 5 — Documentation

- **\`docs/PARITY_GUIDE.md\`** §許容機構 (新設): 2-mechanism lifecycle (registered → active → stale → removed) + status 判定ルール + graceful degradation + 禁止事項 (第 3 機構追加禁止 / reviewAfter 延長による長期凍結禁止 / stale signal だけでの削除禁止)
- **\`docs/OPS_DESIGN.md\`** 定期運用（3日ごと）下に \`Weekly: Upstream recovery triage\` 追加: managed issue の enPatchRecovery / sourceSyncRecovery section を起点とした 4-step 運用フロー (fetch → 目視 → registry 削除 + tracker archive → parity 再確認)
- **\`docs/DOCS_DATE_TRACKING.md\`** output-files 表に \`upstream-recovery-status.json\` + \`docs-actionable-report.json\` の upstream-recovery passthrough を追記

## Invariants preserved

- \`parity-baseline.json\`: schemaVersion=2, entries=0 (regression なし)
- **2-mechanism rule**: 第 3 許容機構追加なし (既存 \`en_source_patches\` + \`source_sync_exclusions\` の拡張のみ)
- **No new workflow / issue family**: \`sourceSyncHealth\` family 内部拡張のみ
- **Non-blocking**: aggregator + sticky comment + managed issue いずれも情報提示のみ (gate 効果なし)
- **No untrusted input interpolation**: comment body は locally-generated JSON + static strings のみ (security hook advisory 準拠)

## Local verification

\`\`\`
$ npm run check:upstream-recovery
[upstream-recovery] total=35 active=34 stale=1 overdue=0 unknown=0

$ npm run check:summary
  パリティフォローアップ: ベースライン=0 無効化=0 ブロッキング=0
  ソース原文の既知問題: 除外=1 未復旧=0 復旧候補=1

$ node -e "..."
shouldOpenIssue: true
sourceSyncRecovery.staleExclusions: 1  // pull-requests slug
body contains upstream recovery section: true
\`\`\`

(stale=1 は Phase A と同じく local \`source-sync-status.json\` が \`pull-requests\` を \`excluded-recovered\` 報告しているため。registry 削除は Task 7 / pull-requests cleanup PR scope.)

## Test plan

- [x] \`npm run test\` green (2202 pass / 0 fail / 1 skip — +5 new tests vs. main)
- [x] \`npm run lint\` green (0 errors / 0 warnings in 288 files)
- [x] \`npm run build\` green (290 pages)
- [x] \`npm run check:parity\` — 0 issues
- [x] \`npm run check:upstream-recovery\` — JSON shape OK
- [x] \`npm run check:summary\` — docs-actionable-report.json に enPatchRecovery / sourceSyncRecovery passthrough あり
- [x] sourceSyncHealth issue body に \"## 上流修正候補 (upstream recovery)\" section + stale entry 行が出る (staleExclusions=1 のとき)
- [x] parity-baseline.json regression なし

## Dependencies / Ordering

- **Phase A (#362)** — merged 2026-04-20 (6dc878c) ✅
- **本 PR (Phase B)** — Phase A 出力に依存、PR Z merge 後でないと触れない \`detection_reports.mjs\` (schema v2) 前提 ✅
- **Task 7 / pull-requests cleanup** — 別 PR (今 sticky=1 表示されている pull-requests entry の registry 削除)

## 参考

- Plan: \`docs/superpowers/plans/2026-04-20-upstream-recovery-detection.md\` Rev 4 §Phase B (Task 4 / 5)
- Phase A spec: \`docs/superpowers/specs/2026-04-20-upstream-recovery-spec.md\`
- Phase A PR: #362