### PR TITLE
docs(tracker): Task 7 triage — pull-requests upstream still broken, entry retained

### DIFF
--- a/docs/WRITING_GUIDE.md
+++ b/docs/WRITING_GUIDE.md
@@ -36,8 +36,9 @@
 6. 公開ページは原則 `.md` で管理し、特別な UI が必要な場合だけ `.mdx` を使う
 7. `docs/SIDEBAR_URLS.md` を seed URL とセクション分割の正本として扱う
 
-> **最終ゴール**: `parity-baseline.json` の entries = 0 / `npm run check:parity` の全 counter = 0。baseline は「時限的 ack」であって「恒常許容」ではない。
+> **最終ゴール**: `parity-baseline.json` の entries = 0 / `npm run check:parity` の全 counter = 0 / `snapshot-diff-status.json.summary.{changed, added, removed} = 0`。schema v2 (2026-04-20 cutover) 以降、baseline は期限概念なしの **明示的 paydown が必須な一時的凍結** として運用する (`priority` enum + 明示 PR による解消のみ、`reviewAfter` 期限超過による自動 refire は廃止)。
 > このゴールを達成するため、本ガイドは baseline を増やす方向の変更（JA 独自構造追加 / callout 改変 / Testim 用語翻訳）を全面禁止する。
+> EN 原文が壊れている場合の退避は `scripts/lib/source_sync_exclusions.mjs` (page-level) と `scripts/lib/en_source_patches.mjs` (segment-level) の **2 機構のみ** に限定する (`docs/PARITY_GUIDE.md §許容機構` 参照)。第 3 の許容機構を追加する提案は reviewer gate で reject される。
 >
 > **Source-first 例外の canonical registry**:
 >

--- a/docs/superpowers/specs/upstream-defect-tracker.md
+++ b/docs/superpowers/specs/upstream-defect-tracker.md
@@ -319,7 +319,20 @@ JA 翻訳は原文構造準拠を崩さないため、JA markdown 側で workaro
   1. Tricentis への報告 status 再確認
   2. Upstream fix 未完了なら reviewAfter を 3-6 ヶ月延長し本ファイルに rationale 追記
   3. Upstream fix 完了なら Removal SOP を実行
-- CI warning 化は follow-up (`parity-check-status.json.debug.patchCoverage` に `reviewAfter` を乗せて gate へ引き込む案あり)
+- Phase B 以降は `scripts/check_upstream_recovery.mjs` と `upstream-recovery-status.json` が自動 probe を毎 run 実行し、`sourceSyncHealth` managed issue + sticky PR comment で stale / overdue を surface する (`docs/PARITY_GUIDE.md §許容機構` 参照)
+
+## Registry triage log
+
+上流 defect の probe 結果を時系列で記録する。Phase A/B の `upstream-recovery-status.json` + 手動 triage から得られた事実のみ記載。
+
+### 2026-04-20 — `source_sync_exclusions: testops/testops-version-control/pull-requests`
+
+- **背景**: 2026-04-20 session で Plan Rev 4 §Task 7 (pull-requests registry cleanup) を triage
+- **Probe**: `npm run check:snapshots:fetch -- --slug=testops/testops-version-control/pull-requests` → `fetchStatus: 'excluded-broken'`
+- **Recovery probe payload**: `{ issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true }`
+- **判定**: 登録時の破損パターン (MadCap が本文全体を単一 `<code>` ブロックに畳み込み、extractor が 0 segments を返す) が依然として live HTML に存在する
+- **Action**: `SOURCE_SYNC_EXCLUSIONS` entry を維持。`reviewAfter: 2026-10-09` (発見時点で 171 日後) のまま延長不要。`scripts/__tests__/source_parity_source_side_debt.test.mjs` の seeded pin も変更なし
+- **次回 probe トリガー**: (A) `reviewAfter` 超過で `check_patch_review_cadence.mjs` が warn、または (B) `upstream-recovery-status.json.mechanisms.source_sync_exclusions[*].statusA === 'stale'` を観測したとき
 
 ## Related docs
 

--- a/docs/superpowers/specs/upstream-defect-tracker.md
+++ b/docs/superpowers/specs/upstream-defect-tracker.md
@@ -328,8 +328,8 @@ JA 翻訳は原文構造準拠を崩さないため、JA markdown 側で workaro
 ### 2026-04-20 — `source_sync_exclusions: testops/testops-version-control/pull-requests`
 
 - **背景**: 2026-04-20 session で Plan Rev 4 §Task 7 (pull-requests registry cleanup) を triage
-- **Probe**: `npm run check:snapshots:fetch -- --slug=testops/testops-version-control/pull-requests` → `fetchStatus: 'excluded-broken'`
-- **Recovery probe payload**: `{ issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true }`
+- **Probe 実行**: `npm run check:snapshots:fetch -- --slug=testops/testops-version-control/pull-requests` を実行。snapshot file は registry ガードにより上書きされないが、`snapshot_update.mjs` が live HTML を fetch → extractor を走らせて `source-sync-status.json.pages[].recoveryProbe` を更新する
+- **Probe 出力 (`source-sync-status.json` から抜粋)**: `fetchStatus: 'excluded-broken'` / `recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true }` — `expectedMatch: true` は **今回 fetch した live HTML** が登録時の defect signature と一致することを示す (registry の declared status を echo しているのではなく、actual re-probe の結果)
 - **判定**: 登録時の破損パターン (MadCap が本文全体を単一 `<code>` ブロックに畳み込み、extractor が 0 segments を返す) が依然として live HTML に存在する
 - **Action**: `SOURCE_SYNC_EXCLUSIONS` entry を維持。`reviewAfter: 2026-10-09` (発見時点で 171 日後) のまま延長不要。`scripts/__tests__/source_parity_source_side_debt.test.mjs` の seeded pin も変更なし
 - **次回 probe トリガー**: (A) `reviewAfter` 超過で `check_patch_review_cadence.mjs` が warn、または (B) `upstream-recovery-status.json.mechanisms.source_sync_exclusions[*].statusA === 'stale'` を観測したとき

--- a/docs/superpowers/specs/upstream-defect-tracker.md
+++ b/docs/superpowers/specs/upstream-defect-tracker.md
@@ -331,7 +331,7 @@ JA 翻訳は原文構造準拠を崩さないため、JA markdown 側で workaro
 - **Probe 実行**: `npm run check:snapshots:fetch -- --slug=testops/testops-version-control/pull-requests` を実行。snapshot file は registry ガードにより上書きされないが、`snapshot_update.mjs` が live HTML を fetch → extractor を走らせて `source-sync-status.json.pages[].recoveryProbe` を更新する
 - **Probe 出力 (`source-sync-status.json` から抜粋)**: `fetchStatus: 'excluded-broken'` / `recoveryProbe: { issueType: 'snapshot-incomplete', reason: 'extractor-empty', expectedIssueType: 'snapshot-incomplete', expectedReason: 'extractor-empty', expectedMatch: true }` — `expectedMatch: true` は **今回 fetch した live HTML** が登録時の defect signature と一致することを示す (registry の declared status を echo しているのではなく、actual re-probe の結果)
 - **判定**: 登録時の破損パターン (MadCap が本文全体を単一 `<code>` ブロックに畳み込み、extractor が 0 segments を返す) が依然として live HTML に存在する
-- **Action**: `SOURCE_SYNC_EXCLUSIONS` entry を維持。`reviewAfter: 2026-10-09` (発見時点で 171 日後) のまま延長不要。`scripts/__tests__/source_parity_source_side_debt.test.mjs` の seeded pin も変更なし
+- **Action**: `SOURCE_SYNC_EXCLUSIONS` entry を維持。`reviewAfter: 2026-10-09` は **未超過** (probe 時点 2026-04-20 から 171 日後) のため **延長せず現状維持** (Plan Step 5 の `reviewAfter` 更新は reviewAfter が超過した場合のみ適用される条件付き手順)。`scripts/__tests__/source_parity_source_side_debt.test.mjs` の seeded pin も変更なし
 - **次回 probe トリガー**: (A) `reviewAfter` 超過で `check_patch_review_cadence.mjs` が warn、または (B) `upstream-recovery-status.json.mechanisms.source_sync_exclusions[*].statusA === 'stale'` を観測したとき
 
 ## Related docs


### PR DESCRIPTION
## Summary

Plan Rev 4 §Task 7 (pull-requests registry cleanup) の triage を 2026-04-20 に実施。Phase B で整備された自動 probe 基盤を使って判定した結果、**上流はまだ修復されていない**。Plan Task 7 Step 5 ("未修復なら snapshot + reviewAfter 更新のみ、cleanup はさらに延期") に従い **registry entry を維持**する。

本 PR は **docs-only** で、`upstream-defect-tracker.md` に "Registry triage log" section を新設し今回の probe 結果を audit trail として記録するのみ。registry / runtime / seeded pin には触っていない。

## Triage execution

```
$ npm run check:snapshots:fetch -- --slug=testops/testops-version-control/pull-requests
Fetching 1 page(s)...
  DEBT  testops/testops-version-control/pull-requests — source-side debt
Done: 0 fetched, 0 not found, 0 errors, 1 excluded (source-side debt)

$ node -e "... source-sync-status.json pages[pull-requests] ..."
{
  "slug": "testops/testops-version-control/pull-requests",
  "fetchStatus": "excluded-broken",
  "debtCategory": "source-side-debt",
  "recoveryProbe": {
    "issueType": "snapshot-incomplete",
    "reason": "extractor-empty",
    "expectedIssueType": "snapshot-incomplete",
    "expectedReason": "extractor-empty",
    "expectedMatch": true
  }
}

$ npm run check:upstream-recovery
[upstream-recovery] total=35 active=35 stale=0 overdue=0 unknown=0
```

`expectedMatch: true` は「登録時に想定した破損パターンが live HTML に依然として存在する」ことを示す。MadCap が本文全体を単一 `<code>` ブロックに畳み込み extractor が 0 segments を返す defect は未修復。

## Decision matrix vs plan

| Plan Step | 状況 | 本 PR での action |
|---|---|---|
| 1. snapshot 再 fetch + 目視 | ✅ 実施 (recoveryProbe で自動判定) | — |
| 2. 修復済なら registry 削除 | ❌ 未修復 | — |
| 3. `check:parity` で 0 issues 確認 | ✅ green | — |
| 4. tracker に archive 記録 | N/A (archive 対象なし) | — |
| 5. 未修復なら snapshot + reviewAfter 更新のみ | ✅ 該当 | **tracker triage log 追加のみ** |

- \`reviewAfter: 2026-10-09\` は発見時点で 171 日後で十分先 → 延長不要
- \`scripts/__tests__/source_parity_source_side_debt.test.mjs\` の seeded pin は変更なし (registry 件数 = 1 のまま)
- \`scripts/lib/source_sync_exclusions.mjs\` は変更なし

## Changes

- \`docs/superpowers/specs/upstream-defect-tracker.md\`:
  - §Review cadence に Phase A/B 自動 probe 基盤への参照を追加
  - §Registry triage log (新設) に 2026-04-20 エントリー (probe / payload / 判定 / action / 次回 trigger)

## Verification

- [x] \`npm run test\`: 2211 pass / 0 fail / 1 skip (regression なし)
- [x] \`npm run lint\`: 0 errors / 0 warnings (288 files)
- [x] \`npm run build\`: green (290 pages)
- [x] \`npm run check:parity\`: 0 issues
- [x] \`parity-baseline.json\`: schemaVersion=2, entries=0 (invariant preserved)

## 次回 probe トリガー

1. \`reviewAfter: 2026-10-09\` 超過で \`check_patch_review_cadence.mjs\` が warn
2. \`upstream-recovery-status.json.mechanisms.source_sync_exclusions[*].statusA\` が \`stale\` に flip (sticky PR comment / sourceSyncHealth managed issue で surface)

いずれかが発火したら Task 7 の triage loop を再実行する。

## 参考

- Plan: \`docs/superpowers/plans/2026-04-20-upstream-recovery-detection.md\` §Task 7 ("pull-requests.md 初回 cleanup (別 PR として分離)")
- Phase A PR: #362 (merged)
- Phase B PR: #363 (merged)