### PR TITLE
Phase 2: JA segment extractor with nested list flattening (Issue #368)

### DIFF
--- a/docs/PYTHON_MIGRATION_PLAN.md
+++ b/docs/PYTHON_MIGRATION_PLAN.md
@@ -542,16 +542,39 @@ def handle_paragraph(tokens: list, start: int, state: WalkState) -> int:
   proper kind に分類してから JA emitter で再 emit する。Phase 1 で port 済の
   ``segments_en`` を library として利用する最初の cross-module 契約
 
+### 146 divergent page の pattern 分布 (architect review L2)
+
+Python が mjs より少ない segment を emit する 146 ページは、以下 3 パターンの
+いずれか (または複数) が該当する。Phase 3 reviewer が「想定内 flatten」と
+「新規 regression」を一目で区別できるよう具体例を載せる:
+
+| Pattern | 対象ページ例 | 説明 |
+| --- | --- | --- |
+| **nested unordered list** | `administration/project-user-management.md`, `settings/cli-settings.md` | `- outer\n  - inner` 形式。nested items の text が親 item に merge |
+| **loose list (indented continuation)** | `administration/encrypted-credentials.md` | `1. step\n\n   continuation paragraph\n\n2. next` 形式。blank 行 + indent の continuation が親 item に吸収 |
+| **indented markdown table inside list** | 一部 API docs | list item 直下の `| a | b |` 行は CommonMark が list content として吸収し、mjs の per-row ``table-cell`` emit は発動しない |
+
+Python extractor は 3 パターンとも CommonMark semantics に沿って正しく処理する。
+mjs line-based 挙動は歴史的な line-regex 起因の bug であり、これらの flatten が
+Issue #368 の core fix。
+
 ### 既知の follow-up (Phase 3 着手前に検討)
 
 - **Boundary stability >= 0.95 の実測**: alignment scoring を Phase 3 で port
   した後、288-page corpus で stability を測定。Phase 2 成果が alignment 層で
   想定通り parity issue を減らすかの final verification
-- **EN walker との flatten 文字列 separator 統一**: Python JA の nested flatten は
-  ``' '.join(inline.content)`` で space separator、EN walker は BS4 text traversal
-  の結果そのままで separator を自動挿入しないケースあり。alignment scoring は
-  weighted-LCS で space 差を吸収するため現状 blocking ではないが、Phase 3 で
-  issue 数を見て separator を揃えるか判断する
+- **EN walker との flatten 文字列 separator 統一** (architect H2): Python JA の
+  nested flatten は ``' '.join(inline.content)`` で space separator、EN walker
+  は BS4 text traversal の結果そのままで separator を自動挿入しないケースあり。
+  alignment scoring は weighted-LCS で space 差を吸収するため現状 blocking では
+  ないが、Phase 3 で issue 数を見て separator を揃えるか判断する。Phase 3 着手
+  時に diagnostic を 1 pass 流して 146 divergent page の textNorm delta を計測し、
+  5% を超えるなら ``segments_shared.create_segment`` の whitespace collapse で
+  両 runtime を揃える
+- **multi-line summary ``lines[i]`` 再処理 pattern の refactor** (python-reviewer
+  MED #1): 現行 ``lines[i] = remainder`` の in-place mutation は immutability
+  convention 違反。``pending: str | None`` slot で explicit に書き直す。挙動
+  変更なしの cleanup なので Phase 4 cutover 前までに対応
 
 ---
 

--- a/docs/PYTHON_MIGRATION_PLAN.md
+++ b/docs/PYTHON_MIGRATION_PLAN.md
@@ -504,12 +504,54 @@ def handle_paragraph(tokens: list, start: int, state: WalkState) -> int:
 
 `collect_list_item_text` が nested markdown を自動フラット化するため、**JA content 変更ゼロで parity 成立**。
 
-### Phase 2 verification gate
+### Phase 2 verification gate ✅ 全通過
 
-- 既存 clean pages (181 files): issue 数が増えない
-- Issue #368 対象 128 files: `segment-missing` / `segment-extra` が 0 に減少
-- Callout 境界テスト: `:::note{title="X"} ... :::` が正しく `callout-body` segment を emit
-- Boundary stability >= 0.95
+- `uv run pytest` pass — **368 tests, 94.96% coverage** (unit 26 + conformance 3 を追加)
+- `uv run ruff check src tests` / `format --check` / `uv run mypy src` — 全 clean
+- `npm run test` pass (mjs 2040/2041、1 skip、0 fail — Phase 1 と同じ)
+- `npm run build` — 290 pages OK
+- JA 288 ページ corpus 実測:
+  - **byte-identical with mjs: 142 pages** (49%、nest-free 領域)
+  - **Python が nested list を flatten する divergent: 146 pages**
+  - total segments: py=11810 vs mjs=12671 → **861 segment が flatten で除去** (Issue #368 対象)
+  - **regression (py > mjs) pages: 0** — conformance test の ``test_ja_corpus_zero_regressions`` で hard guard
+- Callout 境界テスト: `:::note{title="X"} ... :::` を ``callout-body`` として emit する unit test 済 (`TestCallout::test_callout_with_title_attr`)
+- Boundary stability >= 0.95 の measurement は Phase 3 alignment port 後に実施 (Phase 2 単独では alignment scoring 未接続のため)
+
+### Phase 2 実装メモ (2026-04-21)
+
+- **HYBRID の粒度**: mjs line-based state machine を Python に verbatim port
+  し、**list region のみ** markdown-it-py に委譲する構成を採用。plan 当初案の
+  「全面 AST 駆動」よりも byte-identical 領域を最大化 (142/288)、regression
+  リスクを最小化した
+- **list region 収集**: ``_collect_list_region`` が連続する list 行 / 先頭
+  whitespace 行 / blank + continuation を 1 region に纏め、``_flatten_list_region``
+  が ``MarkdownIt("commonmark").parse(region)`` で AST を取得、top-level
+  ``list_item_open``/``list_item_close`` 間だけ emit する (nested は parent
+  の textNorm に ``inline.content`` を space 区切りで混ぜ込む)
+- **loose list 対応**: ``1. item\n\n   continuation paragraph\n\n2. next`` のような
+  blank 行 + indent 3 の continuation も CommonMark 意味論で single item に
+  merge される。mjs line-based 実装は continuation を別 segment として emit
+  するため、意図的 divergent の主要パターンの一つ
+- **code fence inside list**: list region terminator に ``_FENCE_RE`` が含まれ
+  るため、list の途中に ``\`\`\`js`` が来ると region を閉じる。これにより top-
+  level の code fence handler が発火して code-block segment を emit する
+  (意図的 — CommonMark の tight-list 挙動と一致)
+- **loose ``<summary>`` delegation**: ``<details>`` 外の ``<summary>`` は EN walker
+  (``extract_segments_from_html``) に内部 HTML を渡して element children を
+  proper kind に分類してから JA emitter で再 emit する。Phase 1 で port 済の
+  ``segments_en`` を library として利用する最初の cross-module 契約
+
+### 既知の follow-up (Phase 3 着手前に検討)
+
+- **Boundary stability >= 0.95 の実測**: alignment scoring を Phase 3 で port
+  した後、288-page corpus で stability を測定。Phase 2 成果が alignment 層で
+  想定通り parity issue を減らすかの final verification
+- **EN walker との flatten 文字列 separator 統一**: Python JA の nested flatten は
+  ``' '.join(inline.content)`` で space separator、EN walker は BS4 text traversal
+  の結果そのままで separator を自動挿入しないケースあり。alignment scoring は
+  weighted-LCS で space 差を吸収するため現状 blocking ではないが、Phase 3 で
+  issue 数を見て separator を揃えるか判断する
 
 ---
 

--- a/docs/PYTHON_MIGRATION_PLAN.md
+++ b/docs/PYTHON_MIGRATION_PLAN.md
@@ -510,11 +510,11 @@ def handle_paragraph(tokens: list, start: int, state: WalkState) -> int:
 - `uv run ruff check src tests` / `format --check` / `uv run mypy src` — 全 clean
 - `npm run test` pass (mjs 2040/2041、1 skip、0 fail — Phase 1 と同じ)
 - `npm run build` — 290 pages OK
-- JA 288 ページ corpus 実測:
-  - **byte-identical with mjs: 142 pages** (49%、nest-free 領域)
-  - **Python が nested list を flatten する divergent: 146 pages**
-  - total segments: py=11810 vs mjs=12671 → **861 segment が flatten で除去** (Issue #368 対象)
+- JA 288 ページ corpus 実測 (codex review P2 #1 対応後):
+  - **byte-identical with mjs: 141 pages** (49%、nest-free 領域)
+  - **Python が nested list / indented fence / indented image を flatten する divergent: 147 pages**
   - **regression (py > mjs) pages: 0** — conformance test の ``test_ja_corpus_zero_regressions`` で hard guard
+  - byte-identical の page 数は ``_NEST_FREE_CORPUS_SIZE`` 定数で static に pin (architect review H3)。corpus shape が shift した PR で diff が明示される
 - Callout 境界テスト: `:::note{title="X"} ... :::` を ``callout-body`` として emit する unit test 済 (`TestCallout::test_callout_with_title_attr`)
 - Boundary stability >= 0.95 の measurement は Phase 3 alignment port 後に実施 (Phase 2 単独では alignment scoring 未接続のため)
 
@@ -542,9 +542,9 @@ def handle_paragraph(tokens: list, start: int, state: WalkState) -> int:
   proper kind に分類してから JA emitter で再 emit する。Phase 1 で port 済の
   ``segments_en`` を library として利用する最初の cross-module 契約
 
-### 146 divergent page の pattern 分布 (architect review L2)
+### 147 divergent page の pattern 分布 (architect review L2 + codex P2 fix)
 
-Python が mjs より少ない segment を emit する 146 ページは、以下 3 パターンの
+Python が mjs より少ない segment を emit する 147 ページは、以下 4 パターンの
 いずれか (または複数) が該当する。Phase 3 reviewer が「想定内 flatten」と
 「新規 regression」を一目で区別できるよう具体例を載せる:
 
@@ -553,6 +553,7 @@ Python が mjs より少ない segment を emit する 146 ページは、以下
 | **nested unordered list** | `administration/project-user-management.md`, `settings/cli-settings.md` | `- outer\n  - inner` 形式。nested items の text が親 item に merge |
 | **loose list (indented continuation)** | `administration/encrypted-credentials.md` | `1. step\n\n   continuation paragraph\n\n2. next` 形式。blank 行 + indent の continuation が親 item に吸収 |
 | **indented markdown table inside list** | 一部 API docs | list item 直下の `| a | b |` 行は CommonMark が list content として吸収し、mjs の per-row ``table-cell`` emit は発動しない |
+| **indented code fence / image inside list** | `advanced-editing/data-driven-testing/configuring-...md`, `running-tests/play-from-here.md` | list item 内の indented `\`\`\`fence` / `![image]` は parent item の textNorm に flatten される (EN HTML walker の ``collectInlineText`` と等価)。mjs は独立 code-block / image segment として emit するため意図的 divergence (codex review P2 #1 で明示的に pin)。top-level (indent 0) の fence / image は従来通り list region を terminate して独立 segment を emit |
 
 Python extractor は 3 パターンとも CommonMark semantics に沿って正しく処理する。
 mjs line-based 挙動は歴史的な line-regex 起因の bug であり、これらの flatten が

--- a/scripts/py/conformance/harness.mjs
+++ b/scripts/py/conformance/harness.mjs
@@ -32,6 +32,7 @@ import {
   decodeEntities,
   extractSegmentsFromHtml,
 } from '../../lib/source_parity_segments_en.mjs';
+import { extractSegmentsFromMarkdown } from '../../lib/source_parity_segments_ja.mjs';
 import {
   ARTIFACT_REGISTRY,
   createArtifactCoverage,
@@ -315,6 +316,15 @@ const DISPATCH = {
       : {};
     return extractSegmentsFromHtml(html, options);
   },
+
+  // -------- segments_ja --------
+  // Phase 2: JA markdown canonical segment extractor. Byte-identical conformance
+  // is expected for all inputs EXCEPT nested-list patterns — the Python port
+  // intentionally flattens nested <li> text into the top-level item (Issue #368
+  // fix), while mjs emits each nested line as its own segment. Conformance
+  // samples that exercise nested lists go through dedicated Python-only unit
+  // tests; the harness dispatch samples must remain nest-free.
+  segments_ja_extract: ([body]) => extractSegmentsFromMarkdown(body),
 };
 
 async function readStdin() {

--- a/scripts/py/conformance/harness.mjs
+++ b/scripts/py/conformance/harness.mjs
@@ -324,6 +324,10 @@ const DISPATCH = {
   // fix), while mjs emits each nested line as its own segment. Conformance
   // samples that exercise nested lists go through dedicated Python-only unit
   // tests; the harness dispatch samples must remain nest-free.
+  // Consumers: scripts/py/tests/conformance/test_segments_ja_parity.py
+  //   (nest-free byte parity + 288-page corpus regression guard) and
+  //   scripts/py/tests/test_segments_ja.py::TestIssue368NestedListFlattening
+  //   (Python-only flatten behaviour record).
   segments_ja_extract: ([body]) => extractSegmentsFromMarkdown(body),
 };
 

--- a/scripts/py/src/testim_parity/segments_ja.py
+++ b/scripts/py/src/testim_parity/segments_ja.py
@@ -435,12 +435,24 @@ _MD_PARSER = MarkdownIt("commonmark")
 def _is_list_region_terminator(line: str) -> bool:
     """list region を終了させるべき行なら True。
 
-    heading / callout / code fence / HTML table / horizontal rule / details
-    token / standalone image は list 外に出す。逆に blank 行 / 先頭 whitespace
-    のある continuation 行は region に含める。
+    **先頭に whitespace がある行は常に list continuation** として扱う
+    (CommonMark lazy continuation rule)。これにより indent された code fence /
+    heading-looking 行 / image などは parent list item に吸収され、EN HTML
+    walker と同じ粒度で segment が揃う (codex review P2 #1 の対応)。
+
+    top-level (indent 0) 行のみ terminator 判定対象:
+      - heading / callout / code fence / HTML table / horizontal rule
+      - ``<details>`` / ``<summary>`` / ``</details>`` token
+      - standalone image (markdown ``![...](...)``/``<img>``/``<Image>``)
+
+    blank 行は ``_collect_list_region`` 側の lookahead で判定するため、本関数
+    では常に ``False`` を返す。
     """
     stripped = line.strip()
     if stripped == "":
+        return False
+    # Indented line is list item content (lazy continuation); never a terminator.
+    if line and line[0] in (" ", "\t"):
         return False
     for pattern in _LIST_REGION_TERMINATOR_RES:
         if pattern.match(stripped):
@@ -448,11 +460,7 @@ def _is_list_region_terminator(line: str) -> bool:
     if _DETAILS_TERMINATOR_RE.search(line):
         return True
     # standalone image at indent 0
-    return (
-        not line.startswith(" ")
-        and not line.startswith("\t")
-        and _IMAGE_RE.match(stripped) is not None
-    )
+    return _IMAGE_RE.match(stripped) is not None
 
 
 def _collect_list_region(lines: list[str], start: int) -> int:
@@ -516,8 +524,18 @@ def _flatten_list_region(region: str) -> list[tuple[str, str, int | None]]:
 
     ``kind`` は ``"ordered-list-item"`` / ``"unordered-list-item"``。
     ``line_offset`` は region 内の 0-based 行番号 (top-level item の開始行)。
-    ネストされた list item の inline content は親 item の ``raw_text`` にスペース
-    区切りで連結される。
+
+    **top-level ``list_item`` の内容 (inline content + 内部 fence の body) を
+    すべて親 item の ``raw_text`` にスペース区切りで連結する**。ネストされた
+    ``list_item`` / indented code fence / image-only paragraph / 任意の block
+    要素が item 内にあっても、全て同じ segment に flatten される (EN HTML
+    walker の ``collectInlineText`` 挙動と等価)。
+
+    ``fence`` token の ``content`` も拾う理由 (codex review P2 #1): indent
+    された code fence は CommonMark で list item continuation に当たるため、
+    EN 側でも ``<pre>`` の text が親 ``<li>`` の textNorm に連結される。mjs
+    line-based 実装は fence を top-level code-block として別 emit するが、
+    Python 側は EN walker と揃える。
     """
     tokens = _MD_PARSER.parse(region)
     results: list[tuple[str, str, int | None]] = []
@@ -554,6 +572,11 @@ def _flatten_list_region(region: str) -> list[tuple[str, str, int | None]]:
                 current_kind = None
                 current_line = None
             item_depth -= 1
+            continue
+        if tok.type == "fence" and item_depth >= 1:
+            content = tok.content or ""
+            if content.strip():
+                current_parts.append(content.rstrip("\n"))
             continue
         if tok.type == "inline" and item_depth >= 1:
             content = tok.content or ""

--- a/scripts/py/src/testim_parity/segments_ja.py
+++ b/scripts/py/src/testim_parity/segments_ja.py
@@ -518,18 +518,25 @@ def _collect_list_region(lines: list[str], start: int) -> int:
     return last_list_line
 
 
-def _flatten_list_region(region: str) -> tuple[list[tuple[str, str, int | None]], int | None]:
+def _flatten_list_region(
+    region: str,
+) -> tuple[list[tuple[str, str, int | None]], int | None, int | None]:
     """list region 文字列を markdown-it-py で parse して flatten 結果を返す。
 
-    戻り値 ``(items, list_end_line)``:
+    戻り値 ``(items, list_start_line, list_end_line)``:
 
     - ``items``: ``(kind, raw_text, line_offset)`` の list。``kind`` は
       ``"ordered-list-item"`` / ``"unordered-list-item"``、``line_offset`` は
       region 内の 0-based 行番号 (top-level item の開始行)。
+    - ``list_start_line``: region 内で **最初の top-level list が始まる行** の
+      0-based index (inclusive)。prefix (例: 4-space indented fallback
+      marker) が先行していれば ``> 0`` になる。codex review P2 follow-up
+      で prefix を mjs fallback で emit する必要があるため、正確な list
+      境界を伝える。list が 1 つも無ければ ``None``。
     - ``list_end_line``: region 内で **最後の top-level list が閉じた行** の
       0-based index (exclusive)。region にこれ以降の content があれば main
-      loop に戻して非 list content として再処理する (codex review P2 #1
-      follow-up)。list が 1 つも見つからなければ ``None``。
+      loop に戻して非 list content として再処理する。list が 1 つも見つから
+      なければ ``None``。
 
     **top-level ``list_item`` の内容 (inline content + 内部 fence の body) を
     すべて親 item の ``raw_text`` にスペース区切りで連結する**。ネストされた
@@ -550,6 +557,7 @@ def _flatten_list_region(region: str) -> tuple[list[tuple[str, str, int | None]]
     current_parts: list[str] = []
     current_kind: str | None = None
     current_line: int | None = None
+    list_start_line: int | None = None
     list_end_line: int | None = None
 
     for tok in tokens:
@@ -557,7 +565,11 @@ def _flatten_list_region(region: str) -> tuple[list[tuple[str, str, int | None]]
             list_depth += 1
             # top-level list_open の map は list 全体 [start, end_exclusive] を示す。
             # nested list の map は subset なので、top-level のみ追跡する。
+            # 連続する top-level lists (例: nested 無し複数 list) の場合は
+            # 最初の start と最後の end を採用する。
             if list_depth == 1 and tok.map is not None:
+                if list_start_line is None:
+                    list_start_line = tok.map[0]
                 list_end_line = tok.map[1]
             continue
         if tok.type in ("bullet_list_close", "ordered_list_close"):
@@ -593,32 +605,36 @@ def _flatten_list_region(region: str) -> tuple[list[tuple[str, str, int | None]]
             content = tok.content or ""
             if content:
                 current_parts.append(content)
-    return (results, list_end_line)
+    return (results, list_start_line, list_end_line)
 
 
-def _emit_lines_as_mjs_fallback_list(
-    lines_slice: list[str],
+def _emit_single_fallback_list_item(
+    line: str,
     emit: Any,
     section_path: str,
-    base_line_no: int,
+    line_no: int,
 ) -> None:
-    """``_flatten_list_region`` が CommonMark 的に list を認識しなかったときの
-    fall-back: mjs line-based 実装と同じく、list-regex に match する各行を
-    単独の list-item として emit する (codex review P2 #2)。
+    """単一行を mjs line-based 実装と同じ挙動で list-item として emit する。
 
-    該当ケース: ``    - codeish`` のように 4-space indent された list marker
-    行。CommonMark は code block として扱うが、mjs は list-item として emit
-    するため、silent に content を drop しないよう mjs 側と揃える。
+    ``_flatten_list_region`` が CommonMark 的に list を認識しなかったときの
+    fallback (例: ``    - codeish`` のように 4-space indent された list marker
+    は CommonMark では indented code block 扱い)。mjs は ``_UNORDERED_RE`` /
+    ``_ORDERED_RE`` の match で list-item を emit するため、silent に content
+    を drop しないよう mjs 側と揃える (codex review P2 #2)。
+
+    **呼び出し元の契約**: 本関数は 1 行だけ処理する。main loop は ``i`` を 1
+    だけ進めて、次行以降は通常の dispatch に戻す。これにより region に含まれる
+    blank 行 / 非 list paragraph も main loop が正しく扱える (codex follow-up
+    P2 #2: fallback prefix 後の trailing content を dropping しない)。
     """
-    for offset, line in enumerate(lines_slice):
-        ordered_match = _ORDERED_RE.match(line)
-        unordered_match = _UNORDERED_RE.match(line)
-        if ordered_match is None and unordered_match is None:
-            continue
-        match = ordered_match if ordered_match is not None else unordered_match
-        assert match is not None  # for mypy
-        kind = "ordered-list-item" if ordered_match is not None else "unordered-list-item"
-        emit(section_path, kind, match.group(2), base_line_no + offset)
+    ordered_match = _ORDERED_RE.match(line)
+    unordered_match = _UNORDERED_RE.match(line)
+    if ordered_match is None and unordered_match is None:
+        return
+    match = ordered_match if ordered_match is not None else unordered_match
+    assert match is not None  # for mypy
+    kind = "ordered-list-item" if ordered_match is not None else "unordered-list-item"
+    emit(section_path, kind, match.group(2), line_no)
 
 
 # ---------------------------------------------------------------------------
@@ -885,30 +901,43 @@ def extract_segments_from_markdown(body: object) -> list[dict[str, Any]]:
 
         # Ordered / unordered list — Issue #368 fix:
         # 単行 match ではなく **list region 全体** を収集して markdown-it-py に
-        # 渡し、top-level item だけ 1 segment で emit する。
+        # 渡し、top-level item だけ 1 segment で emit する。prefix / suffix の
+        # 非 list 行は main loop に戻して再処理する (codex review P2 follow-up)。
         if _ORDERED_RE.match(line) or _UNORDERED_RE.match(line):
             flush_paragraph()
             end_idx = _collect_list_region(lines, i)
             region_lines = lines[i : end_idx + 1]
             region = "\n".join(region_lines)
-            flattened, list_end_line = _flatten_list_region(region)
+            flattened, list_start_line, list_end_line = _flatten_list_region(region)
             path = build_section_path(heading_stack)
-            if flattened:
+            if flattened and list_end_line is not None:
+                # codex review P2 follow-up: list_start > 0 の場合、prefix には
+                # CommonMark が list と認識しなかった list-regex 行 (例: 4-space
+                # indented fallback marker) が含まれる。それらを mjs-style で
+                # 単行 emit してから、本 list を flatten 結果で emit する。
+                prefix_end = list_start_line if list_start_line is not None else 0
+                for prefix_offset in range(prefix_end):
+                    _emit_single_fallback_list_item(
+                        region_lines[prefix_offset],
+                        emitter.emit,
+                        path,
+                        line_no + prefix_offset,
+                    )
                 for kind, raw_text, row_offset in flattened:
                     resolved_line = line_no + (row_offset or 0)
                     emitter.emit(path, kind, raw_text, resolved_line)
-                # codex review P2 #1 follow-up: markdown-it-py が認識した list
-                # の範囲だけ consume し、残りは main loop に戻して非 list content
-                # として再処理する。1-space indented paragraph や non-indented
-                # trailing content を silent に dropping しない契約。
-                consumed = list_end_line if list_end_line is not None else len(region_lines)
-                i += consumed
+                # list_end_line までを consume し、残り lines は main loop に戻す。
+                # これで 1-space indented paragraph や non-indented trailing
+                # content を silent に drop しない (codex review P2 #1)。
+                i += list_end_line
             else:
-                # CommonMark が list を認識しなかったケース (例: 4-space indent
-                # された list marker は indented code block 扱い)。mjs 等価の
-                # 単行 emit に fall back する (codex review P2 #2)。
-                _emit_lines_as_mjs_fallback_list(region_lines, emitter.emit, path, line_no)
-                i = end_idx + 1
+                # CommonMark が list を認識しなかったケース (例: ``    - codeish``
+                # のみ、続く行が paragraph 等)。現在行だけ mjs-style で emit し、
+                # ``i`` を 1 だけ進めて次行以降は main loop が通常 dispatch で
+                # 処理する。これで trailing non-list content を main loop が拾え
+                # silent drop しない (codex review P2 #2 follow-up)。
+                _emit_single_fallback_list_item(line, emitter.emit, path, line_no)
+                i += 1
             continue
 
         if _HORIZONTAL_RULE_RE.match(trimmed):

--- a/scripts/py/src/testim_parity/segments_ja.py
+++ b/scripts/py/src/testim_parity/segments_ja.py
@@ -67,17 +67,23 @@ from typing import Any
 from markdown_it import MarkdownIt
 
 from .segments_en import extract_segments_from_html
+from .segments_ja_html import (
+    extract_html_table_cells,
+    html_inline_to_markdown_text,
+    scan_for_matching_summary_close,
+    split_table_cells,
+    tokenize_details_line,
+)
 from .segments_shared import build_section_path, create_segment, push_heading
 
 _FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
 _CALLOUT_OPEN_RE = re.compile(r"^:::(note|warning|info|tip|caution|danger)(?:\{[^}]*\})?\s*$")
 _CALLOUT_CLOSE_RE = re.compile(r"^:::\s*$")
+# ``<details>`` / ``<summary>`` token の粗検出用。行内に detailsまわりがあるかを
+# O(1) で判定するためだけに残す。実際の tokenize は
+# ``segments_ja_html.tokenize_details_line`` が担当する。
 _DETAILS_TOKEN_RE = re.compile(r"<\/?details\b|<summary\b", re.IGNORECASE)
-_DETAILS_OPEN_PREFIX_RE = re.compile(r"^<details\b", re.IGNORECASE)
-_DETAILS_CLOSE_PREFIX_RE = re.compile(r"^<\/details\s*>", re.IGNORECASE)
-_SUMMARY_OPEN_PREFIX_RE = re.compile(r"^<summary\b", re.IGNORECASE)
-_SUMMARY_CLOSE_RE = re.compile(r"^<\/summary\s*>", re.IGNORECASE)
 _IMAGE_RE = re.compile(r"^(?:!\[[^\]]*\]\([^)]+\)|<Image\b|<img\b)", re.IGNORECASE)
 _UNORDERED_RE = re.compile(r"^(\s*)[-*+]\s+(.+)$")
 _ORDERED_RE = re.compile(r"^(\s*)\d+\.\s+(.+)$")
@@ -103,283 +109,6 @@ _LIST_REGION_TERMINATOR_RES: tuple[re.Pattern[str], ...] = (
 # details/summary token は別途検出する (行内に出現するため regex match ではなく
 # substring test で拾う)
 _DETAILS_TERMINATOR_RE = _DETAILS_TOKEN_RE
-
-
-def _split_table_cells(line: str) -> list[str]:
-    """pipe table 行を trimmed cell 列に分解する。
-
-    cell 内の backslash-escape された pipe (``\\|``) は phantom column 分割を
-    起こさないよう literal ``|`` として扱う (mjs 等価)。
-    """
-    trimmed = line.strip()
-    if trimmed.startswith("|"):
-        trimmed = trimmed[1:]
-    if trimmed.endswith("|"):
-        trimmed = trimmed[:-1].rstrip()
-    cells: list[str] = []
-    current: list[str] = []
-    i = 0
-    n = len(trimmed)
-    while i < n:
-        ch = trimmed[i]
-        if ch == "\\" and i + 1 < n and trimmed[i + 1] == "|":
-            current.append("|")
-            i += 2
-            continue
-        if ch == "|":
-            cells.append("".join(current).strip())
-            current = []
-            i += 1
-            continue
-        current.append(ch)
-        i += 1
-    cells.append("".join(current).strip())
-    return cells
-
-
-def _find_tag_end(text: str, start: int) -> int:
-    """``start`` 以降で HTML tag の閉じ ``>`` 位置を返す。
-
-    ``<details data-x="1>0">`` のような quoted attribute 内の ``>`` は skip する。
-    見つからなければ ``-1``。mjs ``findTagEnd`` 等価。
-    """
-    quote: str | None = None
-    n = len(text)
-    i = start
-    while i < n:
-        ch = text[i]
-        if quote is not None:
-            if ch == quote:
-                quote = None
-            i += 1
-            continue
-        if ch in ('"', "'"):
-            quote = ch
-            i += 1
-            continue
-        if ch == ">":
-            return i
-        i += 1
-    return -1
-
-
-def _scan_for_matching_summary_close(text: str, start_depth: int) -> tuple[int, int, int]:
-    """``text`` 内を走査して depth が 0 になる ``</summary>`` 位置を返す。
-
-    戻り値は ``(depth, close_pos, close_len)``。matching close が見つからない
-    場合は ``close_pos = -1``、``depth`` は scan 終了時点の depth (multi-line
-    accumulator で carry-forward する)。mjs ``scanForMatchingSummaryClose`` 等価。
-    """
-    depth = start_depth
-    n = len(text)
-    i = 0
-    while i < n:
-        if text[i] != "<":
-            i += 1
-            continue
-        tail = text[i:]
-        # </summary> close 候補
-        close_match = _SUMMARY_CLOSE_RE.match(tail)
-        if close_match:
-            depth -= 1
-            if depth == 0:
-                return (depth, i, len(close_match.group(0)))
-            i += len(close_match.group(0))
-            continue
-        # <summary> nested open
-        if _SUMMARY_OPEN_PREFIX_RE.match(tail):
-            depth += 1
-            tag_end = _find_tag_end(text, i + 1)
-            if tag_end == -1:
-                return (depth, -1, 0)
-            i = tag_end + 1
-            continue
-        # その他の tag — quote-aware に skip
-        if tail.startswith("</") or (len(tail) >= 2 and tail[0] == "<" and tail[1].isalpha()):
-            tag_end = _find_tag_end(text, i + 1)
-            if tag_end == -1:
-                i += 1
-                continue
-            i = tag_end + 1
-            continue
-        # stray '<' — text として scan 継続
-        i += 1
-    return (depth, -1, 0)
-
-
-def _tokenize_details_line(line: str) -> list[dict[str, Any]]:
-    """markdown 1 行を ``<details>`` / ``<summary>`` / ``</details>`` tokens +
-    text span の event 列に分解する (mjs ``tokenizeDetailsLine`` 等価)。
-
-    condensed 1-liner ``Lead <details><summary>Q</summary></details> tail`` を
-    左→右で正しい順序で emit するために必要。quote-aware な ``_find_tag_end``
-    経由で ``data-x="1>0"`` 等の attribute value を安全に skip する。
-    """
-    events: list[dict[str, Any]] = []
-    n = len(line)
-    cursor = 0
-    i = 0
-
-    def _emit_pending_text(upto: int) -> None:
-        if upto > cursor:
-            events.append({"type": "text", "value": line[cursor:upto]})
-
-    while i < n:
-        if line[i] != "<":
-            i += 1
-            continue
-        tail = line[i:]
-
-        close_match = _DETAILS_CLOSE_PREFIX_RE.match(tail)
-        if close_match:
-            _emit_pending_text(i)
-            events.append({"type": "details-close"})
-            i += len(close_match.group(0))
-            cursor = i
-            continue
-
-        if _DETAILS_OPEN_PREFIX_RE.match(tail):
-            tag_end = _find_tag_end(line, i + 1)
-            if tag_end == -1:
-                break
-            _emit_pending_text(i)
-            events.append({"type": "details-open"})
-            i = tag_end + 1
-            cursor = i
-            continue
-
-        if _SUMMARY_OPEN_PREFIX_RE.match(tail):
-            open_end = _find_tag_end(line, i + 1)
-            if open_end == -1:
-                break
-            after_open = line[open_end + 1 :]
-            depth, close_pos, close_len = _scan_for_matching_summary_close(after_open, 1)
-            if close_pos == -1:
-                # multi-line 状態へ遷移
-                _emit_pending_text(i)
-                events.append(
-                    {
-                        "type": "summary-open",
-                        "initialInner": after_open,
-                        "initialDepth": depth,
-                    }
-                )
-                cursor = n
-                i = n
-                break
-            _emit_pending_text(i)
-            inner_text = after_open[:close_pos]
-            events.append({"type": "summary", "inner": inner_text})
-            i = open_end + 1 + close_pos + close_len
-            cursor = i
-            continue
-
-        i += 1
-
-    if cursor < n:
-        events.append({"type": "text", "value": line[cursor:]})
-    return events
-
-
-# mjs ``decodeHtmlEntities`` の case-insensitive 一括置換を再現するため compile 版
-# regex を使う (mjs の ``gi`` フラグ等価)。
-_ENTITY_NBSP_RE = re.compile(r"&nbsp;", re.IGNORECASE)
-_ENTITY_AMP_RE = re.compile(r"&amp;", re.IGNORECASE)
-_ENTITY_LT_RE = re.compile(r"&lt;", re.IGNORECASE)
-_ENTITY_GT_RE = re.compile(r"&gt;", re.IGNORECASE)
-_ENTITY_QUOT_RE = re.compile(r"&quot;", re.IGNORECASE)
-_ENTITY_39_RE = re.compile(r"&#39;", re.IGNORECASE)
-_ENTITY_APOS_RE = re.compile(r"&apos;", re.IGNORECASE)
-
-
-def _decode_html_entities(text: str) -> str:
-    """MadCap Flare / JA inline HTML に現れる entity の限定 decode (mjs 等価)。
-
-    EN walker の ``decode_entities`` で扱う tag vocabulary と揃えている。
-    ``&nbsp;`` / ``&amp;`` / ``&lt;`` / ``&gt;`` / ``&quot;`` / ``&#39;`` /
-    ``&apos;`` のみを case-insensitive に置換する。
-    """
-    text = _ENTITY_NBSP_RE.sub(" ", text)
-    text = _ENTITY_AMP_RE.sub("&", text)
-    text = _ENTITY_LT_RE.sub("<", text)
-    text = _ENTITY_GT_RE.sub(">", text)
-    text = _ENTITY_QUOT_RE.sub('"', text)
-    text = _ENTITY_39_RE.sub("'", text)
-    text = _ENTITY_APOS_RE.sub("'", text)
-    return text
-
-
-_CODE_TAG_RE = re.compile(r"<code\b[^>]*>([\s\S]*?)<\/code>", re.IGNORECASE)
-# HTML tag ストリップ用 regex。``<code>`` inner と ``<a>`` inner 両方で使うため
-# 汎用名にしている (python-reviewer LOW)。mjs 側も同一 regex を両箇所で再利用。
-_HTML_TAG_STRIP_RE = re.compile(r"<[^>]+>")
-_A_TAG_RE = re.compile(
-    r"<a\b[^>]*\bhref\s*=\s*[\"']([^\"']*)[\"'][^>]*>([\s\S]*?)<\/a>",
-    re.IGNORECASE,
-)
-_ANY_TAG_RE = re.compile(r"<[^>]+>")
-_WHITESPACE_RUN_RE = re.compile(r"\s+")
-
-
-def _html_inline_to_markdown_text(html: Any) -> str:
-    """HTML inline fragment を invariant-token を保持する markdown 風 text に変換。
-
-    ``<a href>`` / ``<code>`` は markdown 構文 (``[label](url)`` / `` `Y` ``) に
-    書き換えて ``create_segment`` の invariant-token extractor で拾えるようにし、
-    それ以外の tag は strip して inner text のみ残す。mjs ``htmlInlineToMarkdownText``
-    等価で rewrite 順序 (``<code>`` 先、``<a>`` 後) も同一。
-    """
-    if not isinstance(html, str):
-        return ""
-    text = html
-
-    def _code_sub(m: re.Match[str]) -> str:
-        inner = _HTML_TAG_STRIP_RE.sub("", m.group(1)).strip()
-        return f"`{inner}`"
-
-    text = _CODE_TAG_RE.sub(_code_sub, text)
-
-    def _a_sub(m: re.Match[str]) -> str:
-        href = m.group(1)
-        inner = m.group(2)
-        label = _HTML_TAG_STRIP_RE.sub("", inner).strip()
-        # mjs は <code> 書き換え後の backtick を残す実装。Python でも `_HTML_TAG_STRIP_RE`
-        # は tag のみ削除し backtick は保持するので等価。
-        if not href or href.startswith("#") or href.startswith("javascript:"):
-            return label
-        return f"[{label}]({href})"
-
-    text = _A_TAG_RE.sub(_a_sub, text)
-    text = _ANY_TAG_RE.sub(" ", text)
-    text = _decode_html_entities(text)
-    text = _WHITESPACE_RUN_RE.sub(" ", text).strip()
-    return text
-
-
-_TBODY_RE = re.compile(r"<tbody\b[^>]*>([\s\S]*?)<\/tbody>", re.IGNORECASE)
-_THEAD_STRIP_RE = re.compile(r"<thead\b[\s\S]*?<\/thead>", re.IGNORECASE)
-_TD_RE = re.compile(r"<td\b[^>]*>([\s\S]*?)<\/td>", re.IGNORECASE)
-
-
-def _extract_html_table_cells(table_html: str) -> list[str]:
-    """HTML ``<table>`` block から cell text を抽出する。
-
-    ``<tbody>`` がある場合はその内部だけ、ない場合は ``<thead>`` を除いた全体
-    から ``<tr><td>...</td></tr>`` の ``<td>`` inner を markdown 化して返す。
-    mjs ``extractHtmlTableCells`` 等価。
-    """
-    has_tbody = re.search(r"<tbody\b", table_html, re.IGNORECASE) is not None
-    if has_tbody:
-        m = _TBODY_RE.search(table_html)
-        body_html = m.group(1) if m else ""
-    else:
-        body_html = _THEAD_STRIP_RE.sub("", table_html)
-    cells: list[str] = []
-    for match in _TD_RE.finditer(body_html):
-        text = _html_inline_to_markdown_text(match.group(1))
-        if len(text) > 0:
-            cells.append(text)
-    return cells
 
 
 class _Emitter:
@@ -739,7 +468,7 @@ def extract_segments_from_markdown(body: object) -> list[dict[str, Any]]:
             multiline_summary_start_line if multiline_summary_start_line > 0 else closing_line_no
         )
         if details_depth > 0:
-            summary_text = _html_inline_to_markdown_text(joined)
+            summary_text = html_inline_to_markdown_text(joined)
             if len(summary_text) > 0:
                 path_at_close = build_section_path(heading_stack)
                 emitter.emit(path_at_close, "details-summary", summary_text, start_line)
@@ -776,7 +505,7 @@ def extract_segments_from_markdown(body: object) -> list[dict[str, Any]]:
             continue
 
         if in_multiline_summary:
-            depth, close_pos, close_len = _scan_for_matching_summary_close(
+            depth, close_pos, close_len = scan_for_matching_summary_close(
                 line, multiline_summary_depth
             )
             if close_pos == -1:
@@ -803,7 +532,7 @@ def extract_segments_from_markdown(body: object) -> list[dict[str, Any]]:
                     break
             if end_idx != -1:
                 table_html = "\n".join(lines[i : end_idx + 1])
-                cells = _extract_html_table_cells(table_html)
+                cells = extract_html_table_cells(table_html)
                 path = build_section_path(heading_stack)
                 for cell in cells:
                     emitter.emit(path, "table-cell", cell, line_no)
@@ -813,7 +542,7 @@ def extract_segments_from_markdown(body: object) -> list[dict[str, Any]]:
 
         if _DETAILS_TOKEN_RE.search(line):
             flush_paragraph()
-            events = _tokenize_details_line(line)
+            events = tokenize_details_line(line)
             path_at_line = build_section_path(heading_stack)
             for ev in events:
                 etype = ev["type"]
@@ -831,7 +560,7 @@ def extract_segments_from_markdown(body: object) -> list[dict[str, Any]]:
                     continue
                 if etype == "summary":
                     if details_depth > 0:
-                        summary_text = _html_inline_to_markdown_text(ev["inner"])
+                        summary_text = html_inline_to_markdown_text(ev["inner"])
                         if summary_text:
                             emitter.emit(path_at_line, "details-summary", summary_text, line_no)
                     else:
@@ -897,7 +626,7 @@ def extract_segments_from_markdown(body: object) -> list[dict[str, Any]]:
             if _TABLE_SEPARATOR_RE.match(next_line):
                 i += 1
                 continue
-            cells = _split_table_cells(trimmed)
+            cells = split_table_cells(trimmed)
             path = build_section_path(heading_stack)
             for cell in cells:
                 emitter.emit(path, "table-cell", cell, line_no)

--- a/scripts/py/src/testim_parity/segments_ja.py
+++ b/scripts/py/src/testim_parity/segments_ja.py
@@ -518,12 +518,18 @@ def _collect_list_region(lines: list[str], start: int) -> int:
     return last_list_line
 
 
-def _flatten_list_region(region: str) -> list[tuple[str, str, int | None]]:
-    """list region 文字列を markdown-it-py で parse して ``(kind, raw_text, line_offset)``
-    のリストを返す。
+def _flatten_list_region(region: str) -> tuple[list[tuple[str, str, int | None]], int | None]:
+    """list region 文字列を markdown-it-py で parse して flatten 結果を返す。
 
-    ``kind`` は ``"ordered-list-item"`` / ``"unordered-list-item"``。
-    ``line_offset`` は region 内の 0-based 行番号 (top-level item の開始行)。
+    戻り値 ``(items, list_end_line)``:
+
+    - ``items``: ``(kind, raw_text, line_offset)`` の list。``kind`` は
+      ``"ordered-list-item"`` / ``"unordered-list-item"``、``line_offset`` は
+      region 内の 0-based 行番号 (top-level item の開始行)。
+    - ``list_end_line``: region 内で **最後の top-level list が閉じた行** の
+      0-based index (exclusive)。region にこれ以降の content があれば main
+      loop に戻して非 list content として再処理する (codex review P2 #1
+      follow-up)。list が 1 つも見つからなければ ``None``。
 
     **top-level ``list_item`` の内容 (inline content + 内部 fence の body) を
     すべて親 item の ``raw_text`` にスペース区切りで連結する**。ネストされた
@@ -544,10 +550,15 @@ def _flatten_list_region(region: str) -> list[tuple[str, str, int | None]]:
     current_parts: list[str] = []
     current_kind: str | None = None
     current_line: int | None = None
+    list_end_line: int | None = None
 
     for tok in tokens:
         if tok.type in ("bullet_list_open", "ordered_list_open"):
             list_depth += 1
+            # top-level list_open の map は list 全体 [start, end_exclusive] を示す。
+            # nested list の map は subset なので、top-level のみ追跡する。
+            if list_depth == 1 and tok.map is not None:
+                list_end_line = tok.map[1]
             continue
         if tok.type in ("bullet_list_close", "ordered_list_close"):
             list_depth -= 1
@@ -582,7 +593,32 @@ def _flatten_list_region(region: str) -> list[tuple[str, str, int | None]]:
             content = tok.content or ""
             if content:
                 current_parts.append(content)
-    return results
+    return (results, list_end_line)
+
+
+def _emit_lines_as_mjs_fallback_list(
+    lines_slice: list[str],
+    emit: Any,
+    section_path: str,
+    base_line_no: int,
+) -> None:
+    """``_flatten_list_region`` が CommonMark 的に list を認識しなかったときの
+    fall-back: mjs line-based 実装と同じく、list-regex に match する各行を
+    単独の list-item として emit する (codex review P2 #2)。
+
+    該当ケース: ``    - codeish`` のように 4-space indent された list marker
+    行。CommonMark は code block として扱うが、mjs は list-item として emit
+    するため、silent に content を drop しないよう mjs 側と揃える。
+    """
+    for offset, line in enumerate(lines_slice):
+        ordered_match = _ORDERED_RE.match(line)
+        unordered_match = _UNORDERED_RE.match(line)
+        if ordered_match is None and unordered_match is None:
+            continue
+        match = ordered_match if ordered_match is not None else unordered_match
+        assert match is not None  # for mypy
+        kind = "ordered-list-item" if ordered_match is not None else "unordered-list-item"
+        emit(section_path, kind, match.group(2), base_line_no + offset)
 
 
 # ---------------------------------------------------------------------------
@@ -853,13 +889,26 @@ def extract_segments_from_markdown(body: object) -> list[dict[str, Any]]:
         if _ORDERED_RE.match(line) or _UNORDERED_RE.match(line):
             flush_paragraph()
             end_idx = _collect_list_region(lines, i)
-            region = "\n".join(lines[i : end_idx + 1])
-            flattened = _flatten_list_region(region)
+            region_lines = lines[i : end_idx + 1]
+            region = "\n".join(region_lines)
+            flattened, list_end_line = _flatten_list_region(region)
             path = build_section_path(heading_stack)
-            for kind, raw_text, row_offset in flattened:
-                resolved_line = line_no + (row_offset or 0)
-                emitter.emit(path, kind, raw_text, resolved_line)
-            i = end_idx + 1
+            if flattened:
+                for kind, raw_text, row_offset in flattened:
+                    resolved_line = line_no + (row_offset or 0)
+                    emitter.emit(path, kind, raw_text, resolved_line)
+                # codex review P2 #1 follow-up: markdown-it-py が認識した list
+                # の範囲だけ consume し、残りは main loop に戻して非 list content
+                # として再処理する。1-space indented paragraph や non-indented
+                # trailing content を silent に dropping しない契約。
+                consumed = list_end_line if list_end_line is not None else len(region_lines)
+                i += consumed
+            else:
+                # CommonMark が list を認識しなかったケース (例: 4-space indent
+                # された list marker は indented code block 扱い)。mjs 等価の
+                # 単行 emit に fall back する (codex review P2 #2)。
+                _emit_lines_as_mjs_fallback_list(region_lines, emitter.emit, path, line_no)
+                i = end_idx + 1
             continue
 
         if _HORIZONTAL_RULE_RE.match(trimmed):

--- a/scripts/py/src/testim_parity/segments_ja.py
+++ b/scripts/py/src/testim_parity/segments_ja.py
@@ -1,0 +1,842 @@
+"""JA markdown canonical segment extractor — ``source_parity_segments_ja.mjs`` の port。
+
+JA markdown body を走査し、exact-diff engine 用の flat な segment 列を emit する。
+Kind を判定できない構造は skip することで gate-eligible segment を clean に保つ
+保守的な設計 (mjs と同一)。
+
+## Phase 2 の核: Issue #368 nested list flattening
+
+mjs 実装は line-based regex で、ネストされた ``<li>`` (indented list item) を
+各行 1 segment として emit する。一方 EN parser (HTML tree walker) は top-level
+``<li>`` を 1 segment にフラット化する。結果、**同一意味の EN/JA ページが parity
+check で 128 files / 823 issues を出す** のが Issue #368 の症状。
+
+Python 側は以下の HYBRID アプローチで fix する:
+
+1. **非リスト content**: mjs の line-based state machine を verbatim port。
+   heading / callout / details / summary / code fence / HTML table / markdown
+   table / image / horizontal rule / paragraph を 1:1 で処理する。
+   conformance harness で mjs と byte 一致を guard する。
+2. **リスト region**: line-based regex で region の範囲を特定したら、その
+   range を ``markdown-it-py`` に渡して CommonMark AST を取得し、**top-level
+   ``list_item`` だけ** を emit する。ネストされた ``list_item`` の inline
+   content は親 item の textNorm にフラット化して混ぜ込む。これにより EN
+   walker と同じ粒度で segment が揃い、Issue #368 が解消される。
+
+mjs 側は当面 Phase 4 cutover まで既存の line-based 実装を保持するため、**nested
+list を含むページは mjs と Python で意図的に divergent** (segment count が
+Python < mjs)。conformance harness dispatch (``segments_ja_extract``) は
+nest-free な sample だけで byte 一致を要求し、Issue #368 の fix 挙動は
+dedicated Python unit test で記録する。
+
+## 保存されている mjs 挙動 (byte-identical 想定)
+
+- frontmatter 剥がし (``--- ... ---`` の 1 回目 skip)
+- H1 を page title 扱い (emit しない, heading stack に push しない)
+- heading anchor suffix ``{#id}`` 剥がし
+- ``:::note{title="..."}`` / ``:::warning`` / ``:::info`` / ``:::tip`` /
+  ``:::caution`` / ``:::danger`` callout open。``:::`` 単独で close。
+  内部 paragraph は ``callout-body`` kind で emit
+- ``<details>``/``<summary>``/``</details>`` multi-line 対応、nested ``<summary>``
+  の depth tracking、condensed one-liner handling
+- loose ``<summary>`` (``<details>`` に囲まれていない) は EN walker に委譲し、
+  element children を full classifier で分類してから JA emitter に再 emit する
+- HTML ``<table>`` block — ``<tbody>`` 内の ``<td>`` だけ cell として emit
+- markdown table — separator row / header row 検出で skip、本体 row のみ cell emit
+- code fence — backtick / tilde 両方、開閉 fence 間の body を ``code-block`` emit
+- standalone image line (``![...](...)`` / ``<Image>`` / ``<img>``) → ``image``
+- horizontal rule (``---`` / ``***`` / ``___``) は segment を emit しない
+
+## 意図的な divergence (Issue #368 fix)
+
+- ネストされた list item は top-level に flatten される (mjs は各行 1 segment)。
+  具体的には ``markdown_it.MarkdownIt().parse(region)`` の token stream を walk
+  し、``list_item_open`` で depth を +1、``list_item_close`` で -1 する。depth
+  が 1 のときの ``inline.content`` を rawText として集め、``list_item_close``
+  で depth が 1 → 0 に落ちる瞬間に flush する
+- list region 境界は line-based で検出: list 行 / blank 行 / 先頭 whitespace 行
+  を region に取り込み、heading / callout / details / code fence / HTML table /
+  horizontal rule / image-only / non-indented non-list 行で terminate する
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from markdown_it import MarkdownIt
+
+from .segments_en import extract_segments_from_html
+from .segments_shared import build_section_path, create_segment, push_heading
+
+_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+_CALLOUT_OPEN_RE = re.compile(r"^:::(note|warning|info|tip|caution|danger)(?:\{[^}]*\})?\s*$")
+_CALLOUT_CLOSE_RE = re.compile(r"^:::\s*$")
+_DETAILS_TOKEN_RE = re.compile(r"<\/?details\b|<summary\b", re.IGNORECASE)
+_DETAILS_OPEN_PREFIX_RE = re.compile(r"^<details\b", re.IGNORECASE)
+_DETAILS_CLOSE_PREFIX_RE = re.compile(r"^<\/details\s*>", re.IGNORECASE)
+_SUMMARY_OPEN_PREFIX_RE = re.compile(r"^<summary\b", re.IGNORECASE)
+_SUMMARY_CLOSE_RE = re.compile(r"^<\/summary\s*>", re.IGNORECASE)
+_IMAGE_RE = re.compile(r"^(?:!\[[^\]]*\]\([^)]+\)|<Image\b|<img\b)", re.IGNORECASE)
+_UNORDERED_RE = re.compile(r"^(\s*)[-*+]\s+(.+)$")
+_ORDERED_RE = re.compile(r"^(\s*)\d+\.\s+(.+)$")
+_TABLE_ROW_RE = re.compile(r"^\|.+\|\s*$")
+_TABLE_SEPARATOR_RE = re.compile(r"^\|\s*:?-+:?\s*(?:\|\s*:?-+:?\s*)+\|\s*$")
+_HTML_TABLE_OPEN_RE = re.compile(r"^<table\b", re.IGNORECASE)
+_HTML_TABLE_CLOSE_RE = re.compile(r"<\/table>", re.IGNORECASE)
+_HORIZONTAL_RULE_RE = re.compile(r"^(-{3,}|\*{3,}|_{3,})$")
+_ANCHOR_SUFFIX_RE = re.compile(r"\s*\{#[^}]*\}\s*$")
+
+# list-region terminator: "このパターンに該当する行が現れたら list region を
+# 閉じる" 契約の明示リスト (heading / callout / details token / code fence /
+# HTML table / horizontal rule / image-only)。
+_LIST_REGION_TERMINATOR_RES: tuple[re.Pattern[str], ...] = (
+    _HEADING_RE,
+    _CALLOUT_OPEN_RE,
+    _CALLOUT_CLOSE_RE,
+    _FENCE_RE,
+    _HTML_TABLE_OPEN_RE,
+    _HORIZONTAL_RULE_RE,
+)
+
+# details/summary token は別途検出する (行内に出現するため regex match ではなく
+# substring test で拾う)
+_DETAILS_TERMINATOR_RE = _DETAILS_TOKEN_RE
+
+
+def _split_table_cells(line: str) -> list[str]:
+    """pipe table 行を trimmed cell 列に分解する。
+
+    cell 内の backslash-escape された pipe (``\\|``) は phantom column 分割を
+    起こさないよう literal ``|`` として扱う (mjs 等価)。
+    """
+    trimmed = line.strip()
+    if trimmed.startswith("|"):
+        trimmed = trimmed[1:]
+    if trimmed.endswith("|"):
+        trimmed = trimmed[:-1].rstrip()
+    cells: list[str] = []
+    current: list[str] = []
+    i = 0
+    n = len(trimmed)
+    while i < n:
+        ch = trimmed[i]
+        if ch == "\\" and i + 1 < n and trimmed[i + 1] == "|":
+            current.append("|")
+            i += 2
+            continue
+        if ch == "|":
+            cells.append("".join(current).strip())
+            current = []
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+    cells.append("".join(current).strip())
+    return cells
+
+
+def _find_tag_end(text: str, start: int) -> int:
+    """``start`` 以降で HTML tag の閉じ ``>`` 位置を返す。
+
+    ``<details data-x="1>0">`` のような quoted attribute 内の ``>`` は skip する。
+    見つからなければ ``-1``。mjs ``findTagEnd`` 等価。
+    """
+    quote: str | None = None
+    n = len(text)
+    i = start
+    while i < n:
+        ch = text[i]
+        if quote is not None:
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            quote = ch
+            i += 1
+            continue
+        if ch == ">":
+            return i
+        i += 1
+    return -1
+
+
+def _scan_for_matching_summary_close(text: str, start_depth: int) -> tuple[int, int, int]:
+    """``text`` 内を走査して depth が 0 になる ``</summary>`` 位置を返す。
+
+    戻り値は ``(depth, close_pos, close_len)``。matching close が見つからない
+    場合は ``close_pos = -1``、``depth`` は scan 終了時点の depth (multi-line
+    accumulator で carry-forward する)。mjs ``scanForMatchingSummaryClose`` 等価。
+    """
+    depth = start_depth
+    n = len(text)
+    i = 0
+    while i < n:
+        if text[i] != "<":
+            i += 1
+            continue
+        tail = text[i:]
+        # </summary> close 候補
+        close_match = _SUMMARY_CLOSE_RE.match(tail)
+        if close_match:
+            depth -= 1
+            if depth == 0:
+                return (depth, i, len(close_match.group(0)))
+            i += len(close_match.group(0))
+            continue
+        # <summary> nested open
+        if _SUMMARY_OPEN_PREFIX_RE.match(tail):
+            depth += 1
+            tag_end = _find_tag_end(text, i + 1)
+            if tag_end == -1:
+                return (depth, -1, 0)
+            i = tag_end + 1
+            continue
+        # その他の tag — quote-aware に skip
+        if tail.startswith("</") or (len(tail) >= 2 and tail[0] == "<" and tail[1].isalpha()):
+            tag_end = _find_tag_end(text, i + 1)
+            if tag_end == -1:
+                i += 1
+                continue
+            i = tag_end + 1
+            continue
+        # stray '<' — text として scan 継続
+        i += 1
+    return (depth, -1, 0)
+
+
+def _tokenize_details_line(line: str) -> list[dict[str, Any]]:
+    """markdown 1 行を ``<details>`` / ``<summary>`` / ``</details>`` tokens +
+    text span の event 列に分解する (mjs ``tokenizeDetailsLine`` 等価)。
+
+    condensed 1-liner ``Lead <details><summary>Q</summary></details> tail`` を
+    左→右で正しい順序で emit するために必要。quote-aware な ``_find_tag_end``
+    経由で ``data-x="1>0"`` 等の attribute value を安全に skip する。
+    """
+    events: list[dict[str, Any]] = []
+    n = len(line)
+    cursor = 0
+    i = 0
+
+    def _emit_pending_text(upto: int) -> None:
+        if upto > cursor:
+            events.append({"type": "text", "value": line[cursor:upto]})
+
+    while i < n:
+        if line[i] != "<":
+            i += 1
+            continue
+        tail = line[i:]
+
+        close_match = _DETAILS_CLOSE_PREFIX_RE.match(tail)
+        if close_match:
+            _emit_pending_text(i)
+            events.append({"type": "details-close"})
+            i += len(close_match.group(0))
+            cursor = i
+            continue
+
+        if _DETAILS_OPEN_PREFIX_RE.match(tail):
+            tag_end = _find_tag_end(line, i + 1)
+            if tag_end == -1:
+                break
+            _emit_pending_text(i)
+            events.append({"type": "details-open"})
+            i = tag_end + 1
+            cursor = i
+            continue
+
+        if _SUMMARY_OPEN_PREFIX_RE.match(tail):
+            open_end = _find_tag_end(line, i + 1)
+            if open_end == -1:
+                break
+            after_open = line[open_end + 1 :]
+            depth, close_pos, close_len = _scan_for_matching_summary_close(after_open, 1)
+            if close_pos == -1:
+                # multi-line 状態へ遷移
+                _emit_pending_text(i)
+                events.append(
+                    {
+                        "type": "summary-open",
+                        "initialInner": after_open,
+                        "initialDepth": depth,
+                    }
+                )
+                cursor = n
+                i = n
+                break
+            _emit_pending_text(i)
+            inner_text = after_open[:close_pos]
+            events.append({"type": "summary", "inner": inner_text})
+            i = open_end + 1 + close_pos + close_len
+            cursor = i
+            continue
+
+        i += 1
+
+    if cursor < n:
+        events.append({"type": "text", "value": line[cursor:]})
+    return events
+
+
+# mjs ``decodeHtmlEntities`` の case-insensitive 一括置換を再現するため compile 版
+# regex を使う (mjs の ``gi`` フラグ等価)。
+_ENTITY_NBSP_RE = re.compile(r"&nbsp;", re.IGNORECASE)
+_ENTITY_AMP_RE = re.compile(r"&amp;", re.IGNORECASE)
+_ENTITY_LT_RE = re.compile(r"&lt;", re.IGNORECASE)
+_ENTITY_GT_RE = re.compile(r"&gt;", re.IGNORECASE)
+_ENTITY_QUOT_RE = re.compile(r"&quot;", re.IGNORECASE)
+_ENTITY_39_RE = re.compile(r"&#39;", re.IGNORECASE)
+_ENTITY_APOS_RE = re.compile(r"&apos;", re.IGNORECASE)
+
+
+def _decode_html_entities(text: str) -> str:
+    """MadCap Flare / JA inline HTML に現れる entity の限定 decode (mjs 等価)。
+
+    EN walker の ``decode_entities`` で扱う tag vocabulary と揃えている。
+    ``&nbsp;`` / ``&amp;`` / ``&lt;`` / ``&gt;`` / ``&quot;`` / ``&#39;`` /
+    ``&apos;`` のみを case-insensitive に置換する。
+    """
+    text = _ENTITY_NBSP_RE.sub(" ", text)
+    text = _ENTITY_AMP_RE.sub("&", text)
+    text = _ENTITY_LT_RE.sub("<", text)
+    text = _ENTITY_GT_RE.sub(">", text)
+    text = _ENTITY_QUOT_RE.sub('"', text)
+    text = _ENTITY_39_RE.sub("'", text)
+    text = _ENTITY_APOS_RE.sub("'", text)
+    return text
+
+
+_CODE_TAG_RE = re.compile(r"<code\b[^>]*>([\s\S]*?)<\/code>", re.IGNORECASE)
+_CODE_INNER_STRIP_RE = re.compile(r"<[^>]+>")
+_A_TAG_RE = re.compile(
+    r"<a\b[^>]*\bhref\s*=\s*[\"']([^\"']*)[\"'][^>]*>([\s\S]*?)<\/a>",
+    re.IGNORECASE,
+)
+_ANY_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RUN_RE = re.compile(r"\s+")
+
+
+def _html_inline_to_markdown_text(html: Any) -> str:
+    """HTML inline fragment を invariant-token を保持する markdown 風 text に変換。
+
+    ``<a href>`` / ``<code>`` は markdown 構文 (``[label](url)`` / `` `Y` ``) に
+    書き換えて ``create_segment`` の invariant-token extractor で拾えるようにし、
+    それ以外の tag は strip して inner text のみ残す。mjs ``htmlInlineToMarkdownText``
+    等価で rewrite 順序 (``<code>`` 先、``<a>`` 後) も同一。
+    """
+    if not isinstance(html, str):
+        return ""
+    text = html
+
+    def _code_sub(m: re.Match[str]) -> str:
+        inner = _CODE_INNER_STRIP_RE.sub("", m.group(1)).strip()
+        return f"`{inner}`"
+
+    text = _CODE_TAG_RE.sub(_code_sub, text)
+
+    def _a_sub(m: re.Match[str]) -> str:
+        href = m.group(1)
+        inner = m.group(2)
+        label = _CODE_INNER_STRIP_RE.sub("", inner).strip()
+        # mjs は <code> 書き換え後の backtick を残す実装。Python でも `_CODE_INNER_STRIP_RE`
+        # は tag のみ削除し backtick は保持するので等価。
+        if not href or href.startswith("#") or href.startswith("javascript:"):
+            return label
+        return f"[{label}]({href})"
+
+    text = _A_TAG_RE.sub(_a_sub, text)
+    text = _ANY_TAG_RE.sub(" ", text)
+    text = _decode_html_entities(text)
+    text = _WHITESPACE_RUN_RE.sub(" ", text).strip()
+    return text
+
+
+_TBODY_RE = re.compile(r"<tbody\b[^>]*>([\s\S]*?)<\/tbody>", re.IGNORECASE)
+_THEAD_STRIP_RE = re.compile(r"<thead\b[\s\S]*?<\/thead>", re.IGNORECASE)
+_TD_RE = re.compile(r"<td\b[^>]*>([\s\S]*?)<\/td>", re.IGNORECASE)
+
+
+def _extract_html_table_cells(table_html: str) -> list[str]:
+    """HTML ``<table>`` block から cell text を抽出する。
+
+    ``<tbody>`` がある場合はその内部だけ、ない場合は ``<thead>`` を除いた全体
+    から ``<tr><td>...</td></tr>`` の ``<td>`` inner を markdown 化して返す。
+    mjs ``extractHtmlTableCells`` 等価。
+    """
+    has_tbody = re.search(r"<tbody\b", table_html, re.IGNORECASE) is not None
+    if has_tbody:
+        m = _TBODY_RE.search(table_html)
+        body_html = m.group(1) if m else ""
+    else:
+        body_html = _THEAD_STRIP_RE.sub("", table_html)
+    cells: list[str] = []
+    for match in _TD_RE.finditer(body_html):
+        text = _html_inline_to_markdown_text(match.group(1))
+        if len(text) > 0:
+            cells.append(text)
+    return cells
+
+
+class _Emitter:
+    """``(sectionPath, kind)`` 毎に segment index をカウントしつつ segments を集める。"""
+
+    def __init__(self) -> None:
+        self._counters: dict[str, int] = {}
+        self.segments: list[dict[str, Any]] = []
+
+    def emit(self, section_path: str, kind: str, raw_text: Any, line: int | None) -> None:
+        if not isinstance(raw_text, str) or raw_text.strip() == "":
+            return
+        key = f"{section_path}\x00{kind}"
+        index = self._counters.get(key, 0)
+        self._counters[key] = index + 1
+        self.segments.append(
+            create_segment(
+                section_path=section_path,
+                kind=kind,
+                segment_index=index,
+                raw_text=raw_text,
+                line=line,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# List region flattening (Issue #368 fix)
+# ---------------------------------------------------------------------------
+
+# markdown-it-py のデフォルト設定。list parsing 以外の feature (table, strikethrough)
+# は使わないが、instance 生成コストを削るため module-level で 1 度だけ作る。
+_MD_PARSER = MarkdownIt("commonmark")
+
+
+def _is_list_region_terminator(line: str) -> bool:
+    """list region を終了させるべき行なら True。
+
+    heading / callout / code fence / HTML table / horizontal rule / details
+    token / standalone image は list 外に出す。逆に blank 行 / 先頭 whitespace
+    のある continuation 行は region に含める。
+    """
+    stripped = line.strip()
+    if stripped == "":
+        return False
+    for pattern in _LIST_REGION_TERMINATOR_RES:
+        if pattern.match(stripped):
+            return True
+    if _DETAILS_TERMINATOR_RE.search(line):
+        return True
+    # standalone image at indent 0
+    return (
+        not line.startswith(" ")
+        and not line.startswith("\t")
+        and _IMAGE_RE.match(stripped) is not None
+    )
+
+
+def _collect_list_region(lines: list[str], start: int) -> int:
+    """``start`` を list region の先頭として、region の末尾 index (inclusive) を返す。
+
+    region に含める行:
+      - list marker を持つ行 (indent 不問)
+      - blank 行
+      - 先頭 whitespace を持つ行 (lazy continuation / nested block)
+
+    stop 条件:
+      - indent 0 かつ list marker を持たない非 blank 行
+      - heading / callout / code fence / HTML table / horizontal rule / details
+        token / standalone image
+
+    返り値は **最後に region に含めた行の index**。trailing blank 行は region
+    末尾に含めない。
+    """
+    n = len(lines)
+    last_list_line = start
+    i = start
+    while i < n:
+        line = lines[i]
+        stripped = line.strip()
+        if _is_list_region_terminator(line):
+            break
+        if stripped == "":
+            # 先見: 次の非 blank 行が list-continuation かを確認
+            j = i + 1
+            while j < n and lines[j].strip() == "":
+                j += 1
+            if j >= n:
+                break
+            next_line = lines[j]
+            if _is_list_region_terminator(next_line):
+                break
+            if (
+                _ORDERED_RE.match(next_line)
+                or _UNORDERED_RE.match(next_line)
+                or next_line.startswith(" ")
+                or next_line.startswith("\t")
+            ):
+                i = j
+                continue
+            break
+        if _ORDERED_RE.match(line) or _UNORDERED_RE.match(line):
+            last_list_line = i
+            i += 1
+            continue
+        if line.startswith(" ") or line.startswith("\t"):
+            last_list_line = i
+            i += 1
+            continue
+        break
+    return last_list_line
+
+
+def _flatten_list_region(region: str) -> list[tuple[str, str, int | None]]:
+    """list region 文字列を markdown-it-py で parse して ``(kind, raw_text, line_offset)``
+    のリストを返す。
+
+    ``kind`` は ``"ordered-list-item"`` / ``"unordered-list-item"``。
+    ``line_offset`` は region 内の 0-based 行番号 (top-level item の開始行)。
+    ネストされた list item の inline content は親 item の ``raw_text`` にスペース
+    区切りで連結される。
+    """
+    tokens = _MD_PARSER.parse(region)
+    results: list[tuple[str, str, int | None]] = []
+    list_depth = 0
+    item_depth = 0
+    current_parts: list[str] = []
+    current_kind: str | None = None
+    current_line: int | None = None
+
+    for tok in tokens:
+        if tok.type in ("bullet_list_open", "ordered_list_open"):
+            list_depth += 1
+            continue
+        if tok.type in ("bullet_list_close", "ordered_list_close"):
+            list_depth -= 1
+            continue
+        if tok.type == "list_item_open":
+            item_depth += 1
+            if item_depth == 1:
+                current_parts = []
+                # markup は '-' / '*' / '+' (unordered) or '.' (ordered) を含む
+                markup = tok.markup or ""
+                current_kind = (
+                    "ordered-list-item" if markup.endswith(".") else "unordered-list-item"
+                )
+                current_line = tok.map[0] if tok.map else None
+            continue
+        if tok.type == "list_item_close":
+            if item_depth == 1 and current_kind is not None:
+                text = " ".join(p for p in current_parts if p).strip()
+                if text:
+                    results.append((current_kind, text, current_line))
+                current_parts = []
+                current_kind = None
+                current_line = None
+            item_depth -= 1
+            continue
+        if tok.type == "inline" and item_depth >= 1:
+            content = tok.content or ""
+            if content:
+                current_parts.append(content)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Main extractor
+# ---------------------------------------------------------------------------
+
+
+def _strip_frontmatter(lines: list[str]) -> list[str]:
+    """``--- ... ---`` YAML frontmatter を剥がす。
+
+    最初の非空行が ``---`` でなければ何もしない。mjs ``stripFrontmatter`` 等価。
+    """
+    if len(lines) == 0 or lines[0].strip() != "---":
+        return lines
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return lines[i + 1 :]
+    return lines
+
+
+def extract_segments_from_markdown(body: Any) -> list[dict[str, Any]]:
+    """JA markdown document body から canonical segment 列を抽出する。
+
+    mjs ``extractSegmentsFromMarkdown`` と同じ API 契約:
+
+    - input が string でなければ ``[]``
+    - frontmatter は内部で strip
+    - ``paragraphKind`` state で paragraph buffer を ``paragraph`` / ``callout-body``
+      のどちらで emit するかを切り替える。``:::note`` / ``:::caution`` 等の
+      callout block 内だけ ``callout-body`` になり、list item / image / table
+      は通常の classification path を通るため ``callout-body`` 以外の kind で emit
+      される (EN ``walkCalloutBody`` と同じ挙動)
+    - ``<details>`` 内の text block は ``paragraph`` で emit (EN walker と同等)。
+      ``<details>`` 出入りで ``paragraphKind`` を save/restore するため、
+      ``:::note`` 内の ``<details>`` でも内側の paragraph は ``paragraph`` kind
+    """
+    if not isinstance(body, str):
+        return []
+
+    raw_lines = body.split("\n")
+    lines = _strip_frontmatter(raw_lines)
+    line_offset = len(raw_lines) - len(lines)
+
+    emitter = _Emitter()
+    heading_stack: list[dict[str, Any]] = []
+    first_h1_consumed = False
+
+    paragraph_buf: list[str] = []
+    paragraph_start_line = 0
+    paragraph_kind = "paragraph"
+
+    in_callout = False
+
+    details_depth = 0
+    details_kind_stack: list[str] = []
+
+    in_multiline_summary = False
+    multiline_summary_buf: list[str] = []
+    multiline_summary_start_line = 0
+    multiline_summary_depth = 1
+
+    in_code_fence = False
+    code_fence_start_line = 0
+    code_fence_buf: list[str] = []
+
+    def flush_paragraph() -> None:
+        nonlocal paragraph_buf
+        if not paragraph_buf:
+            return
+        path = build_section_path(heading_stack)
+        emitter.emit(path, paragraph_kind, " ".join(paragraph_buf), paragraph_start_line)
+        paragraph_buf = []
+
+    def emit_loose_summary_inner(inner_html: str, start_line_no: int) -> None:
+        """loose ``<summary>`` の inner fragment を EN walker に委譲して再 emit。
+
+        mjs ``emitLooseSummaryInner`` 等価。EN walker が element children を
+        proper kind (img / ul / table / …) に分類してから、JA emitter 経由で
+        現在の sectionPath / kind-index counter を継承する。
+        """
+        en_segments = extract_segments_from_html(inner_html)
+        path_at_line = build_section_path(heading_stack)
+        for seg in en_segments:
+            emitter.emit(path_at_line, seg["segmentKind"], seg["textNorm"], start_line_no)
+
+    def flush_multiline_summary(closing_line_no: int) -> None:
+        nonlocal in_multiline_summary, multiline_summary_buf
+        nonlocal multiline_summary_start_line, multiline_summary_depth
+        joined = " ".join(multiline_summary_buf)
+        start_line = multiline_summary_start_line or closing_line_no
+        if details_depth > 0:
+            summary_text = _html_inline_to_markdown_text(joined)
+            if len(summary_text) > 0:
+                path_at_close = build_section_path(heading_stack)
+                emitter.emit(path_at_close, "details-summary", summary_text, start_line)
+        else:
+            emit_loose_summary_inner(joined, start_line)
+        in_multiline_summary = False
+        multiline_summary_buf = []
+        multiline_summary_start_line = 0
+        multiline_summary_depth = 1
+
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        trimmed = line.strip()
+        line_no = i + 1 + line_offset
+
+        if _FENCE_RE.match(trimmed):
+            if not in_code_fence:
+                flush_paragraph()
+                in_code_fence = True
+                code_fence_start_line = line_no
+                code_fence_buf = []
+            else:
+                in_code_fence = False
+                path = build_section_path(heading_stack)
+                emitter.emit(path, "code-block", "\n".join(code_fence_buf), code_fence_start_line)
+                code_fence_buf = []
+            i += 1
+            continue
+        if in_code_fence:
+            code_fence_buf.append(line)
+            i += 1
+            continue
+
+        if in_multiline_summary:
+            depth, close_pos, close_len = _scan_for_matching_summary_close(
+                line, multiline_summary_depth
+            )
+            if close_pos == -1:
+                multiline_summary_buf.append(line)
+                multiline_summary_depth = depth
+                i += 1
+                continue
+            multiline_summary_buf.append(line[:close_pos])
+            flush_multiline_summary(line_no)
+            remainder = line[close_pos + close_len :]
+            if remainder.strip():
+                lines[i] = remainder
+                # 再処理するため i は進めない
+                continue
+            i += 1
+            continue
+
+        if _HTML_TABLE_OPEN_RE.match(trimmed):
+            flush_paragraph()
+            end_idx = -1
+            for j in range(i, n):
+                if _HTML_TABLE_CLOSE_RE.search(lines[j]):
+                    end_idx = j
+                    break
+            if end_idx != -1:
+                table_html = "\n".join(lines[i : end_idx + 1])
+                cells = _extract_html_table_cells(table_html)
+                path = build_section_path(heading_stack)
+                for cell in cells:
+                    emitter.emit(path, "table-cell", cell, line_no)
+                i = end_idx + 1
+                continue
+            # unterminated — fall through
+
+        if _DETAILS_TOKEN_RE.search(line):
+            flush_paragraph()
+            events = _tokenize_details_line(line)
+            path_at_line = build_section_path(heading_stack)
+            for ev in events:
+                etype = ev["type"]
+                if etype == "text":
+                    text_span = str(ev["value"]).strip()
+                    if text_span:
+                        emitter.emit(
+                            build_section_path(heading_stack), paragraph_kind, text_span, line_no
+                        )
+                    continue
+                if etype == "details-open":
+                    details_kind_stack.append(paragraph_kind)
+                    paragraph_kind = "paragraph"
+                    details_depth += 1
+                    continue
+                if etype == "summary":
+                    if details_depth > 0:
+                        summary_text = _html_inline_to_markdown_text(ev["inner"])
+                        if summary_text:
+                            emitter.emit(path_at_line, "details-summary", summary_text, line_no)
+                    else:
+                        emit_loose_summary_inner(ev["inner"], line_no)
+                    continue
+                if etype == "summary-open":
+                    in_multiline_summary = True
+                    multiline_summary_buf = [str(ev["initialInner"])]
+                    multiline_summary_start_line = line_no
+                    multiline_summary_depth = int(ev.get("initialDepth", 1))
+                    continue
+                if etype == "details-close":
+                    if details_depth > 0:
+                        details_depth -= 1
+                        paragraph_kind = (
+                            details_kind_stack.pop() if details_kind_stack else "paragraph"
+                        )
+                    continue
+            i += 1
+            continue
+
+        if not in_callout and _CALLOUT_OPEN_RE.match(trimmed):
+            flush_paragraph()
+            in_callout = True
+            paragraph_kind = "callout-body"
+            i += 1
+            continue
+        if in_callout and _CALLOUT_CLOSE_RE.match(trimmed):
+            flush_paragraph()
+            in_callout = False
+            paragraph_kind = "paragraph"
+            i += 1
+            continue
+
+        heading_match = _HEADING_RE.match(line)
+        if heading_match:
+            flush_paragraph()
+            level = len(heading_match.group(1))
+            text = _ANCHOR_SUFFIX_RE.sub("", heading_match.group(2)).strip()
+            if level == 1 and not first_h1_consumed:
+                first_h1_consumed = True
+                i += 1
+                continue
+            heading_stack = push_heading(heading_stack, level, text)
+            path = build_section_path(heading_stack)
+            emitter.emit(path, "heading", text, line_no)
+            i += 1
+            continue
+
+        if _IMAGE_RE.match(trimmed):
+            flush_paragraph()
+            path = build_section_path(heading_stack)
+            emitter.emit(path, "image", trimmed, line_no)
+            i += 1
+            continue
+
+        if _TABLE_ROW_RE.match(trimmed):
+            flush_paragraph()
+            if _TABLE_SEPARATOR_RE.match(trimmed):
+                i += 1
+                continue
+            next_line = lines[i + 1].strip() if i + 1 < n else ""
+            if _TABLE_SEPARATOR_RE.match(next_line):
+                i += 1
+                continue
+            cells = _split_table_cells(trimmed)
+            path = build_section_path(heading_stack)
+            for cell in cells:
+                emitter.emit(path, "table-cell", cell, line_no)
+            i += 1
+            continue
+
+        # Ordered / unordered list — Issue #368 fix:
+        # 単行 match ではなく **list region 全体** を収集して markdown-it-py に
+        # 渡し、top-level item だけ 1 segment で emit する。
+        if _ORDERED_RE.match(line) or _UNORDERED_RE.match(line):
+            flush_paragraph()
+            end_idx = _collect_list_region(lines, i)
+            region = "\n".join(lines[i : end_idx + 1])
+            flattened = _flatten_list_region(region)
+            path = build_section_path(heading_stack)
+            for kind, raw_text, row_offset in flattened:
+                resolved_line = line_no + (row_offset or 0)
+                emitter.emit(path, kind, raw_text, resolved_line)
+            i = end_idx + 1
+            continue
+
+        if _HORIZONTAL_RULE_RE.match(trimmed):
+            flush_paragraph()
+            i += 1
+            continue
+
+        if trimmed == "":
+            flush_paragraph()
+            i += 1
+            continue
+
+        if not paragraph_buf:
+            paragraph_start_line = line_no
+        paragraph_buf.append(trimmed)
+        i += 1
+
+    # Trailing state flush
+    if in_multiline_summary:
+        flush_multiline_summary(n + line_offset)
+    if in_callout:
+        flush_paragraph()
+        paragraph_kind = "paragraph"
+    else:
+        flush_paragraph()
+
+    return emitter.segments
+
+
+__all__ = ["extract_segments_from_markdown"]

--- a/scripts/py/src/testim_parity/segments_ja.py
+++ b/scripts/py/src/testim_parity/segments_ja.py
@@ -310,7 +310,9 @@ def _decode_html_entities(text: str) -> str:
 
 
 _CODE_TAG_RE = re.compile(r"<code\b[^>]*>([\s\S]*?)<\/code>", re.IGNORECASE)
-_CODE_INNER_STRIP_RE = re.compile(r"<[^>]+>")
+# HTML tag ストリップ用 regex。``<code>`` inner と ``<a>`` inner 両方で使うため
+# 汎用名にしている (python-reviewer LOW)。mjs 側も同一 regex を両箇所で再利用。
+_HTML_TAG_STRIP_RE = re.compile(r"<[^>]+>")
 _A_TAG_RE = re.compile(
     r"<a\b[^>]*\bhref\s*=\s*[\"']([^\"']*)[\"'][^>]*>([\s\S]*?)<\/a>",
     re.IGNORECASE,
@@ -332,7 +334,7 @@ def _html_inline_to_markdown_text(html: Any) -> str:
     text = html
 
     def _code_sub(m: re.Match[str]) -> str:
-        inner = _CODE_INNER_STRIP_RE.sub("", m.group(1)).strip()
+        inner = _HTML_TAG_STRIP_RE.sub("", m.group(1)).strip()
         return f"`{inner}`"
 
     text = _CODE_TAG_RE.sub(_code_sub, text)
@@ -340,8 +342,8 @@ def _html_inline_to_markdown_text(html: Any) -> str:
     def _a_sub(m: re.Match[str]) -> str:
         href = m.group(1)
         inner = m.group(2)
-        label = _CODE_INNER_STRIP_RE.sub("", inner).strip()
-        # mjs は <code> 書き換え後の backtick を残す実装。Python でも `_CODE_INNER_STRIP_RE`
+        label = _HTML_TAG_STRIP_RE.sub("", inner).strip()
+        # mjs は <code> 書き換え後の backtick を残す実装。Python でも `_HTML_TAG_STRIP_RE`
         # は tag のみ削除し backtick は保持するので等価。
         if not href or href.startswith("#") or href.startswith("javascript:"):
             return label
@@ -381,16 +383,24 @@ def _extract_html_table_cells(table_html: str) -> list[str]:
 
 
 class _Emitter:
-    """``(sectionPath, kind)`` 毎に segment index をカウントしつつ segments を集める。"""
+    """``(sectionPath, kind)`` 毎に segment index をカウントしつつ segments を集める。
+
+    counter key は ``(section_path, kind)`` の tuple を使う。mjs 側は
+    ``section_path\x00kind`` の文字列結合だが、Python では tuple の方が
+    idiomatic で ``section_path`` が仮に ``\x00`` を含んでも collision しない
+    (python-reviewer MEDIUM #3)。両 runtime とも counter は内部状態で、
+    emit 結果 (``segmentIndex``) の方が conformance 対象のため tuple 化しても
+    byte parity は維持される。
+    """
 
     def __init__(self) -> None:
-        self._counters: dict[str, int] = {}
+        self._counters: dict[tuple[str, str], int] = {}
         self.segments: list[dict[str, Any]] = []
 
     def emit(self, section_path: str, kind: str, raw_text: Any, line: int | None) -> None:
         if not isinstance(raw_text, str) or raw_text.strip() == "":
             return
-        key = f"{section_path}\x00{kind}"
+        key = (section_path, kind)
         index = self._counters.get(key, 0)
         self._counters[key] = index + 1
         self.segments.append(
@@ -410,6 +420,15 @@ class _Emitter:
 
 # markdown-it-py のデフォルト設定。list parsing 以外の feature (table, strikethrough)
 # は使わないが、instance 生成コストを削るため module-level で 1 度だけ作る。
+#
+# Thread-safety: ``MarkdownIt.parse`` は現状 stateless だが、plugin を enable
+# すると plugin 側で mutable state を持つ可能性がある (例: markdown-it-py の
+# ``mdit_py_plugins.footnote`` は parser instance に counter を持つ)。
+# ``extract_segments_from_markdown`` は本 parser instance を直接使うため、
+# plugin を追加する場合は thread-local / per-call instance に切替える必要が
+# ある。現行 pipeline は single-threaded (``check:parity`` が逐次実行) なので
+# 問題ないが、architect review L1 として記録 (Phase 3 以降で並列実行を検討
+# する際の確認事項)。
 _MD_PARSER = MarkdownIt("commonmark")
 
 
@@ -561,7 +580,7 @@ def _strip_frontmatter(lines: list[str]) -> list[str]:
     return lines
 
 
-def extract_segments_from_markdown(body: Any) -> list[dict[str, Any]]:
+def extract_segments_from_markdown(body: object) -> list[dict[str, Any]]:
     """JA markdown document body から canonical segment 列を抽出する。
 
     mjs ``extractSegmentsFromMarkdown`` と同じ API 契約:
@@ -630,7 +649,15 @@ def extract_segments_from_markdown(body: Any) -> list[dict[str, Any]]:
         nonlocal in_multiline_summary, multiline_summary_buf
         nonlocal multiline_summary_start_line, multiline_summary_depth
         joined = " ".join(multiline_summary_buf)
-        start_line = multiline_summary_start_line or closing_line_no
+        # multiline_summary_start_line の初期値は 0。entry 時に ``line_no`` を
+        # 書き込むが、frontmatter 無しの 1 行目から multi-line summary が始まる
+        # 場合の正当な値は ``1 + line_offset``  (最小 1) なので ``or`` で fall-
+        # through するケースは 現行 corpus では発生しない。ただし将来的に
+        # 0-based line を持ち込むと footgun (python-reviewer Phase 3 risk) に
+        # なるため、``if ... else`` で explicit に書く。
+        start_line = (
+            multiline_summary_start_line if multiline_summary_start_line > 0 else closing_line_no
+        )
         if details_depth > 0:
             summary_text = _html_inline_to_markdown_text(joined)
             if len(summary_text) > 0:

--- a/scripts/py/src/testim_parity/segments_ja.py
+++ b/scripts/py/src/testim_parity/segments_ja.py
@@ -604,7 +604,12 @@ def _flatten_list_region(
         if tok.type == "inline" and item_depth >= 1:
             content = tok.content or ""
             if content:
-                current_parts.append(content)
+                # Markdown hard break (``\`` at end of line) は EN の ``<br>``
+                # に相当し textNorm では単なる word-boundary。raw content に
+                # 残る ``\\\n`` を空白化しないと ``step\\ next`` のように
+                # backslash が textNorm に混入して EN walker と drift する
+                # (codex review P2 follow-up #3)。
+                current_parts.append(content.replace("\\\n", " "))
     return (results, list_start_line, list_end_line)
 
 

--- a/scripts/py/src/testim_parity/segments_ja_html.py
+++ b/scripts/py/src/testim_parity/segments_ja_html.py
@@ -1,0 +1,356 @@
+"""JA extractor の HTML / inline-markdown helpers。
+
+``segments_ja.py`` の本体 (line-based state machine + list region flattening)
+から **HTML まわりの pure な文字列処理** を切り出したモジュール。``segments_ja``
+が 800 行 soft cap を超えたため、cohesive な粒度で分割している
+(codex LOW: file-size refactor)。
+
+ここに置くものの判定基準:
+
+- ``<details>`` / ``<summary>`` / HTML table / entity / inline HTML の
+  pure text transform (入力: str, 出力: str or list[str])
+- main state machine と参照を共有しない (stateful な counter や emit 経路
+  は持たない)
+- mjs 側の対応 helper (``findTagEnd`` / ``tokenizeDetailsLine`` /
+  ``decodeHtmlEntities`` / ``htmlInlineToMarkdownText`` / ``extractHtmlTableCells``
+  / ``splitTableCells``) と 1:1 の挙動を保つ
+
+ここに置かないもの:
+
+- ``_IMAGE_RE`` / ``_FENCE_RE`` / ``_HEADING_RE`` / ``_CALLOUT_OPEN_RE`` 等、
+  main loop の line dispatch で使う regex (``segments_ja.py`` に残す)
+- ``_DETAILS_TOKEN_RE`` — main loop で 「この行に details/summary が含まれるか」
+  を粗判定するために使う。tokenize 自体は本モジュールだが、判定の regex は
+  呼び出し側に残る (``segments_ja.py`` に alias `_DETAILS_TERMINATOR_RE`
+  として保持)
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# HTML tag prefix regex — ``<details>`` / ``<summary>`` token の識別
+# ---------------------------------------------------------------------------
+
+DETAILS_OPEN_PREFIX_RE = re.compile(r"^<details\b", re.IGNORECASE)
+DETAILS_CLOSE_PREFIX_RE = re.compile(r"^<\/details\s*>", re.IGNORECASE)
+SUMMARY_OPEN_PREFIX_RE = re.compile(r"^<summary\b", re.IGNORECASE)
+SUMMARY_CLOSE_RE = re.compile(r"^<\/summary\s*>", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# HTML entity decode (mjs `decodeHtmlEntities` 相当 — 7 entity の case-insensitive 置換)
+# ---------------------------------------------------------------------------
+
+# mjs ``decodeHtmlEntities`` の case-insensitive 一括置換を再現するため compile 版
+# regex を使う (mjs の ``gi`` フラグ等価)。
+_ENTITY_NBSP_RE = re.compile(r"&nbsp;", re.IGNORECASE)
+_ENTITY_AMP_RE = re.compile(r"&amp;", re.IGNORECASE)
+_ENTITY_LT_RE = re.compile(r"&lt;", re.IGNORECASE)
+_ENTITY_GT_RE = re.compile(r"&gt;", re.IGNORECASE)
+_ENTITY_QUOT_RE = re.compile(r"&quot;", re.IGNORECASE)
+_ENTITY_39_RE = re.compile(r"&#39;", re.IGNORECASE)
+_ENTITY_APOS_RE = re.compile(r"&apos;", re.IGNORECASE)
+
+
+def decode_html_entities(text: str) -> str:
+    """MadCap Flare / JA inline HTML に現れる entity の限定 decode (mjs 等価)。
+
+    EN walker の ``decode_entities`` で扱う tag vocabulary と揃えている。
+    ``&nbsp;`` / ``&amp;`` / ``&lt;`` / ``&gt;`` / ``&quot;`` / ``&#39;`` /
+    ``&apos;`` のみを case-insensitive に置換する。
+    """
+    text = _ENTITY_NBSP_RE.sub(" ", text)
+    text = _ENTITY_AMP_RE.sub("&", text)
+    text = _ENTITY_LT_RE.sub("<", text)
+    text = _ENTITY_GT_RE.sub(">", text)
+    text = _ENTITY_QUOT_RE.sub('"', text)
+    text = _ENTITY_39_RE.sub("'", text)
+    text = _ENTITY_APOS_RE.sub("'", text)
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Inline HTML → markdown 変換 (invariant token を保持)
+# ---------------------------------------------------------------------------
+
+_CODE_TAG_RE = re.compile(r"<code\b[^>]*>([\s\S]*?)<\/code>", re.IGNORECASE)
+# HTML tag ストリップ用 regex。``<code>`` inner と ``<a>`` inner 両方で使うため
+# 汎用名にしている (python-reviewer LOW)。mjs 側も同一 regex を両箇所で再利用。
+_HTML_TAG_STRIP_RE = re.compile(r"<[^>]+>")
+_A_TAG_RE = re.compile(
+    r"<a\b[^>]*\bhref\s*=\s*[\"']([^\"']*)[\"'][^>]*>([\s\S]*?)<\/a>",
+    re.IGNORECASE,
+)
+_ANY_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RUN_RE = re.compile(r"\s+")
+
+
+def html_inline_to_markdown_text(html: Any) -> str:
+    """HTML inline fragment を invariant-token を保持する markdown 風 text に変換。
+
+    ``<a href>`` / ``<code>`` は markdown 構文 (``[label](url)`` / `` `Y` ``) に
+    書き換えて ``create_segment`` の invariant-token extractor で拾えるようにし、
+    それ以外の tag は strip して inner text のみ残す。mjs ``htmlInlineToMarkdownText``
+    等価で rewrite 順序 (``<code>`` 先、``<a>`` 後) も同一。
+    """
+    if not isinstance(html, str):
+        return ""
+    text = html
+
+    def _code_sub(m: re.Match[str]) -> str:
+        inner = _HTML_TAG_STRIP_RE.sub("", m.group(1)).strip()
+        return f"`{inner}`"
+
+    text = _CODE_TAG_RE.sub(_code_sub, text)
+
+    def _a_sub(m: re.Match[str]) -> str:
+        href = m.group(1)
+        inner = m.group(2)
+        label = _HTML_TAG_STRIP_RE.sub("", inner).strip()
+        # mjs は <code> 書き換え後の backtick を残す実装。Python でも `_HTML_TAG_STRIP_RE`
+        # は tag のみ削除し backtick は保持するので等価。
+        if not href or href.startswith("#") or href.startswith("javascript:"):
+            return label
+        return f"[{label}]({href})"
+
+    text = _A_TAG_RE.sub(_a_sub, text)
+    text = _ANY_TAG_RE.sub(" ", text)
+    text = decode_html_entities(text)
+    text = _WHITESPACE_RUN_RE.sub(" ", text).strip()
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Markdown pipe table / HTML table cell 抽出
+# ---------------------------------------------------------------------------
+
+
+def split_table_cells(line: str) -> list[str]:
+    """pipe table 行を trimmed cell 列に分解する。
+
+    cell 内の backslash-escape された pipe (``\\|``) は phantom column 分割を
+    起こさないよう literal ``|`` として扱う (mjs 等価)。
+    """
+    trimmed = line.strip()
+    if trimmed.startswith("|"):
+        trimmed = trimmed[1:]
+    if trimmed.endswith("|"):
+        trimmed = trimmed[:-1].rstrip()
+    cells: list[str] = []
+    current: list[str] = []
+    i = 0
+    n = len(trimmed)
+    while i < n:
+        ch = trimmed[i]
+        if ch == "\\" and i + 1 < n and trimmed[i + 1] == "|":
+            current.append("|")
+            i += 2
+            continue
+        if ch == "|":
+            cells.append("".join(current).strip())
+            current = []
+            i += 1
+            continue
+        current.append(ch)
+        i += 1
+    cells.append("".join(current).strip())
+    return cells
+
+
+_TBODY_RE = re.compile(r"<tbody\b[^>]*>([\s\S]*?)<\/tbody>", re.IGNORECASE)
+_THEAD_STRIP_RE = re.compile(r"<thead\b[\s\S]*?<\/thead>", re.IGNORECASE)
+_TD_RE = re.compile(r"<td\b[^>]*>([\s\S]*?)<\/td>", re.IGNORECASE)
+_TBODY_PROBE_RE = re.compile(r"<tbody\b", re.IGNORECASE)
+
+
+def extract_html_table_cells(table_html: str) -> list[str]:
+    """HTML ``<table>`` block から cell text を抽出する。
+
+    ``<tbody>`` がある場合はその内部だけ、ない場合は ``<thead>`` を除いた全体
+    から ``<tr><td>...</td></tr>`` の ``<td>`` inner を markdown 化して返す。
+    mjs ``extractHtmlTableCells`` 等価。
+    """
+    has_tbody = _TBODY_PROBE_RE.search(table_html) is not None
+    if has_tbody:
+        m = _TBODY_RE.search(table_html)
+        body_html = m.group(1) if m else ""
+    else:
+        body_html = _THEAD_STRIP_RE.sub("", table_html)
+    cells: list[str] = []
+    for match in _TD_RE.finditer(body_html):
+        text = html_inline_to_markdown_text(match.group(1))
+        if len(text) > 0:
+            cells.append(text)
+    return cells
+
+
+# ---------------------------------------------------------------------------
+# ``<details>`` / ``<summary>`` tokenization helpers
+# ---------------------------------------------------------------------------
+
+
+def find_tag_end(text: str, start: int) -> int:
+    """``start`` 以降で HTML tag の閉じ ``>`` 位置を返す。
+
+    ``<details data-x="1>0">`` のような quoted attribute 内の ``>`` は skip する。
+    見つからなければ ``-1``。mjs ``findTagEnd`` 等価。
+    """
+    quote: str | None = None
+    n = len(text)
+    i = start
+    while i < n:
+        ch = text[i]
+        if quote is not None:
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ('"', "'"):
+            quote = ch
+            i += 1
+            continue
+        if ch == ">":
+            return i
+        i += 1
+    return -1
+
+
+def scan_for_matching_summary_close(text: str, start_depth: int) -> tuple[int, int, int]:
+    """``text`` 内を走査して depth が 0 になる ``</summary>`` 位置を返す。
+
+    戻り値は ``(depth, close_pos, close_len)``。matching close が見つからない
+    場合は ``close_pos = -1``、``depth`` は scan 終了時点の depth (multi-line
+    accumulator で carry-forward する)。mjs ``scanForMatchingSummaryClose`` 等価。
+    """
+    depth = start_depth
+    n = len(text)
+    i = 0
+    while i < n:
+        if text[i] != "<":
+            i += 1
+            continue
+        tail = text[i:]
+        # </summary> close 候補
+        close_match = SUMMARY_CLOSE_RE.match(tail)
+        if close_match:
+            depth -= 1
+            if depth == 0:
+                return (depth, i, len(close_match.group(0)))
+            i += len(close_match.group(0))
+            continue
+        # <summary> nested open
+        if SUMMARY_OPEN_PREFIX_RE.match(tail):
+            depth += 1
+            tag_end = find_tag_end(text, i + 1)
+            if tag_end == -1:
+                return (depth, -1, 0)
+            i = tag_end + 1
+            continue
+        # その他の tag — quote-aware に skip
+        if tail.startswith("</") or (len(tail) >= 2 and tail[0] == "<" and tail[1].isalpha()):
+            tag_end = find_tag_end(text, i + 1)
+            if tag_end == -1:
+                i += 1
+                continue
+            i = tag_end + 1
+            continue
+        # stray '<' — text として scan 継続
+        i += 1
+    return (depth, -1, 0)
+
+
+def tokenize_details_line(line: str) -> list[dict[str, Any]]:
+    """markdown 1 行を ``<details>`` / ``<summary>`` / ``</details>`` tokens +
+    text span の event 列に分解する (mjs ``tokenizeDetailsLine`` 等価)。
+
+    condensed 1-liner ``Lead <details><summary>Q</summary></details> tail`` を
+    左→右で正しい順序で emit するために必要。quote-aware な ``find_tag_end``
+    経由で ``data-x="1>0"`` 等の attribute value を安全に skip する。
+
+    event の ``type`` とペイロード:
+
+    - ``{"type": "text", "value": str}``
+    - ``{"type": "details-open"}``
+    - ``{"type": "details-close"}``
+    - ``{"type": "summary", "inner": str}`` — 同じ行内で閉じた場合
+    - ``{"type": "summary-open", "initialInner": str, "initialDepth": int}``
+      — multi-line 状態に入る場合 (行の終わりまで閉じない)
+    """
+    events: list[dict[str, Any]] = []
+    n = len(line)
+    cursor = 0
+    i = 0
+
+    def _emit_pending_text(upto: int) -> None:
+        if upto > cursor:
+            events.append({"type": "text", "value": line[cursor:upto]})
+
+    while i < n:
+        if line[i] != "<":
+            i += 1
+            continue
+        tail = line[i:]
+
+        close_match = DETAILS_CLOSE_PREFIX_RE.match(tail)
+        if close_match:
+            _emit_pending_text(i)
+            events.append({"type": "details-close"})
+            i += len(close_match.group(0))
+            cursor = i
+            continue
+
+        if DETAILS_OPEN_PREFIX_RE.match(tail):
+            tag_end = find_tag_end(line, i + 1)
+            if tag_end == -1:
+                break
+            _emit_pending_text(i)
+            events.append({"type": "details-open"})
+            i = tag_end + 1
+            cursor = i
+            continue
+
+        if SUMMARY_OPEN_PREFIX_RE.match(tail):
+            open_end = find_tag_end(line, i + 1)
+            if open_end == -1:
+                break
+            after_open = line[open_end + 1 :]
+            depth, close_pos, close_len = scan_for_matching_summary_close(after_open, 1)
+            if close_pos == -1:
+                # multi-line 状態へ遷移
+                _emit_pending_text(i)
+                events.append(
+                    {
+                        "type": "summary-open",
+                        "initialInner": after_open,
+                        "initialDepth": depth,
+                    }
+                )
+                cursor = n
+                i = n
+                break
+            _emit_pending_text(i)
+            inner_text = after_open[:close_pos]
+            events.append({"type": "summary", "inner": inner_text})
+            i = open_end + 1 + close_pos + close_len
+            cursor = i
+            continue
+
+        i += 1
+
+    if cursor < n:
+        events.append({"type": "text", "value": line[cursor:]})
+    return events
+
+
+__all__ = [
+    "decode_html_entities",
+    "extract_html_table_cells",
+    "find_tag_end",
+    "html_inline_to_markdown_text",
+    "scan_for_matching_summary_close",
+    "split_table_cells",
+    "tokenize_details_line",
+]

--- a/scripts/py/tests/conformance/test_segments_ja_parity.py
+++ b/scripts/py/tests/conformance/test_segments_ja_parity.py
@@ -197,6 +197,37 @@ def test_ja_corpus_zero_regressions(ja_pages, mjs_ja_segments_by_slug):
     )
 
 
+# 現行 288-page corpus で nested-list flatten が発動しないページ数 (Phase 2 計測)。
+# この数字が変動する = corpus 側で nested list パターンが追加/削除された、または
+# Python extractor の挙動が変わった、のいずれか。どちらも Phase 2 review では
+# 意図した変更なので、本定数を更新して diff を PR に明示する運用。静的な pin
+# があることで、"drop-one-add-one" で count が偶然保存されるような silent バグ
+# を corpus-shape 側からも tripwire できる (architect review H3)。
+_NEST_FREE_CORPUS_SIZE = 142
+
+
+def test_ja_corpus_nest_free_count_pinned(ja_pages, mjs_ja_segments_by_slug):
+    """nest-free ページ数が Phase 2 計測値 (``_NEST_FREE_CORPUS_SIZE``) と一致。
+
+    architect review H3: ``test_ja_corpus_nest_free_pages_byte_identical`` が
+    auto-derive で nest-free subset を拾うため、corpus side の shift (新規
+    nested list 追加 / 既存 flatten page の content 変更) を silent に取り込む
+    リスクがある。本 test で subset 数を static に pin することで、corpus
+    shape 変化を PR で明示的に認識させる (subset 数が変わったら本定数を更新
+    する PR が必要)。
+    """
+    equal_count_pages = sum(
+        1
+        for slug, body in ja_pages
+        if len(extract_segments_from_markdown(body)) == len(mjs_ja_segments_by_slug[slug])
+    )
+    assert equal_count_pages == _NEST_FREE_CORPUS_SIZE, (
+        f"nest-free page count shifted: actual={equal_count_pages} "
+        f"pinned={_NEST_FREE_CORPUS_SIZE}. "
+        "If corpus change is intentional, update _NEST_FREE_CORPUS_SIZE."
+    )
+
+
 def test_ja_corpus_nest_free_pages_byte_identical(ja_pages, mjs_ja_segments_by_slug):
     """segment 数が mjs と一致する全ページで byte-identical。
 
@@ -204,6 +235,10 @@ def test_ja_corpus_nest_free_pages_byte_identical(ja_pages, mjs_ja_segments_by_s
     line-based 挙動と揃っている。このサブセットで byte 一致していれば、
     headings / callout / details / code fence / table / paragraph / image の
     挙動が mjs と drift していないことを示せる。
+
+    ペアになる ``test_ja_corpus_nest_free_count_pinned`` が subset 数を static
+    に pin するため、"drop-one-add-one" 系の silent バグ (count 保存 but 内容
+    shift) も両 test の組合せで tripwire される (architect review H3)。
     """
     byte_divergences: list[str] = []
     equal_count_pages = 0

--- a/scripts/py/tests/conformance/test_segments_ja_parity.py
+++ b/scripts/py/tests/conformance/test_segments_ja_parity.py
@@ -203,7 +203,11 @@ def test_ja_corpus_zero_regressions(ja_pages, mjs_ja_segments_by_slug):
 # 意図した変更なので、本定数を更新して diff を PR に明示する運用。静的な pin
 # があることで、"drop-one-add-one" で count が偶然保存されるような silent バグ
 # を corpus-shape 側からも tripwire できる (architect review H3)。
-_NEST_FREE_CORPUS_SIZE = 142
+#
+# 141 = 288 - 147 divergent。codex review P2 #1 対応で indented fence / image
+# の flatten 挙動を EN walker と揃えた結果、1 ページが byte-identical subset から
+# flatten subset へ移動した (以前は 142)。
+_NEST_FREE_CORPUS_SIZE = 141
 
 
 def test_ja_corpus_nest_free_count_pinned(ja_pages, mjs_ja_segments_by_slug):

--- a/scripts/py/tests/conformance/test_segments_ja_parity.py
+++ b/scripts/py/tests/conformance/test_segments_ja_parity.py
@@ -1,0 +1,237 @@
+"""``segments_ja`` のクロスランタイム conformance。
+
+Phase 2 goal は **Issue #368 (nested list flattening)** を Python で正しく解く
+こと。mjs line-based 実装は nested list を各行 1 segment として emit するが、
+Python port は markdown-it-py AST に委譲して top-level ``<li>`` だけ emit する。
+したがって両 runtime の出力は **nested list を含むケースで意図的に divergent**。
+
+本 conformance test は **nested list を含まない sample だけ** を byte 一致で
+照合する。nest-free 領域の挙動は 1:1 保存しないと段階的な alignment / structure
+gate に影響するため、ここで drift を早期検出する。Issue #368 本体の fix
+挙動 (ネスト時の flattening) は ``tests/test_segments_ja.py`` の
+``TestIssue368NestedListFlattening`` が規定する。
+
+### 288-page regression guard (Phase 1 pattern)
+
+``test_nest_free_pages_match_mjs`` は ``src/content/docs`` 配下の JA markdown
+全ページをスキャンし、nested list を含まない (= mjs と byte 一致する) 全ページ
+で Python 出力が byte 一致することを guard する。一度 mapping が安定したら
+(nest-free vs nested の corpus 分布)、回帰は即検出される。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from testim_parity.segments_ja import extract_segments_from_markdown
+
+from ._harness import run_batch
+
+# -------------------- nest-free conformance samples --------------------
+# 明示的に nested list を含まない sample 群。byte 一致を hard に要求する。
+# (nested list は Python 側で意図的に divergent なので harness batch 時は除外する)
+
+NEST_FREE_SAMPLES: list[str] = [
+    # 空 / 無 body
+    "",
+    "   \n   \n",
+    # Frontmatter だけ
+    "---\ntitle: T\n---\n\nBody.\n",
+    # Heading hierarchy
+    "## A\n\n### A1\n\npara1\n\n#### A1-1\n\npara2\n",
+    # H1 skip + heading stack truncation
+    "# Title\n\n## A\n\n### A1\n\npara\n\n## B\n\npara2\n",
+    # Heading anchor suffix
+    "## Section Title {#anchor-id}\n\nBody.\n",
+    # Flat unordered list (no nest)
+    "- alpha\n- beta\n- gamma\n",
+    # Flat ordered list (no nest)
+    "1. first\n2. second\n3. third\n",
+    # Code fence backtick
+    "## X\n\n```js\nvar x = 1;\nconst y = 2;\n```\n\nAfter code.\n",
+    # Code fence tilde
+    "## X\n\n~~~py\nprint(1)\n~~~\n",
+    # Callout types
+    ":::note\nBody here.\n:::\n",
+    ':::note{title="重要"}\nBody with title.\n:::\n',
+    ":::warning\nLine A.\nLine B.\n:::\n",
+    # Markdown table (no nest)
+    "| a | b |\n| - | - |\n| 1 | 2 |\n| 3 | 4 |\n",
+    # Table with escaped pipe
+    "| h1 | h2 |\n| - | - |\n| pipe\\|here | plain |\n",
+    # HTML table with thead/tbody
+    (
+        "<table>"
+        "<thead><tr><th>H1</th><th>H2</th></tr></thead>"
+        "<tbody><tr><td>D1</td><td>D2</td></tr></tbody>"
+        "</table>\n"
+    ),
+    # Details / summary (single line)
+    "<details><summary>Q</summary><p>body</p></details>\n",
+    # Details with multi-paragraph body (still no nested list)
+    (
+        "<details><summary>FAQ</summary>\n\n"
+        "Answer paragraph 1.\n\n"
+        "Answer paragraph 2.\n\n"
+        "</details>\n"
+    ),
+    # Multi-line summary
+    "<details>\n<summary>\nMulti-line\nQuestion?\n</summary>\nAnswer.\n</details>\n",
+    # Standalone image (markdown)
+    "## X\n\n![alt](/img.png)\n",
+    # Standalone image (HTML)
+    '## X\n\n<img src="/img.png" alt="A" />\n',
+    # Horizontal rule
+    "## X\n\nBefore.\n\n---\n\nAfter.\n",
+    # Paragraph with inline markdown
+    "## X\n\nThis is **bold** and *italic* and `code` text.\n",
+    # Link in paragraph
+    "## X\n\nSee [the docs](/docs/foo) for details.\n",
+    # Callout containing flat list
+    ":::note\nIntro paragraph.\n\n- item one\n- item two\n:::\n",
+    # Details containing flat list
+    "<details><summary>Items</summary>\n\n- a\n- b\n\n</details>\n",
+    # Paragraph + image sequence
+    "## X\n\nLead paragraph.\n\n![alt](/x.png)\n\nTrail paragraph.\n",
+    # Consecutive callouts
+    ":::note\nFirst.\n:::\n\n:::warning\nSecond.\n:::\n",
+    # Mixed content flow
+    (
+        "## Overview\n\n"
+        "Intro text.\n\n"
+        ":::note\nCallout body.\n:::\n\n"
+        "### Details\n\n"
+        "More details here.\n\n"
+        "```bash\ncurl example.com\n```\n\n"
+        "Closing paragraph.\n"
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def mjs_nest_free_results(repo_root, node_available) -> list[list[dict]]:
+    if not node_available:
+        pytest.skip("node not available")
+    calls = [{"function": "segments_ja_extract", "args": [body]} for body in NEST_FREE_SAMPLES]
+    return run_batch(repo_root, calls)
+
+
+def test_nest_free_samples_match_mjs(mjs_nest_free_results):
+    """nest-free sample で Python output が mjs と byte 一致する。"""
+    for body, mjs in zip(NEST_FREE_SAMPLES, mjs_nest_free_results, strict=True):
+        py = extract_segments_from_markdown(body)
+        assert len(py) == len(mjs), (
+            f"segment count differs for body={body!r}:\n"
+            f"  py={len(py)} mjs={len(mjs)}\n"
+            f"  py={py!r}\n"
+            f"  mjs={mjs!r}"
+        )
+        for i, (py_seg, mjs_seg) in enumerate(zip(py, mjs, strict=True)):
+            assert py_seg == mjs_seg, (
+                f"segment[{i}] differs for body={body[:50]!r}:\n"
+                f"  py  = {py_seg!r}\n"
+                f"  mjs = {mjs_seg!r}"
+            )
+
+
+# -------------------- 288-page corpus regression guard --------------------
+# nested list を含まない JA ページ全て (現状 142 file) で byte 一致を確認。
+# ``_NEST_ALLOWLIST`` には「nested list を含むため意図的 divergent」なページを
+# 自動で振り分ける — 実行時に Python 出力と mjs 出力の差分を見て、segment 数
+# delta が負 (Python flatten による減少) なら allowlist 扱い、それ以外は fail。
+
+
+SNAPSHOT_ROOT_PARTS = ("src", "content", "docs")
+
+
+def _collect_ja_pages(repo_root) -> list[tuple[str, str]]:
+    """``(slug, body)`` のリストを返す。slug は拡張子なしの相対パス。"""
+    root = repo_root
+    for part in SNAPSHOT_ROOT_PARTS:
+        root = root / part
+    if not root.exists():
+        return []
+    pairs: list[tuple[str, str]] = []
+    for path in sorted(root.rglob("*.md")):
+        rel = path.relative_to(root).with_suffix("")
+        slug = rel.as_posix()
+        pairs.append((slug, path.read_text(encoding="utf-8")))
+    return pairs
+
+
+@pytest.fixture(scope="module")
+def ja_pages(repo_root) -> list[tuple[str, str]]:
+    pages = _collect_ja_pages(repo_root)
+    if not pages:
+        pytest.skip("src/content/docs/ が空 — JA corpus 未同期")
+    return pages
+
+
+@pytest.fixture(scope="module")
+def mjs_ja_segments_by_slug(repo_root, node_available, ja_pages) -> dict[str, list]:
+    if not node_available:
+        pytest.skip("node not available")
+    # 288 page を 1 回の node spawn で batch 処理
+    calls = [{"function": "segments_ja_extract", "args": [body]} for _, body in ja_pages]
+    results = run_batch(repo_root, calls, timeout=300.0)
+    return {slug: mjs for (slug, _), mjs in zip(ja_pages, results, strict=True)}
+
+
+def test_ja_corpus_zero_regressions(ja_pages, mjs_ja_segments_by_slug):
+    """288 page で **regression (py_count > mjs_count) が 0 件**。
+
+    Issue #368 の fix は Python 側で segment を **減らす** 方向にしか働かない
+    (nested list flattening)。Python が mjs より **多く** emit するのは必ず
+    regression。全 divergence が flatten 方向であることを hard 確認する。
+    """
+    regressions: list[tuple[str, int, int]] = []
+    for slug, body in ja_pages:
+        py = extract_segments_from_markdown(body)
+        mjs = mjs_ja_segments_by_slug[slug]
+        if len(py) > len(mjs):
+            regressions.append((slug, len(py), len(mjs)))
+
+    assert not regressions, (
+        f"{len(regressions)} page(s) emit more segments than mjs (regression):\n"
+        + "\n".join(f"  {slug}: py={pc} mjs={mc}" for slug, pc, mc in regressions[:10])
+    )
+
+
+def test_ja_corpus_nest_free_pages_byte_identical(ja_pages, mjs_ja_segments_by_slug):
+    """segment 数が mjs と一致する全ページで byte-identical。
+
+    segment 数が一致する = nested list flattening が発動していない = mjs
+    line-based 挙動と揃っている。このサブセットで byte 一致していれば、
+    headings / callout / details / code fence / table / paragraph / image の
+    挙動が mjs と drift していないことを示せる。
+    """
+    byte_divergences: list[str] = []
+    equal_count_pages = 0
+    for slug, body in ja_pages:
+        py = extract_segments_from_markdown(body)
+        mjs = mjs_ja_segments_by_slug[slug]
+        if len(py) != len(mjs):
+            continue  # nested list flatten 発動ページ、本 test の対象外
+        equal_count_pages += 1
+        if py != mjs:
+            # 最初の違いだけ出す
+            first_diff_idx: int | None = None
+            for i, (p, m) in enumerate(zip(py, mjs, strict=True)):
+                if p != m:
+                    first_diff_idx = i
+                    break
+            detail = f"  slug={slug}"
+            if first_diff_idx is not None:
+                detail += (
+                    f"\n    first diff at index {first_diff_idx}:"
+                    f"\n      py  = {py[first_diff_idx]!r}"
+                    f"\n      mjs = {mjs[first_diff_idx]!r}"
+                )
+            byte_divergences.append(detail)
+
+    # 必ず 1 ページ以上 equal_count があるはず (空 corpus なら fixture skip する)
+    assert equal_count_pages > 0, "no nest-free pages found"
+    assert not byte_divergences, (
+        f"{len(byte_divergences)} nest-free page(s) diverge byte-wise from mjs:\n"
+        + "\n".join(byte_divergences[:10])
+    )

--- a/scripts/py/tests/test_segments_ja.py
+++ b/scripts/py/tests/test_segments_ja.py
@@ -377,6 +377,22 @@ class TestListRegionEdgeCases:
         assert kinds == ["unordered-list-item"] * 3
         assert [s["textNorm"] for s in segs] == ["codeish", "more", "real"]
 
+    def test_hard_break_in_list_item_stripped(self):
+        """Markdown hard-break ``\\`` + newline は空白化して textNorm から除去。
+
+        codex review P2 follow-up #3: ``1. step\\\\\\n   next`` のように list
+        item が hardbreak を使うと、markdown-it-py の ``inline.content`` に
+        raw ``\\\\\\n`` が残る。EN walker は ``<br>`` を単なる word-boundary として
+        扱うため、Python 側も hardbreak を空白化して EN と textNorm を揃える。
+        """
+        md = "1. Step one\\\n   Next sentence.\n"
+        segs = extract_segments_from_markdown(md)
+        assert len(segs) == 1
+        assert segs[0]["segmentKind"] == "ordered-list-item"
+        # textNorm に backslash が残らない
+        assert "\\" not in segs[0]["textNorm"]
+        assert segs[0]["textNorm"] == "step one next sentence."
+
     def test_top_level_fence_still_terminates_list_region(self):
         """top-level (non-indented) fence は list region を終了させる。
 

--- a/scripts/py/tests/test_segments_ja.py
+++ b/scripts/py/tests/test_segments_ja.py
@@ -269,6 +269,49 @@ class TestListRegionEdgeCases:
         # horizontal rule 自体は emit されず、後続 paragraph だけ emit
         assert kinds == ["unordered-list-item", "paragraph"]
 
+    def test_indented_fence_inside_list_absorbed(self):
+        """indented code fence は list item に吸収 (codex review P2 #1)。
+
+        CommonMark では indent された code fence が list item continuation に
+        なる。EN HTML walker は ``<li>`` 内の ``<pre>`` を parent list-item
+        の textNorm に連結する。Python JA も同じ挙動で揃える。mjs line-based
+        実装は fence を独立 code-block として emit するため意図的 divergence。
+        """
+        md = (
+            "1. step one\n\n"
+            "   ```js\n"
+            "   var x = 1;\n"
+            "   ```\n\n"
+            "   continuation paragraph\n\n"
+            "2. step two\n"
+        )
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        # 2 list-items のみ。code fence も continuation も item 1 に吸収。
+        assert kinds == ["ordered-list-item", "ordered-list-item"]
+        # item 1 の textNorm に fence body と continuation が含まれる
+        assert "step one" in segs[0]["textNorm"]
+        assert "var x" in segs[0]["textNorm"]
+        assert "continuation paragraph" in segs[0]["textNorm"]
+        assert segs[1]["textNorm"] == "step two"
+
+    def test_top_level_fence_still_terminates_list_region(self):
+        """top-level (non-indented) fence は list region を終了させる。
+
+        indented fence は吸収するが、indent 0 の fence は list の直後の独立
+        code block として emit する (CommonMark でも tight list の後に separate
+        code block として扱われるケース)。
+        """
+        md = "- alpha\n- beta\n\n```js\ncode\n```\n\n- gamma\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == [
+            "unordered-list-item",
+            "unordered-list-item",
+            "code-block",
+            "unordered-list-item",
+        ]
+
     def test_indented_table_inside_list_absorbed_by_commonmark(self):
         """indent された markdown table は list item continuation として吸収。
 

--- a/scripts/py/tests/test_segments_ja.py
+++ b/scripts/py/tests/test_segments_ja.py
@@ -295,6 +295,50 @@ class TestListRegionEdgeCases:
         assert "continuation paragraph" in segs[0]["textNorm"]
         assert segs[1]["textNorm"] == "step two"
 
+    def test_one_space_indent_after_list_emits_paragraph(self):
+        """blank 行 + 1-space indent の行は list continuation にならない。
+
+        codex review P2 follow-up: ``- item\\n\\n x\\n`` のような 1-space indent
+        paragraph は markdown-it-py が list 外の paragraph として parse する。
+        以前の実装では region に含めていたが list-item だけ emit し paragraph
+        を silent に drop していた。list_open.map で実際の list 範囲を特定し、
+        残行を main loop に戻すことで paragraph を正しく emit する。
+        """
+        md = "- item\n\n x\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["unordered-list-item", "paragraph"]
+        assert segs[0]["textNorm"] == "item"
+        assert segs[1]["textNorm"] == "x"
+
+    def test_one_space_indent_after_ordered_list_emits_paragraph(self):
+        md = "1. item\n\n x\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["ordered-list-item", "paragraph"]
+
+    def test_four_space_indent_list_marker_mjs_fallback(self):
+        """4-space indent された list marker は mjs fallback で list-item 化。
+
+        codex review P2 follow-up: CommonMark は ``    - codeish`` を indented
+        code block として扱い list_item token を emit しない。mjs line-based
+        実装は ``_UNORDERED_RE.test(trimmed)`` で match して list-item emit
+        するため、Python も silent drop せずに ``_emit_lines_as_mjs_fallback_list``
+        で mjs と揃える。
+        """
+        md = "    - codeish\n"
+        segs = extract_segments_from_markdown(md)
+        assert len(segs) == 1
+        assert segs[0]["segmentKind"] == "unordered-list-item"
+        assert segs[0]["textNorm"] == "codeish"
+
+    def test_four_space_indent_ordered_marker_mjs_fallback(self):
+        md = "    1. codeish\n"
+        segs = extract_segments_from_markdown(md)
+        assert len(segs) == 1
+        assert segs[0]["segmentKind"] == "ordered-list-item"
+        assert segs[0]["textNorm"] == "codeish"
+
     def test_top_level_fence_still_terminates_list_region(self):
         """top-level (non-indented) fence は list region を終了させる。
 

--- a/scripts/py/tests/test_segments_ja.py
+++ b/scripts/py/tests/test_segments_ja.py
@@ -124,6 +124,21 @@ class TestCallout:
             assert len(segs) == 1, f"{callout_type} not recognised"
             assert segs[0]["segmentKind"] == "callout-body"
 
+    def test_list_inside_callout_keeps_list_kind(self):
+        """``:::note`` 内の list item は ``unordered-list-item`` kind で emit される。
+
+        python-reviewer MEDIUM: ``paragraphKind`` state が ``callout-body`` に
+        flip していても、list region handler は ``_flatten_list_region`` の
+        markup から kind を決定するため、``callout-body`` が list item に漏れ
+        込まない契約。Phase 3 alignment で list 粒度比較が壊れないよう、
+        mjs と同じ挙動 (EN ``walkCalloutBody`` と等価) を明示的に test で pin。
+        """
+        md = ":::note\nIntro paragraph.\n\n- item a\n- item b\n:::\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        # intro paragraph は callout-body、list items は unordered-list-item
+        assert kinds == ["callout-body", "unordered-list-item", "unordered-list-item"]
+
 
 class TestDetailsSummary:
     def test_single_line_details_summary(self):
@@ -204,6 +219,117 @@ class TestHorizontalRule:
         kinds = [s["segmentKind"] for s in segs]
         # heading + 2 paragraphs、horizontal rule は emit されない
         assert kinds == ["heading", "paragraph", "paragraph"]
+
+
+class TestListRegionEdgeCases:
+    """``_collect_list_region`` が non-list content を誤吸収しないことを guard。
+
+    architect review H1 / M2 指摘の edge case を記録する。``_LIST_REGION_TERMINATOR_RES``
+    は heading / callout / code fence / HTML table / horizontal rule / details
+    token / standalone image を terminator に含めるが、これらの組合せが
+    list region 境界で正しく機能することを具体例で確認する。
+    """
+
+    def test_list_ends_at_code_fence_inside_region(self):
+        """list 途中に code fence が来ると region は閉じて code-block が emit。"""
+        md = "- alpha\n\n```js\nvar x = 1;\n```\n\n- beta\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["unordered-list-item", "code-block", "unordered-list-item"]
+
+    def test_indented_non_list_paragraph_after_list_not_absorbed(self):
+        """list の後 blank 行 + 非 indent paragraph は list に吸収されない。"""
+        md = "- item\n\nNon-indented paragraph.\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["unordered-list-item", "paragraph"]
+
+    def test_list_then_heading_terminates_region(self):
+        md = "- item\n\n## Section\n\nBody.\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["unordered-list-item", "heading", "paragraph"]
+
+    def test_list_then_callout_terminates_region(self):
+        md = "- item\n\n:::note\nBody.\n:::\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["unordered-list-item", "callout-body"]
+
+    def test_list_then_standalone_image_terminates_region(self):
+        md = "- item\n\n![alt](/x.png)\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["unordered-list-item", "image"]
+
+    def test_list_then_horizontal_rule_terminates_region(self):
+        md = "- item\n\n---\n\nAfter.\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        # horizontal rule 自体は emit されず、後続 paragraph だけ emit
+        assert kinds == ["unordered-list-item", "paragraph"]
+
+    def test_indented_table_inside_list_absorbed_by_commonmark(self):
+        """indent された markdown table は list item continuation として吸収。
+
+        architect review H1: ``_LIST_REGION_TERMINATOR_RES`` は table row を
+        含まないため、list 内の indented ``| a | b |`` 行は region に取り込まれ
+        ``MarkdownIt("commonmark")`` で parse される。CommonMark は table 未対応
+        (拡張なし) のため、table 文字列は list item の inline text として 1
+        segment に集約される。これは CommonMark semantics の正しい挙動 (blank
+        line 無しで list item に連続する indented 内容は item content)。mjs
+        line-based 実装は各 table row を ``table-cell`` として emit する意図
+        的 divergence。
+        """
+        md = "## X\n\n- item with table\n\n  | h1 | h2 |\n  | - | - |\n  | a | b |\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        # heading + 1 list item (table rows absorbed, no table-cell emit)
+        assert kinds == ["heading", "unordered-list-item"]
+        assert "table-cell" not in kinds
+
+    def test_list_with_blank_and_indented_code_block_continuation(self):
+        """4-space indent の "code-looking" 行が list item の continuation に
+        なるケース (CommonMark では list item 内の indented code block)。
+
+        list region が正しく吸収して 1 item として emit する (nested list と
+        同じ flatten 挙動)。region の後に来る非 indent paragraph は別 segment。
+        """
+        md = "- item\n\n    indented-content-line\n\nAfter paragraph.\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        # CommonMark が indented content を list item に吸収するため、list-item
+        # + paragraph で 2 segment。list-item の textNorm に "indented-content-line"
+        # が含まれることも確認する。
+        assert kinds == ["unordered-list-item", "paragraph"]
+        assert "indented-content-line" in segs[0]["textNorm"]
+        assert segs[1]["textNorm"] == "after paragraph."
+
+
+class TestLooseSummaryENDelegation:
+    """``<details>`` に囲まれていない ``<summary>`` を EN walker に委譲する契約。
+
+    architect review M1: ``segments_ja`` → ``segments_en`` の cross-module
+    依存を guard する。EN walker の return shape が変わった場合の silent
+    regression を防ぐため、具体的な element children (paragraph + list +
+    image) を loose ``<summary>`` inner に入れて、JA emitter 経由で適切な
+    kind に分類されることを確認する。
+    """
+
+    def test_loose_summary_paragraph_inner(self):
+        md = "<summary><p>Plain paragraph</p></summary>\n"
+        segs = extract_segments_from_markdown(md)
+        paragraphs = [s for s in segs if s["segmentKind"] == "paragraph"]
+        assert len(paragraphs) == 1
+        assert paragraphs[0]["textNorm"] == "plain paragraph"
+
+    def test_loose_summary_mixed_inner(self):
+        md = "<summary><p>Intro</p><ul><li>a</li><li>b</li></ul></summary>\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        # EN walker 経由で paragraph + 2 list-item が emit される
+        assert "paragraph" in kinds
+        assert kinds.count("unordered-list-item") == 2
 
 
 class TestSectionPath:

--- a/scripts/py/tests/test_segments_ja.py
+++ b/scripts/py/tests/test_segments_ja.py
@@ -339,6 +339,44 @@ class TestListRegionEdgeCases:
         assert segs[0]["segmentKind"] == "ordered-list-item"
         assert segs[0]["textNorm"] == "codeish"
 
+    def test_fallback_prefix_then_real_list(self):
+        """4-space indent marker (CommonMark code) + real list (codex P2 follow-up).
+
+        ``    - codeish\\n- real\\n`` ではmarkdown-it-py が前者を code_block、
+        後者を list として parse する。prefix を mjs-style で emit してから、
+        CommonMark 側の list を flatten 結果で emit し、全 3 lines を consume
+        する契約。content を silent drop しない。
+        """
+        md = "    - codeish\n- real\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["unordered-list-item", "unordered-list-item"]
+        assert [s["textNorm"] for s in segs] == ["codeish", "real"]
+
+    def test_fallback_then_trailing_paragraph(self):
+        """CommonMark が list を認識しないとき trailing content を drop しない。
+
+        ``    - codeish\\n\\n x\\n`` は markdown-it-py が list を検出しない
+        (code_block + paragraph)。現在行 ``    - codeish`` を mjs fallback で
+        emit し、``i`` を 1 だけ進めることで次行以降を main loop に戻す。
+        main loop は blank 行 + 1-space indent paragraph を正しく emit する
+        (codex review P2 follow-up)。
+        """
+        md = "    - codeish\n\n x\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["unordered-list-item", "paragraph"]
+        assert segs[0]["textNorm"] == "codeish"
+        assert segs[1]["textNorm"] == "x"
+
+    def test_multi_fallback_prefix_and_real_list(self):
+        """prefix に multiple 4-space fallback markers + 本 list の組合せ。"""
+        md = "    - codeish\n    - more\n- real\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["unordered-list-item"] * 3
+        assert [s["textNorm"] for s in segs] == ["codeish", "more", "real"]
+
     def test_top_level_fence_still_terminates_list_region(self):
         """top-level (non-indented) fence は list region を終了させる。
 

--- a/scripts/py/tests/test_segments_ja.py
+++ b/scripts/py/tests/test_segments_ja.py
@@ -1,0 +1,222 @@
+"""``testim_parity.segments_ja`` のユニットテスト。
+
+cross-runtime byte parity は ``tests/conformance/test_segments_ja_parity.py``
+が担保する。こちらは node 不在環境でも動く素早い iteration 用と、Issue #368
+fix (nested list flattening) の explicit regression guard。
+"""
+
+from __future__ import annotations
+
+from testim_parity.segments_ja import extract_segments_from_markdown
+
+
+class TestBasicClassification:
+    def test_non_string_returns_empty(self):
+        assert extract_segments_from_markdown(None) == []  # type: ignore[arg-type]
+        assert extract_segments_from_markdown(123) == []  # type: ignore[arg-type]
+
+    def test_empty_returns_empty(self):
+        assert extract_segments_from_markdown("") == []
+        assert extract_segments_from_markdown("   \n   \n") == []
+
+    def test_h1_skipped_as_title(self):
+        md = "# Title\n\n## Section\n\nBody.\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        # H1 は emit されない、H2 だけ heading
+        assert kinds == ["heading", "paragraph"]
+        assert segs[0]["textNorm"] == "section"
+
+    def test_frontmatter_stripped(self):
+        md = "---\ntitle: T\n---\n\nBody paragraph.\n"
+        segs = extract_segments_from_markdown(md)
+        assert len(segs) == 1
+        assert segs[0]["segmentKind"] == "paragraph"
+        assert segs[0]["textNorm"] == "body paragraph."
+
+    def test_heading_anchor_suffix_stripped(self):
+        md = "## Section Title {#anchor-id}\n\nBody.\n"
+        segs = extract_segments_from_markdown(md)
+        assert segs[0]["segmentKind"] == "heading"
+        assert segs[0]["textNorm"] == "section title"
+
+
+class TestIssue368NestedListFlattening:
+    """Issue #368 の核心: nested list を top-level item 1 segment に flatten。"""
+
+    def test_unordered_nested_flattens(self):
+        md = "- Outer\n  - Nested A\n  - Nested B\n- Sibling\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        # 2 top-level items; nested 2 items are absorbed
+        assert kinds == ["unordered-list-item", "unordered-list-item"]
+        assert "outer" in segs[0]["textNorm"]
+        assert "nested a" in segs[0]["textNorm"]
+        assert "nested b" in segs[0]["textNorm"]
+        assert segs[1]["textNorm"] == "sibling"
+
+    def test_ordered_with_nested_unordered_flattens(self):
+        md = "1. Outer step\n   - sub A\n   - sub B\n2. Next step\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["ordered-list-item", "ordered-list-item"]
+        assert "outer step" in segs[0]["textNorm"]
+        assert "sub a" in segs[0]["textNorm"]
+        assert "sub b" in segs[0]["textNorm"]
+        assert segs[1]["textNorm"] == "next step"
+
+    def test_loose_list_multi_paragraph_merged(self):
+        """loose list (blank line + indented paragraph) も 1 item に merge。
+
+        これは ``administration/project-user-management.md`` 等 50+ ページで見られる
+        パターン。mjs line-based 実装は continuation paragraph を別 segment として
+        emit するため segment count が inflate する。
+        """
+        md = "1. First step.\n\n   Continuation paragraph.\n\n2. Second step.\n"
+        segs = extract_segments_from_markdown(md)
+        list_items = [s for s in segs if "list-item" in s["segmentKind"]]
+        assert len(list_items) == 2
+        assert "first step" in list_items[0]["textNorm"]
+        assert "continuation paragraph" in list_items[0]["textNorm"]
+        assert "second step" in list_items[1]["textNorm"]
+
+    def test_flat_list_unchanged(self):
+        """nest なしの list は従来通り 1 item = 1 segment。"""
+        md = "- alpha\n- beta\n- gamma\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["unordered-list-item"] * 3
+        assert [s["textNorm"] for s in segs] == ["alpha", "beta", "gamma"]
+
+    def test_list_segment_index_counter(self):
+        """flatten 後も ``(sectionPath, kind)`` 毎の segmentIndex は連番。"""
+        md = "## S\n\n- a\n- b\n- c\n"
+        segs = extract_segments_from_markdown(md)
+        list_items = [s for s in segs if "list-item" in s["segmentKind"]]
+        assert [s["segmentIndex"] for s in list_items] == [0, 1, 2]
+
+
+class TestCallout:
+    def test_note_callout_body_kind(self):
+        md = ":::note\nInside note.\n:::\n"
+        segs = extract_segments_from_markdown(md)
+        assert len(segs) == 1
+        assert segs[0]["segmentKind"] == "callout-body"
+        assert segs[0]["textNorm"] == "inside note."
+
+    def test_callout_with_title_attr(self):
+        md = ':::note{title="重要"}\nBody here.\n:::\n'
+        segs = extract_segments_from_markdown(md)
+        callouts = [s for s in segs if s["segmentKind"] == "callout-body"]
+        assert len(callouts) == 1
+        assert callouts[0]["textNorm"] == "body here."
+
+    def test_callout_close_restores_paragraph_kind(self):
+        md = ":::warning\nWarn.\n:::\n\nAfter callout.\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        assert kinds == ["callout-body", "paragraph"]
+
+    def test_all_callout_types_recognised(self):
+        for callout_type in ("note", "warning", "info", "tip", "caution", "danger"):
+            md = f":::{callout_type}\nBody.\n:::\n"
+            segs = extract_segments_from_markdown(md)
+            assert len(segs) == 1, f"{callout_type} not recognised"
+            assert segs[0]["segmentKind"] == "callout-body"
+
+
+class TestDetailsSummary:
+    def test_single_line_details_summary(self):
+        md = "<details><summary>Q</summary><p>body</p></details>\n"
+        segs = extract_segments_from_markdown(md)
+        summaries = [s for s in segs if s["segmentKind"] == "details-summary"]
+        assert len(summaries) == 1
+        assert summaries[0]["textNorm"] == "q"
+
+    def test_loose_summary_delegates_to_en_walker(self):
+        """``<summary>`` が ``<details>`` に囲まれていないとき EN walker に委譲する。"""
+        md = "<summary>Loose summary</summary>\n"
+        segs = extract_segments_from_markdown(md)
+        # EN walker 経由で paragraph などに分類される
+        assert len(segs) >= 1
+
+
+class TestCodeFence:
+    def test_backtick_fence_emits_code_block(self):
+        md = "## X\n\n```js\nvar x = 1;\n```\n"
+        segs = extract_segments_from_markdown(md)
+        code_blocks = [s for s in segs if s["segmentKind"] == "code-block"]
+        assert len(code_blocks) == 1
+        assert "var x = 1;" in code_blocks[0]["textNorm"]
+
+    def test_tilde_fence_emits_code_block(self):
+        md = "## X\n\n~~~py\nprint(1)\n~~~\n"
+        segs = extract_segments_from_markdown(md)
+        code_blocks = [s for s in segs if s["segmentKind"] == "code-block"]
+        assert len(code_blocks) == 1
+
+
+class TestTable:
+    def test_markdown_table_emits_tbody_cells(self):
+        md = "| a | b |\n| - | - |\n| 1 | 2 |\n| 3 | 4 |\n"
+        segs = extract_segments_from_markdown(md)
+        cells = [s for s in segs if s["segmentKind"] == "table-cell"]
+        # header row + separator 除外、data row 2 × 2 column = 4 cell
+        assert [s["textNorm"] for s in cells] == ["1", "2", "3", "4"]
+
+    def test_html_table_tbody_filter(self):
+        md = (
+            "<table>"
+            "<thead><tr><th>H</th></tr></thead>"
+            "<tbody><tr><td>Data1</td><td>Data2</td></tr></tbody>"
+            "</table>\n"
+        )
+        segs = extract_segments_from_markdown(md)
+        cells = [s for s in segs if s["segmentKind"] == "table-cell"]
+        # thead は除外、tbody の td のみ
+        assert [s["textNorm"] for s in cells] == ["data1", "data2"]
+
+    def test_escaped_pipe_in_cell_preserved(self):
+        md = "| a | b |\n| - | - |\n| pipe\\|here | normal |\n"
+        segs = extract_segments_from_markdown(md)
+        cells = [s for s in segs if s["segmentKind"] == "table-cell"]
+        # backslash-escaped pipe は literal として残る
+        assert any("pipe|here" == s["textNorm"] for s in cells)
+
+
+class TestImage:
+    def test_standalone_markdown_image_emits_image(self):
+        md = "## X\n\n![alt text](/img.png)\n"
+        segs = extract_segments_from_markdown(md)
+        images = [s for s in segs if s["segmentKind"] == "image"]
+        assert len(images) == 1
+
+    def test_img_tag_emits_image(self):
+        md = '## X\n\n<img src="/img.png" alt="A" />\n'
+        segs = extract_segments_from_markdown(md)
+        assert any(s["segmentKind"] == "image" for s in segs)
+
+
+class TestHorizontalRule:
+    def test_horizontal_rule_not_emitted(self):
+        md = "## X\n\nBefore.\n\n---\n\nAfter.\n"
+        segs = extract_segments_from_markdown(md)
+        kinds = [s["segmentKind"] for s in segs]
+        # heading + 2 paragraphs、horizontal rule は emit されない
+        assert kinds == ["heading", "paragraph", "paragraph"]
+
+
+class TestSectionPath:
+    def test_nested_section_path(self):
+        md = "## A\n\n### A1\n\npara1\n\n#### A1-1\n\npara2\n"
+        segs = extract_segments_from_markdown(md)
+        paragraphs = [s for s in segs if s["segmentKind"] == "paragraph"]
+        assert paragraphs[0]["sectionPath"] == "A > A1"
+        assert paragraphs[1]["sectionPath"] == "A > A1 > A1-1"
+
+    def test_heading_stack_truncated_on_shallower_heading(self):
+        md = "## A\n\n### A1\n\npara1\n\n## B\n\npara2\n"
+        segs = extract_segments_from_markdown(md)
+        paragraphs = [s for s in segs if s["segmentKind"] == "paragraph"]
+        assert paragraphs[0]["sectionPath"] == "A > A1"
+        assert paragraphs[1]["sectionPath"] == "B"


### PR DESCRIPTION
## Summary

Port `scripts/lib/source_parity_segments_ja.mjs` (715 LOC) to
`scripts/py/src/testim_parity/segments_ja.py` (~730 LOC) per
`docs/PYTHON_MIGRATION_PLAN.md` Phase 2. Fix Issue #368 (nested list
flattening parity gap) via a HYBRID approach:

- mjs line-based regex state machine ported verbatim for headings,
  callouts, `<details>`/`<summary>`, code fences, HTML+markdown
  tables, images, horizontal rules, and paragraph classification —
  byte-identical conformance with mjs on all nest-free JA markdown.
- List regions delegate to `markdown-it-py`'s CommonMark AST: only
  top-level `list_item_open`/`list_item_close` boundaries emit
  segments; nested items, indented code fences, indented images,
  and indented continuation paragraphs flatten into the parent
  item's `textNorm` (matches the EN HTML walker's
  `collectInlineText` behaviour).

## Corpus metrics (288 JA pages)

| Metric | Value |
|---|---|
| byte-identical with mjs | 141 (nest-free subset) |
| Python flattens vs mjs | 147 (intentional divergence) |
| regression pages (py > mjs) | **0** |
| total tests | 390 |
| coverage | 94.96% (segments_ja.py 92%) |
| mjs test suite (npm test) | 2040 pass / 1 skip (unchanged) |

Zero regressions hard-guarded by
`test_ja_corpus_zero_regressions` + static `_NEST_FREE_CORPUS_SIZE`
pin (`test_ja_corpus_nest_free_count_pinned`).

## Reviewer gate

All four specialist reviewers consulted per the project's
4-reviewer convention:

- **python-reviewer**: MERGE with MED/LOW follow-ups. Addressed
  counter-key tuple swap, `body: object` API clarity,
  `_CODE_INNER_STRIP_RE` → `_HTML_TAG_STRIP_RE` rename, and the
  `multiline_summary_start_line or` footgun. New test
  `test_list_inside_callout_keeps_list_kind` guards callout/list
  kind separation.
- **typescript-reviewer**: MERGE. Added cross-reference comment on
  the new `segments_ja_extract` harness dispatch entry.
- **architect**: addressed H1 (indented table documentation), H3
  (static corpus-shape pin), M1 (loose-summary EN delegation
  conformance test), M2 (region terminator edge-case tests), L1
  (`_MD_PARSER` thread-safety note), L2 (migration-plan pattern
  table). Separator asymmetry follow-up documented for Phase 3.
- **codex**: three rounds of P2 fixes applied —
  1. Indented fence / image inside list item now absorbed into the
     parent list-item textNorm (matches EN walker).
  2. 1-space indent paragraphs after lists no longer silently
     dropped; 4-space indented list markers fall back to mjs-style
     single-line emission (CommonMark-rejected input).
  3. Fallback prefix lines before a CommonMark-recognised list are
     emitted via mjs fallback before the flattened list; trailing
     non-list content returns to the main loop for reprocessing.
  4. Markdown hard break (`\` + newline) in list items normalised
     to whitespace so JA textNorm matches the EN walker.

## Known follow-ups (deferred to Phase 3)

- **Boundary stability ≥ 0.95 measurement** — requires
  `source_parity_align.mjs` port (Phase 3).
- **Flatten separator symmetry with EN walker** — Python JA joins
  inline content with `" "`; EN walker concatenation may differ in
  some shapes. Weighted-LCS absorbs single-space deltas; diagnostic
  planned at Phase 3 start.
- **`lines[i] = remainder` in-place mutation** (python-reviewer
  MED #1) — refactor to `pending: str | None` slot before Phase 4
  cutover.

## Test plan

- [x] `uv run pytest` → 390 pass (26 unit + 3 conformance +
      supporting = 390; 94.96% coverage)
- [x] `uv run ruff check src tests` / `ruff format --check` — clean
- [x] `uv run mypy src` — clean (16 source files)
- [x] `npm test` — 2040/2041 (1 skip, unchanged from Phase 1)
- [x] 288 JA page byte-identical / regression counts verified
- [ ] Phase 3 alignment scoring run (deferred per plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)