### PR TITLE
Phase 4b.1: turndown 288-matrix byte-parity (xfail removed)

### DIFF
--- a/docs/PYTHON_MIGRATION_PLAN.md
+++ b/docs/PYTHON_MIGRATION_PLAN.md
@@ -949,6 +949,34 @@ CI は `npm run test:all` を実行。mjs テストファイルが 1 つ移植�
 - `scripts/pipeline/` (6 mjs files)
 - `scripts/tools/` (6 mjs tool files → py/ に移動済)
 
+### Conformance test migration (Phase 6 cutover 時、reviewer P7 対応)
+
+Phase 4b で導入された cross-runtime conformance test は mjs harness
+(`scripts/py/conformance/harness.mjs`) を spawn する前提で動作するため、mjs
+削除と同時にそのままでは run できなくなる。cutover 時に以下 3 種類へ分岐して
+処理する:
+
+| 種別 | 対象 test | cutover 時の扱い |
+| --- | --- | --- |
+| **A. byte-parity regression gate** | `tests/conformance/test_turndown_288_matrix.py`, `test_segments_en_parity.py`, `test_segments_ja_parity.py` 等 | **golden snapshot 化**: cutover 直前に mjs harness を最後に一度回し、288-page 分の期待出力を `tests/fixtures/golden/<module>.jsonl` に保存。以降の Python-only 実装は本 fixture と byte 比較する。mjs side の仕様変更は発生しない (mjs は削除済) ので fixture は frozen reference として扱う |
+| **B. dual-source-of-truth drift** | `test_en_source_patches_parity.py` | patch の唯一ソースが mjs (`en_source_patches.mjs`) でなくなるため、mjs / JSON の drift 検出目的自体が消滅。cutover 時に test を削除し、patch data を `_en_source_patches_data.json` ではなく Python dict として `en_source_patches.py` に inline 化する |
+| **C. pure helper conformance** | `test_align_scoring_parity.py` / `test_normalize_parity.py` 等 pure-function byte parity | 同じく golden snapshot 化。harness dispatch を fixture-based に書き換える |
+
+**fixture 生成スクリプト** (cutover PR で追加予定、Phase 6 gate の一部):
+
+```bash
+# 最後の mjs run で golden を出力して commit
+node scripts/py/conformance/harness.mjs --dump-golden > tests/fixtures/golden/turndown_288.jsonl
+```
+
+fixture は `jsonl` (1 行 1 sample) 形式にして、将来 sample を追加する際の diff
+を review-friendly に保つ。conformance harness は cutover PR で retire する
+(node 呼び出し path が消えるため)。
+
+**Phase 6 gate への影響**: `scripts/__tests__/*.mjs` と同じく、cutover 前に
+harness → golden fixture への書き換え PR を挟む。書き換え後の Python-only
+run が 288-matrix で pass することが Phase 6 gate の前提条件になる。
+
 ### dependency 変更 (cutover 時点で実行)
 
 - Remove: `turndown` (全 mjs 削除後、依存するスクリプトが存在しない)

--- a/docs/PYTHON_MIGRATION_PLAN.md
+++ b/docs/PYTHON_MIGRATION_PLAN.md
@@ -790,45 +790,56 @@ Phase 4b: turndown 等価実装 (markdownify + custom converters) を整えて�
 | Milestone | 対象 | 状態 |
 | --- | --- | --- |
 | **M1** | ``testim_parity.turndown`` — mjs ``convertEnHtmlToMd`` / ``turndown.turndown`` 等価 (markdownify + MadCap custom converters: callout / copy-button strip / ol siblings / pipe table / details+summary) | ✅ 39 代表 pattern で mjs と byte-identical (17 unit + 2 parity sample) — PR #375 merged |
-| **M2** | ``check_source_parity.py`` full port (915 LOC, turndown 依存解消) | 🟡 **orchestration 完了** — 38 unit tests、``parity-check-status.json`` schema / 副作用 shape mjs 互換、DI 完備。M5 conformance (baseline / snapshot_diff) で 2 CLI は mjs byte-parity。**turndown 依存 path の full-corpus byte parity は Phase 4b.1 で解消**、PR #376 |
-| **M3** | ``snapshot_update.py`` full port (486 LOC, HTTP + retry + BS4) | 🟡 **orchestration 完了** — 33 unit tests (depth tracking / retry / recovery probe / DI stdout+stderr / registry drift / root_dir input isolation)、PR #376 |
-| **M4** | ``fetch_translate_images.py`` full port (409 LOC, turndown 依存解消) | ✅ 完了 — 22 unit tests、module coverage 88%、PR #376 |
-| **M5** | 4 CLI (generate_parity_baseline / snapshot_diff / check_upstream_recovery / render_upstream_recovery_comment) の end-to-end mjs byte parity | ✅ 完了 — 14 integration tests、全 byte-identical、semantic delta 0 件、PR #376 |
+| **M2** | ``check_source_parity.py`` full port (915 LOC, turndown 依存解消) | ✅ **完了** — 38 unit tests、``parity-check-status.json`` schema / 副作用 shape mjs 互換、DI 完備。M5 conformance (baseline / snapshot_diff) で 2 CLI は mjs byte-parity。turndown full-corpus byte parity は Phase 4b.1 で達成 |
+| **M3** | ``snapshot_update.py`` full port (486 LOC, HTTP + retry + BS4) | ✅ **完了** — 33 unit tests (depth tracking / retry / recovery probe / DI stdout+stderr / registry drift / root_dir input isolation) |
+| **M4** | ``fetch_translate_images.py`` full port (409 LOC, turndown 依存解消) | ✅ 完了 — 22 unit tests、module coverage 88% |
+| **M5** | 4 CLI (generate_parity_baseline / snapshot_diff / check_upstream_recovery / render_upstream_recovery_comment) の end-to-end mjs byte parity | ✅ 完了 — 14 integration tests、全 byte-identical、semantic delta 0 件 |
 
-### Phase 4b.1 follow-up (reviewer P2#2 対応)
+### Phase 4b.1 (2026-04-22 完了)
 
 **Goal**: ``convert_en_html_to_md`` を 288-page corpus 全体で mjs と byte-
-identical にする。現状 ~168 / 288 page が divergent (reviewer round-3 の
-調査で確認)。
+identical にする。M1 時点で 168 / 288 page が divergent、Phase 4b.1 で全て
+解消。
 
-| カテゴリ | divergence 件数 | 内容 |
+| カテゴリ | divergence 件数 | 解消方法 |
 | --- | --- | --- |
-| leading_ws | 84 | ``<br/>`` 等の block boundary 後の leading whitespace collapse |
-| other | 43 | whitespace 複合 / markdownify inline detection 差 |
-| trailing_ws | 23 | list item の trailing 2-space (hard line break) |
-| plus_escape | 13 | ``+`` の markdown list-marker escape (``\+``) |
-| image_concat | 4 | 隣接 ``<img>`` の inline 連結 |
-| hash_escape | 1 | paragraph 内 ``#`` の ATX-heading escape (``\#``) |
+| leading_ws | 67 | ``_collapse_whitespace`` — block / ``<br>`` 境界の leading ws trim |
+| other | 74 | ``_turndown_escape`` の 13 escape 規則 + ``autolinks=False`` |
+| trailing_ws | 13 | ``convert_p`` override で ``<br>`` hard break の trailing `` <SP><SP>\\n `` を preserve |
+| plus_escape | 10 | ``_turndown_escape`` の `` ^+<SP> `` rule |
+| image_concat | 3 | ``_collapse_whitespace`` の void element 隣接 text space preservation |
+| hash_escape | 1 | ``_turndown_escape`` の `` ^#<SP> `` rule |
 
-すべて M1 で取り込まなかった turndown default rule の追加 port で解消できる
-(markdownify subclass の converter を拡張 + ``_normalize_output`` の
-post-processing)。
+**実装**:
 
-**Gate**: ``tests/conformance/test_turndown_288_matrix.py`` が ``xfail``
-marker なしで pass する。Phase 6 atomic cutover までには必ず閉じる。
+- ``_collapse_whitespace(root)`` — BS4 tree 上で mjs turndown の
+  ``collapseWhitespace`` (``node_modules/turndown/lib/turndown.cjs.js``
+  L457-523) を in-place 再現。text node を DFS 走査して block / ``<br>``
+  boundary の leading/trailing space を削り、void element 隣接 text の
+  leading space は preserve する
+- ``_turndown_escape(text)`` — mjs turndown の 13 escape 規則を順序通り
+  適用 (``^-`` / `` ^+<SP> `` / ``^(=+)`` / `` ^(#{1,6})<SP> `` /
+  ``` ` ``` / ``^~~~`` / ``[`` / ``]`` / ``^>`` / ``_`` /
+  `` ^(\\d+)\\.<SP> `` / ``\\\\`` / ``\\*``)。
+  ``_TurndownConverter.escape`` が markdownify の per-text-node hook 経由で
+  呼び、converter が emit する marker (``**`` / `` *<SP><SP><SP> `` 等)
+  は escape されない契約を維持
+- ``_TurndownConverter.convert_p`` — ``content.strip("\\n")`` に限定し、
+  trailing `` <SP><SP>\\n `` (``<br>`` hard break) を preserve する。
+  blank-only paragraph は ``""`` に倒す (mjs ``blankReplacement`` 等価)
+- ``_TurndownConverter.DefaultOptions.autolinks = False`` — markdownify
+  default の ``<URL>`` 縮約を無効化
 
-**現時点の test 配置**: 本テストは追加済み (PR #376 reviewer round-3) で
-``@pytest.mark.xfail(strict=False)`` でレポートされる。M2 / M3 orchestration
-が mjs と **同じ parity-check-status schema** を出力することは M5 conformance
-で確認済なので、merge 後も regression gate として機能する。
+**Gate**: ``tests/conformance/test_turndown_288_matrix.py`` が xfail marker
+なしで pass (288 / 288 byte-identical)。Phase 6 atomic cutover で mjs を
+削除するまで regression gate として run し続ける。
 
-### Phase 4b M1 byte-parity scope (現状)
+### Phase 4b M1 byte-parity scope (履歴)
 
-M1 時点では **39 代表 HTML pattern** (mjs turndown 実出力を harness 経由で batch 取得し
-byte 比較) でのみ parity を保証する。288-page corpus 全体の byte parity 計測は
-M2/M3 integration 時に ``test_convert_en_html_to_md_288_matrix`` を追加して
-実施する (Issue #368 の nested-list flatten は JA extractor 側で完結するため
-EN side の turndown 出力は従来通り mjs 互換の文字列を要求する)。
+M1 時点 (2026-04-22) では **39 代表 HTML pattern** で parity を保証。288-page
+corpus 全体の byte parity は Phase 4b.1 で上記 ``_collapse_whitespace`` +
+``_turndown_escape`` + ``convert_p`` 追加により達成した。以下は M1 で既に
+存在したカバー範囲:
 
 **M1 カバー範囲**:
 

--- a/scripts/py/src/testim_parity/turndown.py
+++ b/scripts/py/src/testim_parity/turndown.py
@@ -9,8 +9,8 @@ Python 版は ``markdownify.MarkdownConverter`` を subclass し、必要な
 output format (``*   `` 3-space bullet / ``**bold**`` / ``_italic_`` / ATX heading /
 fenced code with language) を replicate する。
 
-**turndown default rule の Python port**: review round-1/2 P1/P2 対応で以下を
-上書き実装:
+**turndown default rule の Python port**: review round-1/2 P1/P2 + Phase 4b.1
+対応で以下を上書き実装:
 
 - ``convert_li`` — leading ``\\n`` strip + trailing ``\\n+`` collapse +
   ``\\n`` → ``\\n    `` (4-space indent)。nested list / multi-paragraph
@@ -26,21 +26,32 @@ fenced code with language) を replicate する。
 - ``convert_img`` — ``![alt](src "title")`` を常に emit (markdownify default
   の ``_inline`` context alt-text fallback を無効化)。table cell / heading
   内の ``<img>`` を preserve する
+- ``convert_p`` — turndown と同じく paragraph content の trailing ``  \\n``
+  (``<br>`` hard break) を preserve。markdownify default の
+  ``strip(' \\t\\r\\n')`` を回避 (Phase 4b.1)
+- ``escape`` — mjs turndown の 13 escape 規則 (``^-`` / ``^+ `` / ``^# `` /
+  ``` ` ``` / ``_`` / ``[`` / ``]`` / ``^>`` / ``^~~~`` / ``^(\\d+)\\. ``)
+  を ``_turndown_escape`` 経由で適用 (Phase 4b.1)
+- ``autolinks = False`` — ``<a href=URL>URL</a>`` の ``<URL>`` 縮約を無効化
+  (Phase 4b.1)
 - ``_strip_empty_inline_elements`` — raw HTML 段階で ``<em></em>`` /
   ``<em>   </em>`` 等の空 inline を除去。mjs turndown の DOM whitespace
   normalization を emulate し、``A <em></em> B`` → ``A B`` (単一 space) に
   collapse する
+- ``_collapse_whitespace`` — mjs turndown の DOM ``collapseWhitespace`` を
+  BS4 tree 上で pre-pass として再現 (Phase 4b.1)。block / ``<br>`` 境界の
+  leading ws trim + void element 隣接 text の space preservation で、
+  ``<img>\\n<img>`` → ``![](a) ![](b)`` や ``<p>X<br/> Y</p>`` →
+  ``X  \\nY`` を mjs と byte-identical にする
 - ``_normalize_output`` は fence-aware split (``_FENCE_BLOCK_RE``) で code
   fence 内部の連続空行を preserve する。mjs turndown は code content を
   byte for byte 保持するため、global な ``\\n{3,}`` → ``\\n\\n`` collapse は
   fence 外側のみ適用する必要がある (round-4 P1 対応)
 
-**byte-parity 戦略**: 39 代表 MadCap pattern (5 custom rule + nested list +
-multi-paragraph li + table cell img + heading img + 8 emphasis flanking
-whitespace / empty inline / empty li + 3 code fence blank-line preservation
-+ 4 preprocess chain) を unit test で mjs turndown 出力と byte 比較。
-288-page corpus 全体の byte-parity は M2/M3 integration 時に計測する
-(``test_convert_en_html_to_md_288_matrix``)。
+**byte-parity 戦略**: 39 代表 MadCap pattern を unit test で mjs turndown
+出力と byte 比較 + 288-page corpus 全体を
+``tests/conformance/test_turndown_288_matrix.py`` で byte 比較
+(Phase 4b.1 で全 pass)。
 
 ``preprocess_en_html`` は既存の ``preprocess_en`` module の re-export。
 """
@@ -50,7 +61,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from bs4 import NavigableString, Tag
+from bs4 import BeautifulSoup, Comment, NavigableString, Tag
 from markdownify import MarkdownConverter
 
 from .preprocess_en import preprocess_en_html
@@ -62,6 +73,250 @@ _CALLOUT_CLASS_MAP: dict[str, str] = {
     "note": "note",
     "caution": "caution",
 }
+
+# turndown の DOM whitespace collapse 実装で判定に使う block / void 要素集合。
+# source: ``node_modules/turndown/lib/turndown.cjs.js`` (isBlock / isVoid +
+# block-elements.js / void-elements.js の export list)。
+_TURNDOWN_BLOCK_ELEMENTS: frozenset[str] = frozenset(
+    {
+        "address",
+        "article",
+        "aside",
+        "audio",
+        "blockquote",
+        "body",
+        "canvas",
+        "center",
+        "dd",
+        "dir",
+        "div",
+        "dl",
+        "dt",
+        "fieldset",
+        "figcaption",
+        "figure",
+        "footer",
+        "form",
+        "frameset",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "hgroup",
+        "hr",
+        "html",
+        "isindex",
+        "li",
+        "main",
+        "menu",
+        "nav",
+        "noframes",
+        "noscript",
+        "ol",
+        "output",
+        "p",
+        "pre",
+        "section",
+        "table",
+        "tbody",
+        "td",
+        "tfoot",
+        "th",
+        "thead",
+        "tr",
+        "ul",
+    }
+)
+_TURNDOWN_VOID_ELEMENTS: frozenset[str] = frozenset(
+    {
+        "area",
+        "base",
+        "br",
+        "col",
+        "command",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "keygen",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    }
+)
+
+# turndown の escape 関数が適用する 13 の置換ルール (順序保存)。
+# source: ``node_modules/turndown/lib/turndown.cjs.js`` ``var escapes = [...]``。
+# Python ``re`` と JS 正規表現は一部 syntax が異なるため、pattern は JS regex を
+# そのまま Python re に移植した形にしてある ($ / ^ の意味は同じで、本ルールでは
+# ``\Z`` に書き換える必要はない — 全ルールが行頭/終端以外で sub する)。
+_TURNDOWN_ESCAPES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\\"), r"\\\\"),
+    (re.compile(r"\*"), r"\\*"),
+    (re.compile(r"^-"), r"\\-"),
+    (re.compile(r"^\+ "), r"\\+ "),
+    (re.compile(r"^(=+)"), r"\\\1"),
+    (re.compile(r"^(#{1,6}) "), r"\\\1 "),
+    (re.compile(r"`"), r"\\`"),
+    (re.compile(r"^~~~"), r"\\~~~"),
+    (re.compile(r"\["), r"\\["),
+    (re.compile(r"\]"), r"\\]"),
+    (re.compile(r"^>"), r"\\>"),
+    (re.compile(r"_"), r"\\_"),
+    (re.compile(r"^(\d+)\. "), r"\1\\. "),
+)
+
+
+def _turndown_escape(text: str) -> str:
+    """mjs turndown の ``TurndownService.prototype.escape`` 等価。
+
+    13 regex を順序通り適用する。``escape`` は per-text-node で呼ばれ、
+    converter が emit する markdown marker (``**`` / ``*   `` 等) には
+    適用されない (markdownify の ``process_text`` が text node にだけ
+    escape を呼ぶため)。
+    """
+    if not text:
+        return ""
+    result = text
+    for pattern, replacement in _TURNDOWN_ESCAPES:
+        result = pattern.sub(replacement, result)
+    return result
+
+
+def _is_turndown_block(el: Any) -> bool:
+    return isinstance(el, Tag) and el.name in _TURNDOWN_BLOCK_ELEMENTS
+
+
+def _is_turndown_void(el: Any) -> bool:
+    return isinstance(el, Tag) and el.name in _TURNDOWN_VOID_ELEMENTS
+
+
+def _is_pre_element(el: Any) -> bool:
+    return isinstance(el, Tag) and el.name == "pre"
+
+
+_WHITESPACE_RUN_RE: re.Pattern[str] = re.compile(r"[ \r\n\t]+")
+
+
+def _collapse_whitespace(root: Tag | BeautifulSoup) -> None:
+    """mjs turndown の ``collapseWhitespace`` を BS4 tree に対して in-place 実行する。
+
+    source: ``node_modules/turndown/lib/turndown.cjs.js`` の ``collapseWhitespace``
+    関数 (L457-523) の Python port。
+
+    アルゴリズム:
+      1. 全 text node の ``[ \\r\\n\\t]+`` を single ``" "`` に collapse
+      2. block 要素 / ``<br>`` の前後で trailing/leading space を削除
+      3. void 要素 / ``<pre>`` (inline) の隣接 text は leading space を保持
+         (これが ``<img> <img>`` 間の space preservation を成立させる)
+      4. ``<pre>`` 配下は touch しない (code content の byte-for-byte preserve)
+
+    markdownify の ``process_text`` は空白を line-oriented に縮約するため
+    (``\\n`` を preserve)、``<img>\\n<img>`` が ``![](a)\\n![](b)`` になる。
+    本関数は事前に ``\\n`` を ``" "`` に畳み込み、block/br boundary の
+    leading/trailing space のみを削るため、``![](a) ![](b)`` に揃う。
+    """
+    if not isinstance(root, (Tag, BeautifulSoup)):
+        return
+
+    # Comment / Doctype は collapse 対象外 — そのまま残す。markdownify 側で扱う。
+
+    prev_text: NavigableString | None = None
+    keep_leading_ws = False
+
+    pending_to_remove: list[NavigableString] = []
+
+    def _iter(node: Tag | BeautifulSoup) -> Any:
+        # pre 配下は skip (textContent を preserve する)
+        if _is_pre_element(node):
+            return
+        for child in list(node.children):
+            yield from _visit(child)
+
+    def _visit(node: Any) -> Any:
+        nonlocal prev_text, keep_leading_ws
+        if isinstance(node, Comment):
+            # turndown は Comment に特別 path を持たないが、markdownify 側で
+            # strip される。collapseWhitespace pass 上は単に skip。
+            return
+        if isinstance(node, NavigableString):
+            # NavigableString の subclass (Comment 等) は上で弾かれているので
+            # ここは純粋 text node。
+            text = _WHITESPACE_RUN_RE.sub(" ", str(node))
+            if (
+                (prev_text is None or str(prev_text).endswith(" "))
+                and not keep_leading_ws
+                and text.startswith(" ")
+            ):
+                text = text[1:]
+            if not text:
+                pending_to_remove.append(node)
+                return
+            # NavigableString は immutable だが ``replace_with`` で新しい
+            # instance に差し替えれば prev_text chain は壊れる。BS4 の
+            # ``.string = value`` は NavigableString のみ書き換え不可なので
+            # 明示的に replace_with を使う。
+            new_text = NavigableString(text)
+            node.replace_with(new_text)
+            prev_text = new_text
+            return
+        if isinstance(node, Tag):
+            if _is_pre_element(node):
+                # pre subtree を丸ごと skip。後続 text は block 相当として
+                # leading ws を削る (= prev_text/keep_leading_ws をリセット)。
+                prev_text = None
+                keep_leading_ws = True
+                return
+            if node.name == "br" or _is_turndown_block(node):
+                if prev_text is not None:
+                    trimmed = re.sub(r" $", "", str(prev_text))
+                    if trimmed != str(prev_text):
+                        new_text = NavigableString(trimmed)
+                        prev_text.replace_with(new_text)
+                        # 空になったら removable 扱い (後で _visit loop 後に消す)
+                        if not trimmed:
+                            pending_to_remove.append(new_text)
+                prev_text = None
+                keep_leading_ws = False
+                # block / br の子供は独立した文脈として再帰
+                yield from _iter(node)
+                return
+            if _is_turndown_void(node):
+                prev_text = None
+                keep_leading_ws = True
+                # void 要素は children を持たない
+                return
+            # inline non-void: prev_text があれば keepLeadingWs を解除
+            if prev_text is not None:
+                keep_leading_ws = False
+            yield from _iter(node)
+            return
+
+    # DFS を起動
+    for _ in _iter(root):
+        pass
+
+    # 末尾の prev_text の trailing space を削る
+    if prev_text is not None:
+        trimmed = re.sub(r" $", "", str(prev_text))
+        if trimmed != str(prev_text):
+            if not trimmed:
+                pending_to_remove.append(prev_text)
+            else:
+                new_text = NavigableString(trimmed)
+                prev_text.replace_with(new_text)
+
+    for dead in pending_to_remove:
+        # replace_with 後に parent が None になっている場合があるので防御的に
+        if dead.parent is not None:
+            dead.extract()
+
 
 # ``convert_li`` / ``convert_ul`` の turndown 互換 transformation に使う正規表現。
 # mjs turndown の JS 版: ``content.replace(/^\n+/, '')`` 等価。
@@ -218,6 +473,9 @@ class _TurndownConverter(MarkdownConverter):
         escape_asterisks = False
         escape_underscores = False
         escape_misc = False
+        # ``<a href=URL>URL</a>`` を markdownify default では ``<URL>`` autolink
+        # 形式に縮約するが、mjs turndown は ``[URL](URL)`` 形式を維持する。
+        autolinks = False
 
     class Options(MarkdownConverter.Options):
         heading_style = "atx"
@@ -227,6 +485,44 @@ class _TurndownConverter(MarkdownConverter):
         escape_asterisks = False
         escape_underscores = False
         escape_misc = False
+        autolinks = False
+
+    # ------------------------------------------------------------------
+    # escape — mjs turndown の 13 規則を honor (Phase 4b.1 P2#2 対応)。
+    # markdownify default の ``escape_misc`` / ``escape_asterisks`` /
+    # ``escape_underscores`` では覆えない escape (``^+ `` / ``^# `` / ``` ` ``` /
+    # ``[`` / ``]`` / ``_`` 等) を ensure するため、markdownify の ``escape``
+    # hook を直接 override する。
+    #
+    # NOTE: markdownify converter が emit する marker (``**`` / ``*   `` /
+    # ``[text](href)`` 等) は ``process_text`` → ``escape`` の経路を通らないので、
+    # marker 自体が escape されることはない。
+    # ------------------------------------------------------------------
+    def escape(self, text: str, parent_tags: Any) -> str:
+        return _turndown_escape(text)
+
+    # ------------------------------------------------------------------
+    # <p> — turndown の paragraph rule は ``\n\n + content + \n\n`` で包み、
+    # content の trailing whitespace を trim しない。markdownify default は
+    # ``text.strip(' \t\r\n')`` で ``<br>`` hard-break の ``  \n`` を消して
+    # しまうため、byte-parity が崩れる (Phase 4b.1 trailing_ws 対応)。
+    #
+    # content が純 whitespace-only の場合だけ mjs ``blankReplacement`` 経路で
+    # 空文字にする。それ以外は leading ``\n`` のみ削って ``\n\n`` wrapping を
+    # かける (markdownify は child の前後に既に whitespace を付けるため、単純な
+    # ``\n\n{content}\n\n`` だと余計 ``\n`` が増えるので ``strip('\n')`` で
+    # 揃える — ``strip(' \t\r\n')`` と違い trailing ``  `` は残る)。
+    # ------------------------------------------------------------------
+    def convert_p(self, el: Tag, text: str, parent_tags: Any) -> str:
+        if "_inline" in parent_tags:
+            return " " + (text or "").strip(" \t\r\n") + " "
+        content = text or ""
+        # 先頭末尾の ``\n`` のみ削り、``<br>`` hard-break の trailing ``  `` は
+        # 保持する。blank-only paragraph は無視する (mjs blankReplacement)。
+        content = content.strip("\n")
+        if not content.strip(" \t\r\n"):
+            return ""
+        return "\n\n" + content + "\n\n"
 
     # ------------------------------------------------------------------
     # <em>/<i>/<strong>/<b> — turndown default の ``flankingWhitespace`` +
@@ -505,12 +801,17 @@ def html_to_md(html: str) -> str:
 
     ``preprocess_en_html`` を通さないので callout/details 等の MadCap
     artifact 正規化は caller 責務。通常は ``convert_en_html_to_md`` を使う。
+
+    Phase 4b.1 以降は BS4 tree に対して mjs turndown の collapseWhitespace を
+    適用してから markdownify に渡す。これにより block / ``<br>`` 境界の
+    leading space 除去や ``<img>\\n<img>`` → ``![](a) ![](b)`` の space
+    preservation が mjs と byte-identical になる。
     """
-    # review round-2 P1 (empty/whitespace emphasis)対応: raw HTML 段階で空
-    # inline 要素を除去し、markdownify の text-node whitespace collapse に任せる
     normalized_html = _strip_empty_inline_elements(html)
     converter = _TurndownConverter()
-    return _normalize_output(converter.convert(normalized_html))
+    soup = BeautifulSoup(normalized_html, "html.parser")
+    _collapse_whitespace(soup)
+    return _normalize_output(converter.convert_soup(soup))
 
 
 def convert_en_html_to_md(html: str) -> str:

--- a/scripts/py/src/testim_parity/turndown.py
+++ b/scripts/py/src/testim_parity/turndown.py
@@ -267,12 +267,14 @@ def _collapse_whitespace(root: Tag | BeautifulSoup) -> None:
             prev_text = new_text
             return
         if isinstance(node, Tag):
-            if _is_pre_element(node):
-                # pre subtree を丸ごと skip。後続 text は block 相当として
-                # leading ws を削る (= prev_text/keep_leading_ws をリセット)。
-                prev_text = None
-                keep_leading_ws = True
-                return
+            # ``<pre>`` は ``_TURNDOWN_BLOCK_ELEMENTS`` に含まれ、mjs
+            # ``collapseWhitespace`` (L492) でも ``isBlock(node) === true`` で
+            # block 分岐を通る (``isPre`` の else-if 分岐には落ちない)。
+            # ``_iter`` 側で ``<pre>`` 配下の children を skip しているので
+            # block 分岐の ``yield from _iter(node)`` は空 iterator を返す。
+            # (reviewer P1 対応: 旧 ``_is_pre_element`` 早期リターンは
+            # ``keep_leading_ws=True`` を設定して mjs の block 分岐
+            # (``keep_leading_ws=False``) と乖離していたため削除)
             if node.name == "br" or _is_turndown_block(node):
                 if prev_text is not None:
                     trimmed = re.sub(r" $", "", str(prev_text))
@@ -285,6 +287,7 @@ def _collapse_whitespace(root: Tag | BeautifulSoup) -> None:
                 prev_text = None
                 keep_leading_ws = False
                 # block / br の子供は独立した文脈として再帰
+                # ``<pre>`` の場合は ``_iter`` の pre guard で children が空 iterator になる
                 yield from _iter(node)
                 return
             if _is_turndown_void(node):
@@ -802,15 +805,32 @@ def html_to_md(html: str) -> str:
     ``preprocess_en_html`` を通さないので callout/details 等の MadCap
     artifact 正規化は caller 責務。通常は ``convert_en_html_to_md`` を使う。
 
-    Phase 4b.1 以降は BS4 tree に対して mjs turndown の collapseWhitespace を
-    適用してから markdownify に渡す。これにより block / ``<br>`` 境界の
-    leading space 除去や ``<img>\\n<img>`` → ``![](a) ![](b)`` の space
-    preservation が mjs と byte-identical になる。
+    **Pipeline (5 step, Phase 4b.1)**:
+
+    1. ``_strip_empty_inline_elements(html)`` — raw string 段階で
+       ``<em></em>`` / ``<em>   </em>`` 等の空 inline を剥がす。mjs turndown
+       の DOM whitespace collapse が空 inline を消す挙動と等価にし、後続の
+       text node merge で double-space を生まないようにする
+    2. ``BeautifulSoup(normalized_html, "html.parser")`` — 文字列を BS4 tree
+       に parse
+    3. ``_collapse_whitespace(soup)`` — mjs turndown の DOM
+       ``collapseWhitespace`` を tree 上で in-place 適用 (text node の
+       ``[ \\r\\n\\t]+`` → ``" "`` + block / ``<br>`` 境界の leading/trailing
+       space trim + void 要素隣接 text の leading ws preservation)
+    4. ``_TurndownConverter.convert_soup(soup)`` — markdownify
+       subclass に正規化済 tree を渡し、markdown 文字列に変換
+    5. ``_normalize_output(md)`` — fence-aware split で code fence 外側の
+       ``\\n{3,}`` → ``\\n\\n`` collapse + 全体 trim。code content 内部の
+       連続空行は preserve する
     """
+    # Step 1: 空 inline tag を raw string 段階で剥がす
     normalized_html = _strip_empty_inline_elements(html)
-    converter = _TurndownConverter()
+    # Step 2: BS4 tree parse
     soup = BeautifulSoup(normalized_html, "html.parser")
+    # Step 3: mjs ``collapseWhitespace`` を tree に pre-pass 適用
     _collapse_whitespace(soup)
+    # Step 4 + 5: markdownify → 後処理
+    converter = _TurndownConverter()
     return _normalize_output(converter.convert_soup(soup))
 
 

--- a/scripts/py/src/testim_parity/turndown.py
+++ b/scripts/py/src/testim_parity/turndown.py
@@ -61,7 +61,15 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from bs4 import BeautifulSoup, Comment, NavigableString, Tag
+from bs4 import (
+    BeautifulSoup,
+    Comment,
+    Declaration,
+    Doctype,
+    NavigableString,
+    ProcessingInstruction,
+    Tag,
+)
 from markdownify import MarkdownConverter
 
 from .preprocess_en import preprocess_en_html
@@ -203,6 +211,26 @@ def _is_pre_element(el: Any) -> bool:
 
 _WHITESPACE_RUN_RE: re.Pattern[str] = re.compile(r"[ \r\n\t]+")
 
+# mjs turndown ``collapseWhitespace`` (L507-510) は text (nodeType 3) と
+# CDATA (nodeType 4) と element (nodeType 1) 以外を DOM から remove する:
+#     else {
+#         node = remove(node);
+#         continue
+#     }
+# BS4 の ``NavigableString`` は Comment / Doctype / ProcessingInstruction /
+# Declaration を subclass として含むため、これらを明示的に除去しないと
+# ``replace_with(NavigableString(text))`` が plain text node に変換してしまい、
+# markdownify の ``_can_ignore`` の ``(Comment, Doctype)`` skip が無効化
+# されて ``<!DOCTYPE html>`` が markdown に ``html`` として leak する
+# (reviewer P3 対応)。``CData`` (nodeType 4) は mjs でも text 扱いなので
+# 本集合には含めない。
+_NON_TEXT_NAVIGABLE_TYPES: tuple[type, ...] = (
+    Comment,
+    Doctype,
+    ProcessingInstruction,
+    Declaration,
+)
+
 
 def _collapse_whitespace(root: Tag | BeautifulSoup) -> None:
     """mjs turndown の ``collapseWhitespace`` を BS4 tree に対して in-place 実行する。
@@ -241,13 +269,21 @@ def _collapse_whitespace(root: Tag | BeautifulSoup) -> None:
 
     def _visit(node: Any) -> Any:
         nonlocal prev_text, keep_leading_ws
-        if isinstance(node, Comment):
-            # turndown は Comment に特別 path を持たないが、markdownify 側で
-            # strip される。collapseWhitespace pass 上は単に skip。
+        if isinstance(node, _NON_TEXT_NAVIGABLE_TYPES):
+            # mjs ``collapseWhitespace`` L507-510: node ≠ text / CDATA /
+            # element は remove する。BS4 の Comment / Doctype /
+            # ProcessingInstruction / Declaration が該当。tree から除去
+            # しないと ``NavigableString(text)`` への ``replace_with`` 後に
+            # markdownify の Comment/Doctype skip が効かなくなり、
+            # ``<!DOCTYPE html>`` が literal text として leak する
+            # (reviewer P3 対応)。全て ``NavigableString`` subclass なので
+            # ``pending_to_remove`` (list[NavigableString]) に append 可。
+            assert isinstance(node, NavigableString)
+            pending_to_remove.append(node)
             return
         if isinstance(node, NavigableString):
-            # NavigableString の subclass (Comment 等) は上で弾かれているので
-            # ここは純粋 text node。
+            # ここは ``type(node) is NavigableString`` (plain text) または
+            # ``CData`` (mjs でも nodeType 4 = text 相当)。
             text = _WHITESPACE_RUN_RE.sub(" ", str(node))
             if (
                 (prev_text is None or str(prev_text).endswith(" "))
@@ -757,6 +793,21 @@ class _TurndownConverter(MarkdownConverter):
         return f"\n\n```{language}\n{code}\n```\n\n"
 
 
+def _run_pipeline(html: str, converter: _TurndownConverter) -> str:
+    """Phase 4b.1 の 5-step pipeline (``html_to_md`` と同一) を共有 helper 化。
+
+    ``html_to_md`` (top-level) と ``_convert_fragment`` (nested) の両方から
+    呼ばれる。fragment path を top-level と同じ normalization に通すことで、
+    ``convert_ol`` / ``convert_table`` 内の nested ``<li>`` / cell content でも
+    ``_strip_empty_inline_elements`` / ``_collapse_whitespace`` /
+    ``_normalize_output`` が確実に適用される (reviewer P2 対応)。
+    """
+    normalized_html = _strip_empty_inline_elements(html)
+    soup = BeautifulSoup(normalized_html, "html.parser")
+    _collapse_whitespace(soup)
+    return _normalize_output(converter.convert_soup(soup))
+
+
 def _convert_fragment(
     html: str,
     options: dict[str, Any] | None = None,
@@ -768,6 +819,13 @@ def _convert_fragment(
     MadCap ``<ol>`` rule の sibling 処理 / table cell 内部処理から呼ばれる。
     parent converter と同じ options を使って nested consistency を保つ。
 
+    Phase 4b.1 以降は ``_run_pipeline`` 経由で top-level と同じ normalization
+    (string-level empty-inline strip → BS4 parse → ``_collapse_whitespace`` →
+    markdownify → ``_normalize_output``) を適用する。288-matrix は現状の
+    corpus では fragment 経路で divergence を起こさないが、structurally
+    parallel な code path を持つと将来 silent divergence が発生するため
+    (reviewer P2)、top-level と同一の pipeline を共有する。
+
     ``_depth`` は `_MAX_FRAGMENT_DEPTH` までの再帰深度 guard。現実の MadCap
     HTML では 5-10 階層程度だが、malformed HTML に対して ``RecursionError``
     を未然に防ぐための defensive cap。超過時は raw HTML を返す。
@@ -776,7 +834,7 @@ def _convert_fragment(
         return html
     converter = _TurndownConverter(**(options or {}))
     converter._fragment_depth = _depth  # nested convert_ol/convert_table が depth+1 で使う
-    return converter.convert(html)
+    return _run_pipeline(html, converter)
 
 
 _EMPTY_INLINE_RE: re.Pattern[str] = re.compile(
@@ -823,15 +881,8 @@ def html_to_md(html: str) -> str:
        ``\\n{3,}`` → ``\\n\\n`` collapse + 全体 trim。code content 内部の
        連続空行は preserve する
     """
-    # Step 1: 空 inline tag を raw string 段階で剥がす
-    normalized_html = _strip_empty_inline_elements(html)
-    # Step 2: BS4 tree parse
-    soup = BeautifulSoup(normalized_html, "html.parser")
-    # Step 3: mjs ``collapseWhitespace`` を tree に pre-pass 適用
-    _collapse_whitespace(soup)
-    # Step 4 + 5: markdownify → 後処理
     converter = _TurndownConverter()
-    return _normalize_output(converter.convert_soup(soup))
+    return _run_pipeline(html, converter)
 
 
 def convert_en_html_to_md(html: str) -> str:

--- a/scripts/py/tests/conformance/test_turndown_288_matrix.py
+++ b/scripts/py/tests/conformance/test_turndown_288_matrix.py
@@ -9,29 +9,25 @@ r"""Phase 4b M2/M3 verification gate: 288-page turndown conversion matrix。
     > 比較する実装を通す。M1 の代表 39 pattern だけでは real orchestration に
     > 入った turndown 経路の全 corpus 検証として不足。
 
-## 現状 (2026-04-22, reviewer P2#2 対応時点)
+## 現状 (2026-04-22, Phase 4b.1 完了時点)
 
-Python の ``convert_en_html_to_md`` は **288 pages のうち ~120 件で mjs と
-byte 一致**、残 ~168 件は以下カテゴリの divergence が残る (M1 scope 外の
-turndown default rule:
+Python の ``convert_en_html_to_md`` は **288 pages すべてで mjs と byte-
+identical**。Phase 4b.1 で以下の turndown default rule を追加 port して
+M1 時点の 168 divergence を解消した:
 
-| カテゴリ | 件数 | 内容 |
-| --- | --- | --- |
-| leading_ws | 84 | ``<br/>`` 等の block boundary 後の leading whitespace collapse |
-| other | 43 | whitespace 複合 / markdownify inline detection 差 |
-| trailing_ws | 23 | list item の trailing 2-space (hard line break) |
-| plus_escape | 13 | ``+`` の markdown list-marker escape (``\+``) |
-| image_concat | 4 | 隣接 ``<img>`` の inline 連結 |
-| hash_escape | 1 | paragraph 内 ``#`` の ATX-heading escape (``\#``) |
+- ``_collapse_whitespace`` — mjs turndown の DOM ``collapseWhitespace`` を
+  BS4 tree 上で pre-pass として再現 (block / ``<br>`` 境界の leading ws trim
+  + void element 隣接 text の space preservation)
+- ``_turndown_escape`` + ``_TurndownConverter.escape`` override — mjs
+  turndown の 13 escape 規則 (``^-`` / ``^+ `` / ``^# `` / ``` ` ``` / ``_``
+  / ``[`` / ``]`` 等) を markdownify の ``escape`` hook 経由で適用
+- ``_TurndownConverter.convert_p`` — paragraph content の trailing ``  \\n``
+  (``<br>`` hard break) を preserve (markdownify default の
+  ``strip(' \\t\\r\\n')`` を回避)
+- ``autolinks = False`` — ``<a href=URL>URL</a>`` の ``<URL>`` 縮約を無効化
 
-これらは M1 で取り込まなかった turndown default escape / flanking whitespace
-rule の港が残っている結果で、**Phase 4b.1 (follow-up PR) で解消**する。
-M2 ``check_source_parity`` / M3 ``snapshot_update`` の orchestration 自体は
-mjs と同じ JSON schema / 副作用で完了しているため、本 test は現時点では
-``xfail(strict=False)`` として gap を可視化しつつ regression gate に使用する。
-
-本テストを Phase 4b.1 で pass させた時点で xfail marker を外し、Phase 6
-atomic cutover までに通る状態を維持する。reviewer P2#2 対応。
+本テストは Phase 6 atomic cutover で mjs を削除するまで regression gate と
+して残す (node 不在環境では skip)。
 
 ## batch 戦略
 
@@ -122,14 +118,6 @@ def mjs_turndown_by_slug(repo_root, node_available, snapshot_pages) -> dict[str,
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Phase 4b.1 follow-up: M1 で未港の turndown default escape / "
-        "flanking whitespace rule により ~168/288 pages が mjs と "
-        "byte divergent。詳細カテゴリは module docstring を参照。"
-    ),
-)
 def test_all_288_pages_turndown_matches_mjs(snapshot_pages, mjs_turndown_by_slug):
     """288 page すべてで Python ``convert_en_html_to_md`` が mjs と byte 一致。
 
@@ -176,13 +164,6 @@ def test_all_288_pages_turndown_matches_mjs(snapshot_pages, mjs_turndown_by_slug
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Phase 4b.1 follow-up: aggregate byte length と matching page count は "
-        "上記 ``test_all_288_pages_turndown_matches_mjs`` と同じ gap に由来。"
-    ),
-)
 def test_turndown_288_summary_bytes_match(snapshot_pages, mjs_turndown_by_slug):
     """aggregate check: 合計 byte 長が mjs と一致 + 一致率 100%。
 

--- a/scripts/py/tests/test_turndown.py
+++ b/scripts/py/tests/test_turndown.py
@@ -300,3 +300,71 @@ def test_code_fence_multi_trailing_blank_lines_preserved() -> None:
     前に保持される (turndown ``code.replace(/\\n$/, '')`` と同じ)。"""
     html = '<pre><code class="language-bash">line1\n\n\n</code></pre>'
     assert html_to_md(html) == "```bash\nline1\n\n\n```"
+
+
+# ----------------------------------------------------------------------
+# Phase 4b.1: turndown default rule port
+#   - escape (13 rules)
+#   - collapseWhitespace
+#   - convert_p preserves <br> hard break
+#   - autolinks disabled
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("html", "expected"),
+    [
+        # ``^-`` leading dash escape
+        ("<p>- start</p>", "\\- start"),
+        # ``^+ `` leading plus+space escape (``+ Teammate`` など)
+        ("<p><strong>+ Teammate</strong></p>", "**\\+ Teammate**"),
+        # ``^# `` leading ATX heading escape (callout 本文に ``### Note``)
+        ("<p>### Note about this</p>", "\\### Note about this"),
+        # ``` ` ``` backtick escape
+        ("<p>code `abc` end</p>", "code \\`abc\\` end"),
+        # ``_`` underscore escape (``execute_driver_script``)
+        ("<p>execute_driver_script</p>", "execute\\_driver\\_script"),
+        # ``[`` / ``]`` bracket escape
+        ("<p>[tag]</p>", "\\[tag\\]"),
+        # ``^>`` leading gt escape
+        ("<p>&gt; quoted</p>", "\\> quoted"),
+        # ``^~~~`` leading tilde escape
+        ("<p>~~~fence</p>", "\\~~~fence"),
+        # ``^(\d+)\. `` leading number-dot escape
+        ("<p>1. item</p>", "1\\. item"),
+        # ``^(=+)`` leading equals (setext heading) escape
+        ("<p>=== header</p>", "\\=== header"),
+    ],
+)
+def test_turndown_escape_rules(html: str, expected: str) -> None:
+    assert html_to_md(html) == expected
+
+
+def test_collapse_whitespace_leading_space_after_br() -> None:
+    """``<br>`` 境界 後の leading space を削る (mjs collapseWhitespace)。"""
+    assert html_to_md("<p>text1<br/> text2</p>") == "text1  \ntext2"
+
+
+def test_collapse_whitespace_image_concat_preserves_space() -> None:
+    """隣接 ``<img>`` 間の newline は single space に畳まれる (void element
+    隣接 text は leading space を preserve する turndown の挙動)。"""
+    html = '<div><img src="a.png"/>\n<img src="b.png"/></div>'
+    assert html_to_md(html) == "![](a.png) ![](b.png)"
+
+
+def test_convert_p_preserves_br_hard_break() -> None:
+    """``<p>text<br/> next</p>`` → ``text  \\nnext`` で trailing ``  `` 保持。"""
+    assert html_to_md("<p>text<br/> next</p>") == "text  \nnext"
+
+
+def test_autolinks_disabled() -> None:
+    """``<a href=URL>URL</a>`` は ``[URL](URL)`` で出す (``<URL>`` 縮約しない)。"""
+    url = "https://example.com/foo"
+    assert html_to_md(f'<p><a href="{url}">{url}</a></p>') == f"[{url}]({url})"
+
+
+def test_pre_content_preserved_by_collapse_whitespace() -> None:
+    """``<pre>`` 配下は collapseWhitespace の skip 対象で、code content の
+    連続改行を byte for byte 保持する。"""
+    html = '<pre><code class="language-bash">line1\n\n\nline2</code></pre>'
+    assert html_to_md(html) == "```bash\nline1\n\n\nline2\n```"

--- a/scripts/py/tests/test_turndown.py
+++ b/scripts/py/tests/test_turndown.py
@@ -391,3 +391,66 @@ def test_pre_block_branch_rstrips_prev_text() -> None:
     # mjs: "word\n\n```\nx\n```\n\nend" — trailing space on "word " is trimmed.
     html = "<div>word <pre><code>x</code></pre>end</div>"
     assert html_to_md(html) == "word\n\n```\nx\n```\n\nend"
+
+
+# ----------------------------------------------------------------------
+# reviewer P3: 非 text NavigableString subclass は mjs に合わせて tree から
+# 除去する。``<!DOCTYPE>`` / Comment / ProcessingInstruction / Declaration が
+# text として leak しないことを保証する
+# ----------------------------------------------------------------------
+
+
+def test_doctype_is_removed_not_leaked_as_text() -> None:
+    """``<!DOCTYPE html>`` は mjs と同じく markdown 出力に leak しない。
+
+    旧実装では ``_collapse_whitespace`` が Doctype を
+    ``NavigableString(text)`` に ``replace_with`` していたため、markdownify の
+    ``(Comment, Doctype)`` skip が無効化されて ``"html"`` が leak していた
+    (reviewer P3 対応)。
+    """
+    assert html_to_md("<!DOCTYPE html><p>hi</p>") == "hi"
+
+
+def test_processing_instruction_is_removed() -> None:
+    """``<?pi ...?>`` は mjs と同じく除去される (reviewer P3)."""
+    assert html_to_md("<?pi foo?><p>hi</p>") == "hi"
+
+
+def test_comment_nodes_are_removed() -> None:
+    """``<!-- ... -->`` は tree から除去されて inline 連結でも leak しない。
+
+    mjs: ``<p>before<!--skip-->after</p>`` → ``"beforeafter"``
+    """
+    assert html_to_md("<!--c--><p>hi</p>") == "hi"
+    assert html_to_md("<p>before<!--skip-->after</p>") == "beforeafter"
+
+
+# ----------------------------------------------------------------------
+# reviewer P2: fragment pipeline (``_convert_fragment``) も top-level と同じ
+# normalization を通す。288-matrix は現状 corpus で divergence を起こさないが、
+# nested ``<ol>`` / table cell 内で将来 regression が発生しないよう structural
+# parity を unit test で pin する
+# ----------------------------------------------------------------------
+
+
+def test_fragment_pipeline_strips_empty_inline_in_ol() -> None:
+    """``_convert_fragment`` が ``_strip_empty_inline_elements`` を通す
+    ことで、nested ``<ol><li><em></em> + text</li></ol>`` の empty emphasis
+    が除去されて mjs と byte-identical になる (reviewer P2)。"""
+    html = '<ol><li value="1"><em></em> + text</li></ol>'
+    assert html_to_md(html) == "1. \\+ text"
+
+
+def test_fragment_pipeline_applies_escape_in_table_cell() -> None:
+    """table cell 内でも turndown escape (``^+ `` → ``\\+ ``) が適用される
+    (reviewer P2)。"""
+    html = "<table><tr><td><em></em>   + item</td></tr></table>"
+    assert html_to_md(html) == "| \\+ item |\n| --- |"
+
+
+def test_fragment_pipeline_applies_br_hardbreak_in_ol() -> None:
+    """nested ``<ol><li>text <br/> more</li></ol>`` でも ``<br>`` の hard
+    break が保持され、``collapseWhitespace`` の boundary trim が適用される
+    (reviewer P2)。"""
+    html = '<ol><li value="1">text <br/> more</li></ol>'
+    assert html_to_md(html) == "1. text  \nmore"

--- a/scripts/py/tests/test_turndown.py
+++ b/scripts/py/tests/test_turndown.py
@@ -368,3 +368,26 @@ def test_pre_content_preserved_by_collapse_whitespace() -> None:
     連続改行を byte for byte 保持する。"""
     html = '<pre><code class="language-bash">line1\n\n\nline2</code></pre>'
     assert html_to_md(html) == "```bash\nline1\n\n\nline2\n```"
+
+
+def test_pre_uses_block_branch_in_collapse_whitespace() -> None:
+    """``<pre>`` は mjs と同じく block 分岐を通り、直後の text node の
+    leading space を strip する (reviewer P1 対応)。
+
+    旧実装は ``<pre>`` を void 相当 (``keep_leading_ws=True``) で扱っていたため、
+    ``<pre>...</pre> after`` の leading space が preserve されて mjs と
+    divergence していた。mjs ``collapseWhitespace`` L492 は ``isBlock(PRE) ==
+    true`` で最初の branch に分岐し ``keep_leading_ws=False`` に倒す。
+    """
+    # mjs: "before\n\n```\nx\n```\n\nafter" — leading space on " after" is
+    # stripped by the block branch.
+    html = "<div>before <pre><code>x</code></pre> after</div>"
+    assert html_to_md(html) == "before\n\n```\nx\n```\n\nafter"
+
+
+def test_pre_block_branch_rstrips_prev_text() -> None:
+    """``<pre>`` の直前 text に trailing space があれば削る (block 分岐の
+    ``prev_text = prev_text.replace(/ $/, '')`` 等価、reviewer P1 対応)。"""
+    # mjs: "word\n\n```\nx\n```\n\nend" — trailing space on "word " is trimmed.
+    html = "<div>word <pre><code>x</code></pre>end</div>"
+    assert html_to_md(html) == "word\n\n```\nx\n```\n\nend"


### PR DESCRIPTION
## Summary

- M1 時点で 168 / 288 page が mjs turndown と divergent だった 4 パターンを解消
- `tests/conformance/test_turndown_288_matrix.py` の `@pytest.mark.xfail(strict=False)` を外し、288 / 288 byte-identical を regression gate として pin
- Phase 6 atomic cutover で mjs を削除するまで本 test を維持する契約
- PYTHON_MIGRATION_PLAN.md の Phase 4b progress 表を更新 (M2/M3 を 🟡 → ✅)

## 実装

- `_collapse_whitespace(root)` — mjs turndown の DOM `collapseWhitespace` (`node_modules/turndown/lib/turndown.cjs.js` L457-523) を BS4 tree に in-place 再現。block / `<br>` 境界の leading/trailing space を削り、void element 隣接 text の leading space は preserve する
- `_turndown_escape(text)` + `_TurndownConverter.escape` — mjs turndown の 13 escape 規則 (`^-` / `^+ ` / `^(=+)` / `^# ` / `` ` `` / `^~~~` / `[` / `]` / `^>` / `_` / `^\d+\. ` / `\\` / `*`) を markdownify の per-text-node hook 経由で適用
- `_TurndownConverter.convert_p` — `<br>` hard break の trailing `  \n` を preserve (`strip(" \t\r\n")` を `strip("\n")` に限定)
- `_TurndownConverter.DefaultOptions.autolinks = False` — `<a href=URL>URL</a>` の `<URL>` 縮約を無効化

## Divergence 解消内訳 (168 → 0)

| カテゴリ | 件数 | 解消方法 |
| --- | --- | --- |
| leading_ws | 67 | `_collapse_whitespace` |
| other | 74 | `_turndown_escape` + `autolinks=False` |
| trailing_ws | 13 | `convert_p` hard break preserve |
| plus_escape | 10 | `_turndown_escape` `^+ ` |
| image_concat | 3 | `_collapse_whitespace` void preserve |
| hash_escape | 1 | `_turndown_escape` `^# ` |

## Test plan

- [x] `cd scripts/py && uv run pytest tests/` — 923 passed, 5 deselected (+15 unit 追加)
- [x] `cd scripts/py && uv run pytest tests/ -m slow` — 5 passed (288-matrix 含む、marker なしで pass)
- [x] `cd scripts/py && uv run ruff check src tests` — all checks passed
- [x] `cd scripts/py && uv run ruff format --check src tests` — all formatted
- [x] `cd scripts/py && uv run mypy src` — no issues (60 files)
- [x] `npm run test` — 2040/2041 passed (1 skip, 0 fail)
- [x] `npm run build` — 290 pages OK
- [x] `npm run lint` — 0 errors / 0 warnings
- [x] `npm run check:parity` — **5-counter = 0 維持** (active 0 / baseline 0 / actionable 0 / signal 0 / errors 0)

## Rollback

Single commit。失敗時 `git revert`。Python 側の change のみで mjs は unchanged。

🤖 Generated with [Claude Code](https://claude.com/claude-code)