### PR TITLE
ci: dependabot auto-merge を --squash から --merge に修正

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,8 +26,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
+        # Use --merge (not --squash) because the repository disables squash merging
+        # (``allow_squash_merge=false``) to keep a merge-commit-only history that
+        # matches human PR workflow. ``--squash`` failed with ``GraphQL: Merge
+        # method squash merging is not allowed on this repository`` and left
+        # Dependabot PRs stuck (observed on PR #377 astro bump, 2026-04-21).
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge "$PR_URL" --auto --squash
+        run: gh pr merge "$PR_URL" --auto --merge
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Dependabot PR #377 が auto-merge されず stuck していた問題を修正。

## 原因

``dependabot-auto-merge`` workflow が ``gh pr merge --auto --squash`` を使用していたが、repo settings は ``allow_squash_merge: false`` になっている:

\`\`\`bash
$ gh api repos/rymetry/testim-docs-ja --jq '{allow_merge_commit, allow_squash_merge, allow_rebase_merge, allow_auto_merge}'
{
  "allow_auto_merge": true,
  "allow_merge_commit": true,
  "allow_rebase_merge": true,
  "allow_squash_merge": false
}
\`\`\`

Workflow ログに以下のエラー:

\`\`\`
GraphQL: Merge method squash merging is not allowed on this repository (enablePullRequestAutoMerge)
\`\`\`

## 修正

``--squash`` → ``--merge`` (1 行変更 + 理由 comment)。既存の手動 PR (#376 / #381 等) と同じ merge-commit 方式に統一。

## 影響

- 次の Dependabot PR から auto-merge が正常動作
- 現在 stuck している PR #377 は、本 PR merge 後に手動で ``gh pr merge 377 --auto --merge`` を叩くか、Dependabot の自動 rebase を待つ (pull_request event が再発火して新しい workflow が走る)

## Test plan

- [x] diff 確認 (1 箇所、``--squash`` → ``--merge``、security-risk なし。既存の ``PR_URL`` env + quoted ``$PR_URL`` パターンを維持)
- [ ] Merge 後、PR #377 で ``gh pr merge 377 --auto --merge`` を手動実行して動作確認
- [ ] 次の Dependabot PR で workflow が緑になることを確認

## Alternatives considered

- **repo settings で ``allow_squash_merge: true``** にする案もあるが、admin 権限 + 既存運用 (merge commit only) の変更になるため、**workflow 側を直す本方針を採用**。
- ``--rebase`` も選択可能 (``allow_rebase_merge: true``) だが、既存の手動 PR が merge commit で統一されているので ``--merge`` が一貫性高い。

🤖 Generated with [Claude Code](https://claude.com/claude-code)