### PR TITLE
feat(parity): detect EN-relative image count/order mismatches

### DIFF
--- a/scripts/python/src/testim_parity/checks.py
+++ b/scripts/python/src/testim_parity/checks.py
@@ -1,16 +1,21 @@
 """EN / JA body の count・shape・heuristics 比較 (``source_parity_checks.mjs`` port)。
 
-Phase 3 M3 の後半。``extract.py`` の 13 関数を消費して section 別 count /
-table structure / image / heading 列を比較し、coarse audit signal 系 issue
+Phase 3 M3 の後半。``extract.py`` の関数を消費して section 別 count /
+table structure / heading 列を比較し、coarse audit signal 系 issue
 (bullet-count / paragraph-count / section-count / heading-mismatch /
-table-* / image-order / callout-nesting 等) を emit する。
+table-* / callout-nesting 等) を emit する。``compare_snapshot_structure`` の
+issue 列は mjs と byte-identical な契約。
 
-mjs と byte-identical な issue 列を返す契約。
+なお ``image_parity_issues`` は mjs port 完了後に追加した **Python-only** の
+画像パリティ検出器 (image-mismatch / image-order-mismatch) で、byte-parity
+契約の対象外。EN を生 HTML から抽出する点が ``compare_snapshot_structure``
+(turndown markdown 入力) と異なる。
 """
 
 from __future__ import annotations
 
 import re
+from collections import Counter
 from collections.abc import Iterable, Mapping
 from typing import Any
 
@@ -19,7 +24,6 @@ from .extract import (
     extract_bullet_counts,
     extract_callout_positions,
     extract_heading_sequence,
-    extract_image_sequence,
     extract_invariant_tokens,
     extract_paragraph_counts,
     extract_step_counts,
@@ -43,6 +47,7 @@ from .types import (
 
 __all__ = [
     "compare_snapshot_structure",
+    "image_parity_issues",
     "is_english_only_line",
     "load_sidebar_slugs",
     "load_sidebar_slugs_ordered",
@@ -452,49 +457,133 @@ def _count_section_headings(body: str) -> int:
     return count
 
 
-def _image_order_issues(en_body: str, ja_body: str) -> list[dict[str, Any]]:
-    """画像順序 inversion を検出する (mjs 等価)。"""
+# ---------------------------------------------------------------------------
+# image_parity_issues — EN 基準の画像 枚数 / 重複 / 順序 比較
+#
+# EN を en_body (turndown markdown) から抽出すると ``![alt](src "title")`` の
+# title が basename に混入し、title を持たない JA md と不一致になる。そのため
+# EN は生 HTML (`en_html`) の ``src`` / ``href`` から直接抽出し、JA md と対称な
+# basename 列を得る (この title 混入が原因で旧 ``_image_order_issues`` は事実上
+# 機能しなかったため、本関数に統合・置換した)。
+#
+# 判定はすべて **EN を基準** とする multiset / 順序比較:
+#   - EN に元々ある重複・順序は「正」とみなし、JA がそれを忠実にミラーすれば
+#     一致 = 検知しない (誤検知を出さない)
+#   - JA に EN へ無い余剰/不足/順序差があるときだけ issue を emit する
+# ---------------------------------------------------------------------------
+
+_IMAGE_EXT_GROUP = r"(?:png|jpe?g|gif|svg|webp)"
+_EN_IMAGE_SRC_RE = re.compile(
+    r'(?:src|href)\s*=\s*"([^"]+\.' + _IMAGE_EXT_GROUP + r')"',
+    re.IGNORECASE,
+)
+# markdown ``![alt](src)`` / HTML ``<img src>`` / Astro ``<Image src>`` の 3 形式。
+# ``[^>]+`` は属性列に生の ``>`` を含まない前提 (content snapshot では ``>`` は
+# 実体参照される)。万一含む場合は当該画像を取りこぼす方向 = 検知漏れに倒れ、
+# 誤検知 (false positive) は出さない。
+_JA_IMAGE_RE = re.compile(
+    r"!\[[^\]]*\]\(\s*([^)\s]+)"
+    r'|<img[^>]+src\s*=\s*"([^"]+)"'
+    r'|<Image[^>]+src\s*=\s*"([^"]+)"',
+    re.IGNORECASE,
+)
+_IMAGE_EXT_SUFFIX_RE = re.compile(r"\." + _IMAGE_EXT_GROUP + r"$", re.IGNORECASE)
+_IMAGE_HASH_PREFIX_RE = re.compile(r"^([0-9a-f]{6,})-", re.IGNORECASE)
+
+
+def _normalize_image_token(src: str) -> str:
+    """画像参照を比較用の canonical token に正規化する。
+
+    - basename のみ採用 (クエリ / フラグメントは除去)
+    - 拡張子を落とし、小文字化
+    - 先頭ハッシュ prefix は 7 文字に揃える (EN snapshot の 7 桁 prefix と
+      JA 側のフル SHA prefix を同一視。例: ``abc1234-foo`` ==
+      ``abc1234ef..-foo``)
+    """
+    base = src.split("?", 1)[0].split("#", 1)[0].rstrip("/").rsplit("/", 1)[-1].lower()
+    base = _IMAGE_EXT_SUFFIX_RE.sub("", base)
+    match = _IMAGE_HASH_PREFIX_RE.match(base)
+    if match:
+        base = match.group(1)[:7] + "-" + base[match.end() :]
+    return base
+
+
+def _en_image_tokens(en_html: str) -> list[str]:
+    """EN 生 HTML から画像 (``src`` / ``href`` の image URL) を出現順に抽出する。"""
+    return [_normalize_image_token(src) for src in _EN_IMAGE_SRC_RE.findall(en_html)]
+
+
+def _ja_image_tokens(ja_body: str) -> list[str]:
+    """JA markdown から画像 (``![](...)`` / ``<img src>`` / ``<Image src>``) を出現順に抽出する。
+
+    code fence 内は除外し、markdown の title (``"..."``) は drop する。
+    """
+    tokens: list[str] = []
+    in_code_block = False
+    for line in ja_body.split("\n"):
+        if FENCE_LINE_RE.match(line):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+        for md_src, img_src, image_src in _JA_IMAGE_RE.findall(line):
+            src = md_src or img_src or image_src
+            cleaned = src.split("?", 1)[0].split("#", 1)[0]
+            if _IMAGE_EXT_SUFFIX_RE.search(cleaned):
+                tokens.append(_normalize_image_token(src))
+    return tokens
+
+
+def image_parity_issues(en_html: str, ja_body: str) -> list[dict[str, Any]]:
+    """EN (生 HTML) 基準で JA 画像の 枚数 / 重複 / 順序 を検証する。
+
+    - multiset 不一致 (余剰 / 不足 / 重複) → ``image-mismatch``
+    - multiset 一致だが順序が EN と相違 → ``image-order-mismatch``
+
+    EN 側に元々ある重複・順序は正とみなすため、JA がそれを忠実にミラーする
+    限り issue は出ない (EN-relative)。
+    """
     issues: list[dict[str, Any]] = []
-    en_images = extract_image_sequence(en_body)
-    ja_images = extract_image_sequence(ja_body)
+    en_tokens = _en_image_tokens(en_html)
+    ja_tokens = _ja_image_tokens(ja_body)
 
-    if len(en_images) == 0 or len(ja_images) == 0:
+    en_counts = Counter(en_tokens)
+    ja_counts = Counter(ja_tokens)
+    if en_counts != ja_counts:
+        extra = ja_counts - en_counts  # EN に無い JA 余剰
+        missing = en_counts - ja_counts  # JA に不足している EN 画像
+        parts: list[str] = []
+        if extra:
+            parts.append(
+                "JA 余剰: " + ", ".join(f"{name}×{count}" for name, count in sorted(extra.items()))
+            )
+        if missing:
+            parts.append(
+                "JA 不足: "
+                + ", ".join(f"{name}×{count}" for name, count in sorted(missing.items()))
+            )
+        issues.append(
+            _with_severity(
+                {
+                    "type": "image-mismatch",
+                    "detail": "画像が原文と一致しません (" + "; ".join(parts) + ")",
+                }
+            )
+        )
         return issues
 
-    en_files = [img["file"] for img in en_images]
-    ja_files = [img["file"] for img in ja_images]
-    unique_en: list[str] = []
-    seen_en: set[str] = set()
-    for f in en_files:
-        if f in ja_files and f not in seen_en:
-            unique_en.append(f)
-            seen_en.add(f)
-    unique_ja: list[str] = []
-    seen_ja: set[str] = set()
-    for f in ja_files:
-        if f in en_files and f not in seen_ja:
-            unique_ja.append(f)
-            seen_ja.add(f)
-
-    if len(unique_en) < 2 or len(unique_en) != len(unique_ja):
-        return issues
-
-    ja_index = {f: i for i, f in enumerate(unique_ja)}
-    inversions: list[tuple[str, str]] = []
-    for left in range(len(unique_en)):
-        for right in range(left + 1, len(unique_en)):
-            first = unique_en[left]
-            second = unique_en[right]
-            if first in ja_index and second in ja_index and ja_index[first] > ja_index[second]:
-                inversions.append((first, second))
-
-    if inversions:
-        examples = "; ".join(f"{a} / {b}" for a, b in inversions[:3])
+    if en_tokens != ja_tokens:
+        first = next(
+            index for index in range(len(en_tokens)) if en_tokens[index] != ja_tokens[index]
+        )
         issues.append(
             _with_severity(
                 {
                     "type": "image-order-mismatch",
-                    "detail": f"画像の順序が原文と異なります ({len(inversions)} 箇所): {examples}",
+                    "detail": (
+                        f"画像の順序が原文と異なります (位置 {first + 1}: "
+                        f"原文={en_tokens[first]} / 翻訳={ja_tokens[first]})"
+                    ),
                 }
             )
         )
@@ -573,7 +662,6 @@ def compare_snapshot_structure(en_body: str, ja_body: str) -> list[dict[str, Any
 
     発火する issue type:
 
-    - ``image-order-mismatch`` (画像順 inversion)
     - ``callout-nesting-mismatch`` (callout 深さ差)
     - ``table-shape-mismatch`` / ``table-cell-*`` (テーブル形状と中身)
     - ``section-count-mismatch`` (H2-H4 見出し数)
@@ -581,13 +669,14 @@ def compare_snapshot_structure(en_body: str, ja_body: str) -> list[dict[str, Any
     - ``step-count-mismatch`` / ``bullet-count-mismatch`` /
       ``paragraph-count-mismatch`` (section 別 count)
 
+    画像の枚数 / 重複 / 順序は ``image_parity_issues`` (EN 生 HTML 基準) が担当する。
+
     EN artifact (`<details>` 使用 / code-fence-wrapped) が検出されたら全 issue
     に ``artifacts`` field を付与する。
     """
     issues: list[dict[str, Any]] = []
     en_artifacts = detect_en_artifacts(en_body)
 
-    issues.extend(_image_order_issues(en_body, ja_body))
     issues.extend(_callout_nesting_issues(en_body, ja_body))
     issues.extend(_compare_table_structure(en_body, ja_body))
 

--- a/scripts/python/src/testim_parity/checks.py
+++ b/scripts/python/src/testim_parity/checks.py
@@ -473,18 +473,23 @@ def _count_section_headings(body: str) -> int:
 # ---------------------------------------------------------------------------
 
 _IMAGE_EXT_GROUP = r"(?:png|jpe?g|gif|svg|webp)"
+# ``(?<![\w:-])`` の属性境界で ``data-src`` / ``xlink:href`` 等の誤一致を防ぐ。
+# クォートは ``"`` / ``'`` 両対応 (backref ``\1``)、拡張子の後ろの query /
+# fragment (``?...`` / ``#...``) も許容して JA 側の basename 正規化と対称化する
+# (group 1 = quote, group 2 = URL)。
 _EN_IMAGE_SRC_RE = re.compile(
-    r'(?:src|href)\s*=\s*"([^"]+\.' + _IMAGE_EXT_GROUP + r')"',
+    r"(?<![\w:-])(?:src|href)\b\s*=\s*([\"'])"
+    r"([^\"']+\." + _IMAGE_EXT_GROUP + r"(?:[?#][^\"']*)?)\1",
     re.IGNORECASE,
 )
 # markdown ``![alt](src)`` / HTML ``<img src>`` / Astro ``<Image src>`` の 3 形式。
-# ``[^>]+`` は属性列に生の ``>`` を含まない前提 (content snapshot では ``>`` は
-# 実体参照される)。万一含む場合は当該画像を取りこぼす方向 = 検知漏れに倒れ、
-# 誤検知 (false positive) は出さない。
+# HTML 形式はクォート ``"`` / ``'`` 両対応 (backref ``\2``)、``(?<![\w:-])`` の
+# 属性境界で ``data-src`` 等の誤一致を排除する。``[^>]*?`` は ``>`` まで (行内
+# 1 タグ) で bound され、属性列に生の ``>`` を含まない前提。
+# 既知の制限: markdown の山括弧 destination (``![](<path>)``) は対象外 (JA 未使用)。
 _JA_IMAGE_RE = re.compile(
     r"!\[[^\]]*\]\(\s*([^)\s]+)"
-    r'|<img[^>]+src\s*=\s*"([^"]+)"'
-    r'|<Image[^>]+src\s*=\s*"([^"]+)"',
+    r"|<(?:img|image)\b[^>]*?(?<![\w:-])src\s*=\s*([\"'])([^\"']+)\2",
     re.IGNORECASE,
 )
 _IMAGE_EXT_SUFFIX_RE = re.compile(r"\." + _IMAGE_EXT_GROUP + r"$", re.IGNORECASE)
@@ -510,7 +515,7 @@ def _normalize_image_token(src: str) -> str:
 
 def _en_image_tokens(en_html: str) -> list[str]:
     """EN 生 HTML から画像 (``src`` / ``href`` の image URL) を出現順に抽出する。"""
-    return [_normalize_image_token(src) for src in _EN_IMAGE_SRC_RE.findall(en_html)]
+    return [_normalize_image_token(url) for _quote, url in _EN_IMAGE_SRC_RE.findall(en_html)]
 
 
 def _ja_image_tokens(ja_body: str) -> list[str]:
@@ -526,8 +531,8 @@ def _ja_image_tokens(ja_body: str) -> list[str]:
             continue
         if in_code_block:
             continue
-        for md_src, img_src, image_src in _JA_IMAGE_RE.findall(line):
-            src = md_src or img_src or image_src
+        for md_src, _quote, tag_src in _JA_IMAGE_RE.findall(line):
+            src = md_src or tag_src
             cleaned = src.split("?", 1)[0].split("#", 1)[0]
             if _IMAGE_EXT_SUFFIX_RE.search(cleaned):
                 tokens.append(_normalize_image_token(src))

--- a/scripts/python/src/testim_parity/checks.py
+++ b/scripts/python/src/testim_parity/checks.py
@@ -484,12 +484,14 @@ _EN_IMAGE_SRC_RE = re.compile(
 )
 # markdown ``![alt](src)`` / HTML ``<img src>`` / Astro ``<Image src>`` の 3 形式。
 # HTML 形式はクォート ``"`` / ``'`` 両対応 (backref ``\2``)、``(?<![\w:-])`` の
-# 属性境界で ``data-src`` 等の誤一致を排除する。``[^>]*?`` は ``>`` まで (行内
-# 1 タグ) で bound され、属性列に生の ``>`` を含まない前提。
+# 属性境界で ``data-src`` 等の誤一致を排除する。属性走査は ``[^<>]*?`` で次の
+# ``<`` / ``>`` (= タグ境界) までに bound する。``[^>]*?`` だと閉じ ``>`` の無い
+# 不正な ``<img`` 連続で各開始位置が EOL まで走査し O(n^2) になるため、``<`` も
+# 境界に含めて線形性を保証する。
 # 既知の制限: markdown の山括弧 destination (``![](<path>)``) は対象外 (JA 未使用)。
 _JA_IMAGE_RE = re.compile(
     r"!\[[^\]]*\]\(\s*([^)\s]+)"
-    r"|<(?:img|image)\b[^>]*?(?<![\w:-])src\s*=\s*([\"'])([^\"']+)\2",
+    r"|<(?:img|image)\b[^<>]*?(?<![\w:-])src\s*=\s*([\"'])([^\"']+)\2",
     re.IGNORECASE,
 )
 _IMAGE_EXT_SUFFIX_RE = re.compile(r"\." + _IMAGE_EXT_GROUP + r"$", re.IGNORECASE)

--- a/scripts/python/src/testim_parity/detection/check_source_parity.py
+++ b/scripts/python/src/testim_parity/detection/check_source_parity.py
@@ -48,6 +48,7 @@ from ..baseline import (
 )
 from ..checks import (
     compare_snapshot_structure,
+    image_parity_issues,
     load_sidebar_slugs,
     load_sidebar_slugs_ordered,
     local_check,
@@ -593,6 +594,12 @@ def check_source_parity(
                         else:
                             issues.extend(segment_issues)
                             issues.extend(compare_snapshot_structure(en_body, doc["body"]))
+
+                if not usability_issue:
+                    # EN 基準の画像 枚数 / 重複 / 順序 検証。compare_snapshot_structure と
+                    # 同じ非 usability ケースで実行する。EN は en_html (生 HTML) の
+                    # src / href から抽出し、turndown の title 混入を回避する。
+                    issues.extend(image_parity_issues(en_html, doc["body"]))
 
         issues = tag_issues_with_acknowledgements(
             file_slug, issues, ack_data["entries"], snapshot_fingerprint, today

--- a/scripts/python/tests/test_checks.py
+++ b/scripts/python/tests/test_checks.py
@@ -217,3 +217,33 @@ def test_compare_snapshot_no_longer_emits_image_order():
     ja = "![b](/img/bbb2222-b.png)\n\n![a](/img/aaa1111-a.png)"
     issues = compare_snapshot_structure(en, ja)
     assert all(issue["type"] != "image-order-mismatch" for issue in issues)
+
+
+def test_image_parity_en_query_string_counted():
+    # EN の画像 URL に query/fragment が付いても EN/JA で同一画像として扱う。
+    # (旧 regex は ``.ext"`` 末尾固定で query 付きを取りこぼし、JA 余剰の誤検知を出した)
+    en_html = '<img src="images/aaa1111-foo.png?width=800" />'
+    ja = "![foo](/images/x/aaa1111-foo.png?width=800)"
+    assert image_parity_issues(en_html, ja) == []
+
+
+def test_image_parity_en_data_src_not_double_counted():
+    # EN の lazy-load ``data-src`` は ``src`` と二重計上しない (属性境界)。
+    # (旧 regex は data-src の ``src`` 部にも一致し EN で 2 枚計上 → JA 不足の誤検知)
+    en_html = '<img data-src="images/aaa1111-foo.png" src="images/aaa1111-foo.png" />'
+    ja = "![foo](/images/x/aaa1111-foo.png)"
+    assert image_parity_issues(en_html, ja) == []
+
+
+def test_image_parity_ja_single_quoted_img_counted():
+    # JA の単引用符 <img src='...'> も拾う (両クォート対応)。
+    en_html = '<img src="images/aaa1111-foo.png" />'
+    ja = "<img src='/images/x/aaa1111-foo.png' alt='foo' />"
+    assert image_parity_issues(en_html, ja) == []
+
+
+def test_image_parity_ja_data_src_not_double_counted():
+    # JA の lazy-load ``data-src`` も ``src`` と二重計上しない (属性境界)。
+    en_html = '<img src="images/aaa1111-foo.png" />'
+    ja = '<img data-src="/images/x/aaa1111-foo.png" src="/images/x/aaa1111-foo.png" />'
+    assert image_parity_issues(en_html, ja) == []

--- a/scripts/python/tests/test_checks.py
+++ b/scripts/python/tests/test_checks.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from testim_parity.checks import (
     compare_snapshot_structure,
+    image_parity_issues,
     is_english_only_line,
     load_sidebar_slugs,
     local_check,
@@ -117,3 +118,102 @@ def test_compare_snapshot_artifacts_propagate():
     if issues:
         for issue in issues:
             assert issue.get("artifacts") == ["EN uses <details> blocks"]
+
+
+# --- image_parity_issues (EN 基準の画像枚数 / 重複 / 順序) -------------------
+
+
+def test_image_parity_clean_identical():
+    en_html = '<img src="images/aaa1111-foo.png" /><img src="images/bbb2222-bar.png" />'
+    ja = "![foo](/images/x/aaa1111-foo.png)\n\n![bar](/images/x/bbb2222-bar.png)"
+    assert image_parity_issues(en_html, ja) == []
+
+
+def test_image_parity_en_side_duplicate_mirrored_ok():
+    # EN が同一画像を 2 回使い、JA も 2 回 → EN 基準で一致 = 検知しない
+    en_html = (
+        '<img src="images/aaa1111-foo.png" />'
+        '<img src="images/bbb2222-bar.png" />'
+        '<img src="images/aaa1111-foo.png" />'
+    )
+    ja = (
+        "![foo](/images/x/aaa1111-foo.png)\n\n"
+        "![bar](/images/x/bbb2222-bar.png)\n\n"
+        "![foo again](/images/x/aaa1111-foo.png)"
+    )
+    assert image_parity_issues(en_html, ja) == []
+
+
+def test_image_parity_ja_extra_duplicate_flagged():
+    # EN は foo を 1 回だが JA が 2 回 → image-mismatch (JA 余剰)
+    en_html = '<img src="images/aaa1111-foo.png" /><img src="images/bbb2222-bar.png" />'
+    ja = (
+        "![foo](/images/x/aaa1111-foo.png)\n\n"
+        "![bar](/images/x/bbb2222-bar.png)\n\n"
+        "![foo dup](/images/x/aaa1111-foo.png)"
+    )
+    issues = image_parity_issues(en_html, ja)
+    assert [i["type"] for i in issues] == ["image-mismatch"]
+    assert issues[0]["severity"] == "actionable"
+    assert "aaa1111-foo" in issues[0]["detail"]
+
+
+def test_image_parity_ja_missing_image_flagged():
+    # EN に bar があるが JA に無い → image-mismatch (JA 不足)
+    en_html = '<img src="images/aaa1111-foo.png" /><img src="images/bbb2222-bar.png" />'
+    ja = "![foo](/images/x/aaa1111-foo.png)"
+    issues = image_parity_issues(en_html, ja)
+    assert [i["type"] for i in issues] == ["image-mismatch"]
+    assert "bbb2222-bar" in issues[0]["detail"]
+
+
+def test_image_parity_reorder_flagged_as_order():
+    # 同一 multiset・順序のみ EN と相違 → image-order-mismatch
+    en_html = '<img src="images/aaa1111-foo.png" /><img src="images/bbb2222-bar.png" />'
+    ja = "![bar](/images/x/bbb2222-bar.png)\n\n![foo](/images/x/aaa1111-foo.png)"
+    issues = image_parity_issues(en_html, ja)
+    assert [i["type"] for i in issues] == ["image-order-mismatch"]
+
+
+def test_image_parity_case_and_hash_length_tolerant():
+    # 大文字小文字差 + ハッシュ長差 (7桁 vs フル SHA) は同一画像として扱う
+    en_html = '<img src="images/abc1234-Pic_One.png" />'
+    ja = "![pic](/images/x/abc1234ef567890-pic_one.png)"
+    assert image_parity_issues(en_html, ja) == []
+
+
+def test_image_parity_en_href_image_counted():
+    # EN が <a href> で画像を持つ (cloudinary 等) ケースも EN 側として数える
+    en_html = '<a href="https://res.cloudinary.com/x/abc1234-diagram.png">図</a>'
+    ja = "![diagram](/images/x/abc1234-diagram.png)"
+    assert image_parity_issues(en_html, ja) == []
+
+
+def test_image_parity_ja_code_fence_ignored():
+    # JA のコードフェンス内 ![](...) は画像として数えない (誤検知防止)
+    en_html = '<img src="images/aaa1111-foo.png" />'
+    ja = "![foo](/images/x/aaa1111-foo.png)\n\n```\n![sample](example.png)\n```"
+    assert image_parity_issues(en_html, ja) == []
+
+
+def test_image_parity_ja_html_img_tag_counted():
+    # JA が <img> タグで画像参照しても EN と一致すれば検知しない
+    en_html = '<img src="images/aaa1111-foo.png" />'
+    ja = '<img src="/images/x/aaa1111-foo.png" alt="foo" />'
+    assert image_parity_issues(en_html, ja) == []
+
+
+def test_image_parity_ja_astro_image_tag_counted():
+    # JA が Astro <Image> コンポーネントで画像参照しても EN と一致すれば検知しない
+    en_html = '<img src="images/aaa1111-foo.png" />'
+    ja = '<Image src="/images/x/aaa1111-foo.png" alt="foo" />'
+    assert image_parity_issues(en_html, ja) == []
+
+
+def test_compare_snapshot_no_longer_emits_image_order():
+    # 画像順 / 枚数の検出は image_parity_issues (EN 生 HTML 基準) に統合済み。
+    # compare_snapshot_structure は image-order-mismatch を emit しない。
+    en = "![a](/img/aaa1111-a.png)\n\n![b](/img/bbb2222-b.png)"
+    ja = "![b](/img/bbb2222-b.png)\n\n![a](/img/aaa1111-a.png)"
+    issues = compare_snapshot_structure(en, ja)
+    assert all(issue["type"] != "image-order-mismatch" for issue in issues)

--- a/src/content/docs/editing-tests/editing-your-tests/editing-target-element-properties.md
+++ b/src/content/docs/editing-tests/editing-your-tests/editing-target-element-properties.md
@@ -88,25 +88,23 @@ Testim は AUT ブラウザウィンドウでターゲット要素をハイラ�
 
 1. 再割り当てしたいステップの上にマウスを移動し、**Show Properties** ボタンをクリックします。
 
-![プロパティボタン](/images/steps-editing-tests/editing-target-element-properties/4934439-properties.png)
-
-![プロパティパネル](/images/steps-editing-tests/editing-target-element-properties/a45b094-propertiespanel.png)
+![クリック可能な要素](/images/steps-editing-tests/editing-target-element-properties/765e00b-small-clicklogin.png)
 
 プロパティパネルが右側に開きます。
 
-![クリック可能な要素](/images/steps-editing-tests/editing-target-element-properties/765e00b-small-clicklogin.png)
+![プロパティパネル](/images/steps-editing-tests/editing-target-element-properties/a45b094-propertiespanel.png)
 
 2. ターゲット要素のサムネイルの上にマウスを移動し、**Improve** リンクをクリックします。
+
+![改善された要素](/images/steps-editing-tests/editing-target-element-properties/543c4f1-small-improve.png)
 
 3. AUT ブラウザウィンドウで Base URL がまだ開かれていない場合、Testim は通知を表示します。通知の **Open base URL** リンクまたは **Run test to relevant step** ボタンをクリックして、ターゲット要素の改善を試みてください。
 
 ![Base URL を開く](/images/steps-editing-tests/editing-target-element-properties/f1464de-baseurl.png)
 
-![改善された要素](/images/steps-editing-tests/editing-target-element-properties/543c4f1-small-improve.png)
+4. Testim はスタンバイモードになります。AUT ブラウザで、ターゲット要素の上にマウスを移動し、クリックして選択します。
 
 ![改善対象のボタン](/images/steps-editing-tests/editing-target-element-properties/43cfd47-small-login.png)
-
-4. Testim はスタンバイモードになります。AUT ブラウザで、ターゲット要素の上にマウスを移動し、クリックして選択します。
 
 プロパティパネルの Target element ボックスでターゲット要素が更新されます。
 
@@ -146,13 +144,13 @@ Smart Locators の属性を編集することは一般的に推奨されませ�
 
    ![ロケーターパネル](/images/steps-editing-tests/editing-target-element-properties/827a8f3-Testim_Editing_Tests_030_r.png)
 
-   ![ロケーターパネルの別表示](/images/steps-editing-tests/editing-target-element-properties/c693307-Testim_Editing_Tests_034a_r.png)
-
    テストを実行した後、ロケーターパネルを開くと、星の重み付けに加えて、実行結果に基づくパーセンテージスコアが表示されます。
 
    ![実行後のロケーター](/images/steps-editing-tests/editing-target-element-properties/1f09ed4-Testim_Editing_Tests_033_r.png)
 
 4. 要素を表示している間、表示したい要素の上にマウスを移動し、ターゲットアイコンをクリックすることで、要素を視覚的に識別できます。
+
+![ロケーターパネルの別表示](/images/steps-editing-tests/editing-target-element-properties/c693307-Testim_Editing_Tests_034a_r.png)
 
 選択した要素が一時的にハイライトされた状態で AUT ブラウザが開きます。
 


### PR DESCRIPTION
## Summary

Adds EN-relative image parity detection to the source-parity pipeline and fixes the one image discrepancy it surfaced.

The scheduled diff-detection workflow had reported no actionable issues for ~5 weeks. An independent audit (parallel agents + a deterministic image cross-check over all 288 pages) confirmed the EN source had **not** drifted, but surfaced **one** JA page whose images diverged from the EN source — a class of discrepancy the existing pipeline did not detect (image count / duplication / order were never enforced).

## Background

- `snapshot-diff` only checks EN-side drift; `check_source_parity`'s segment alignment absorbs images as whitespace, so JA-side image count/duplication/order were never compared.
- The pre-existing `_image_order_issues` was effectively dead: it reads `en_body` (turndown markdown), whose images carry `title` attributes that never match the title-less JA basenames, so its dedup/guard logic bailed on every page.

## Changes

- **`image_parity_issues`** (new, `checks.py`): extracts EN images from raw EN HTML (`src`/`href`, avoiding turndown title contamination) and JA images from markdown (`![]()` / `<img>` / `<Image>`), normalizes basenames (lowercase + 7-char hash prefix + extension), and compares **EN-relative**:
  - multiset mismatch → `image-mismatch` (actionable)
  - same multiset, different order → `image-order-mismatch` (actionable)
  - EN-side duplicates/order are canonical, so a faithful JA mirror yields no finding (no false positives).
  - Wired into `check_source_parity` for all non-usability cases; routes through the reportable parity gate.
- **Removed** the superseded dead `_image_order_issues` and its now-unused `extract_image_sequence` import.
- **Content fix** — `editing-target-element-properties.md`: dropped a duplicated `4934439-properties.png` and reordered images in the "Improving the Target Element" / "Viewing Smart Locators" sections to match the EN source. Image parity is now clean across all 288 pages.
- **Tests (+11)**: clean / EN-duplicate-mirrored / JA-extra / JA-missing / reorder / case+hash tolerance / EN href image / JA code-fence / `<img>` / `<Image>`, plus a regression that `compare_snapshot_structure` no longer emits `image-order-mismatch`.

## Verification

- `npm run check:parity` — 288/288, 0 issues; **5-counter DoD all 0**
- Python suite **1919 passed**; conformance + cutover **869 passed**; mjs **21 passed**
- `npm run lint:docs` 0 errors / 288 files; `ruff check`/`format` clean; `npm run build` 290 pages
- Regression: pre-fix emits `image-mismatch`, post-fix clean
- **Two 4-specialist reviewer gates** (Architect / QA / Testing / Security) — both 4/4 PASS, no blocking findings

## Test plan

- [x] Unit tests for `image_parity_issues` (count / duplicate / order / normalization / tag forms)
- [x] Full parity check green across 288 pages, DoD counters 0
- [x] Conformance + cutover gate pass (dead-function removal has no impact)
- [x] Lint / build / mjs green
- [ ] CI `Scheduled Actionable Docs Checks` green on next schedule (managed detection issues unaffected)

## Notes

- New detection enhancement only; no change to the 2-mechanism suppression contract or baseline (`entries` stays 0).
- Known Sev3 nits intentionally deferred (zero current impact): `extract_image_sequence` is now an orphaned-but-tested export; `_JA_IMAGE_RE` could over-match `data-src` (no raw `<img>` / `data-src` exists in JA content).
