### PR TITLE
test: expand production E2E smoke coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test:all": "npm run test:mjs && npm run test:py:full",
     "test:e2e": "playwright test",
     "test:e2e:build": "npm run build && npm run test:e2e",
+    "test:e2e:production": "PLAYWRIGHT_BASE_URL=https://testim-docs-ja.vercel.app playwright test",
     "lint:docs": "cd scripts/python && uv run --locked python -m testim_parity.tools.lint_docs",
     "check:untranslated": "cd scripts/python && uv run python -m testim_parity.detection.find_untranslated",
     "lint:glossary": "cd scripts/python && uv run python -m testim_parity.tools.check_glossary_duplicates",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,8 @@ const localBaseURL = 'http://127.0.0.1:4321';
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: false,
+  forbidOnly: true,
+  failOnFlakyTests: Boolean(process.env.CI),
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: [['list'], ['html', { open: 'never' }]],

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const remoteBaseURL = process.env.PLAYWRIGHT_BASE_URL;
+const localBaseURL = 'http://127.0.0.1:4321';
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: false,
@@ -7,16 +10,18 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: [['list'], ['html', { open: 'never' }]],
   use: {
-    baseURL: 'http://127.0.0.1:4321',
+    baseURL: remoteBaseURL ?? localBaseURL,
     screenshot: 'only-on-failure',
     trace: 'on-first-retry',
   },
-  webServer: {
-    command: 'npm run preview -- --host 127.0.0.1',
-    url: 'http://127.0.0.1:4321',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-  },
+  webServer: remoteBaseURL
+    ? undefined
+    : {
+        command: 'npm run preview -- --host 127.0.0.1',
+        url: localBaseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
   projects: [
     {
       name: 'chromium',

--- a/tests/e2e/site-smoke.spec.ts
+++ b/tests/e2e/site-smoke.spec.ts
@@ -2,9 +2,13 @@ import { readFile } from 'node:fs/promises';
 
 import { expect, test, type Page } from '@playwright/test';
 
-const runtimeIssues = new WeakMap<Page, string[]>();
+type RuntimeIssue = { message: string; url?: string };
+
+const runtimeIssues = new WeakMap<Page, RuntimeIssue[]>();
 const checkedResourceTypes = new Set(['script', 'stylesheet', 'font', 'image']);
 const isRemoteTarget = Boolean(process.env.PLAYWRIGHT_BASE_URL);
+const expectedDocument404ConsoleErrorPattern =
+  /^console\.error: Failed to load resource: the server responded with a status of 404 \((?:Not Found)?\)$/;
 const visualViewports = [
   { name: 'desktop-1440x900', width: 1440, height: 900 },
   { name: 'mobile-390x844', width: 390, height: 844 },
@@ -18,26 +22,48 @@ async function expectNoHorizontalOverflow(page: Page) {
   expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
 }
 
+function acknowledgeExpectedDocument404(page: Page) {
+  const issues = runtimeIssues.get(page) ?? [];
+  const matchingIndexes = issues.flatMap((issue, index) =>
+    expectedDocument404ConsoleErrorPattern.test(issue.message) && issue.url === page.url()
+      ? [index]
+      : []
+  );
+  expect(
+    matchingIndexes.length,
+    '404ドキュメントに付随する既知のconsole error数'
+  ).toBeLessThanOrEqual(1);
+
+  if (matchingIndexes.length === 1) {
+    issues.splice(matchingIndexes[0], 1);
+  }
+}
+
 test.beforeEach(async ({ page }) => {
-  const issues: string[] = [];
+  const issues: RuntimeIssue[] = [];
   runtimeIssues.set(page, issues);
 
   page.on('pageerror', (error) => {
-    issues.push(`pageerror: ${error.message}`);
+    issues.push({ message: `pageerror: ${error.message}` });
   });
   page.on('console', (message) => {
     if (message.type() === 'error') {
-      issues.push(`console.error: ${message.text()}`);
+      issues.push({
+        message: `console.error: ${message.text()}`,
+        url: message.location().url,
+      });
     }
   });
   page.on('requestfailed', (request) => {
     if (checkedResourceTypes.has(request.resourceType())) {
-      issues.push(`requestfailed: ${request.url()} (${request.failure()?.errorText ?? 'unknown'})`);
+      issues.push({
+        message: `requestfailed: ${request.url()} (${request.failure()?.errorText ?? 'unknown'})`,
+      });
     }
   });
   page.on('response', (response) => {
     if (checkedResourceTypes.has(response.request().resourceType()) && response.status() >= 400) {
-      issues.push(`response: ${response.status()} ${response.url()}`);
+      issues.push({ message: `response: ${response.status()} ${response.url()}` });
     }
   });
 });
@@ -141,7 +167,19 @@ test('モバイルのカテゴリナビゲーションからドキュメント�
   await expect(page.getByRole('heading', { level: 1, name: 'Testim REST API' })).toBeVisible();
 });
 
-test('リダイレクト、404、robots、sitemapが有効である', async ({ request }) => {
+test('404ページが期待どおり表示される', async ({ page }) => {
+  const response = await page.goto('/this-page-does-not-exist');
+
+  expect(response?.status()).toBe(404);
+  await expect(page.getByRole('heading', { level: 1, name: '404' })).toBeVisible();
+  await expect(
+    page.getByRole('heading', { level: 2, name: 'ページが見つかりません' })
+  ).toBeVisible();
+  await expect(page.getByRole('link', { name: 'トップページへ戻る' })).toHaveAttribute('href', '/');
+  acknowledgeExpectedDocument404(page);
+});
+
+test('リダイレクト、robots、sitemapが有効である', async ({ request }) => {
   if (isRemoteTarget) {
     const redirect = await request.get('/docs/applitools-integration', { maxRedirects: 0 });
     expect(redirect.status()).toBe(301);
@@ -160,9 +198,6 @@ test('リダイレクト、404、robots、sitemapが有効である', async ({ r
       })
     );
   }
-
-  const notFound = await request.get('/this-page-does-not-exist');
-  expect(notFound.status()).toBe(404);
 
   const robots = await request.get('/robots.txt');
   expect(robots.status()).toBe(200);
@@ -187,34 +222,61 @@ test('公開ページにセキュリティヘッダーが付与される', async
     const vercelConfig = JSON.parse(await readFile('vercel.json', 'utf8')) as {
       headers: Array<{ source: string; headers: Array<{ key: string; value: string }> }>;
     };
-    expect(vercelConfig.headers).toContainEqual({
-      source: '/(.*)',
-      headers: [
-        { key: 'X-Frame-Options', value: 'DENY' },
-        { key: 'X-Content-Type-Options', value: 'nosniff' },
-        { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-      ],
-    });
+    expect(vercelConfig.headers).toContainEqual(
+      expect.objectContaining({
+        source: '/(.*)',
+        headers: expect.arrayContaining([
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+        ]),
+      })
+    );
   }
 });
 
 test('設定済みのNoto Sans JP 4ウェイトを読み込める', async ({ page }) => {
   await page.goto('/');
 
-  const loadedWeights = await page.evaluate(async () => {
-    const weights = [400, 500, 600, 700];
-    // 現行のFontsource設定で配信されるLatin subsetを確実に要求するcanary。
+  const fontFaceResults = await page.evaluate(async () => {
+    const weights = ['400', '500', '600', '700'];
     const fontLoadCanary = 'Testim';
+    const normalizeFamily = (family: string) => family.replace(/^(['"])(.*)\1$/, '$2');
     const fontFamily = getComputedStyle(document.documentElement)
       .getPropertyValue('--font-noto-sans-jp')
       .split(',')[0]
       .trim();
-    const loaded = await Promise.all(
-      weights.map((weight) => document.fonts.load(`${weight} 16px ${fontFamily}`, fontLoadCanary))
+    const matchingFaces = Array.from(document.fonts).filter(
+      (face) => normalizeFamily(face.family) === normalizeFamily(fontFamily)
     );
-    return weights.filter((_, index) => loaded[index].length > 0);
+
+    return Promise.all(
+      weights.map(async (weight) => {
+        const faces = matchingFaces.filter(
+          (face) => face.weight === weight && face.style === 'normal'
+        );
+        await Promise.all(faces.map((face) => face.load()));
+        const canaryFaces = await document.fonts.load(
+          `${weight} 16px ${fontFamily}`,
+          fontLoadCanary
+        );
+        return {
+          weight,
+          count: faces.length,
+          loaded: faces.length === 1 && faces[0].status === 'loaded',
+          canaryMatched: faces.length === 1 && canaryFaces.includes(faces[0]),
+        };
+      })
+    );
   });
-  expect(loadedWeights).toEqual([400, 500, 600, 700]);
+  expect(fontFaceResults).toEqual(
+    ['400', '500', '600', '700'].map((weight) => ({
+      weight,
+      count: 1,
+      loaded: true,
+      canaryMatched: true,
+    }))
+  );
 });
 
 test('desktopとmobileでトップページが横にはみ出さない', async ({ page }, testInfo) => {

--- a/tests/e2e/site-smoke.spec.ts
+++ b/tests/e2e/site-smoke.spec.ts
@@ -3,7 +3,16 @@ import { readFile } from 'node:fs/promises';
 import { expect, test, type Page } from '@playwright/test';
 
 const runtimeIssues = new WeakMap<Page, string[]>();
-const checkedResourceTypes = new Set(['script', 'stylesheet', 'font']);
+const checkedResourceTypes = new Set(['script', 'stylesheet', 'font', 'image']);
+const isRemoteTarget = Boolean(process.env.PLAYWRIGHT_BASE_URL);
+
+async function expectNoHorizontalOverflow(page: Page) {
+  const dimensions = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+}
 
 test.beforeEach(async ({ page }) => {
   const issues: string[] = [];
@@ -34,14 +43,27 @@ test.afterEach(async ({ page }) => {
 });
 
 test('トップページから代表ドキュメントへ遷移できる', async ({ page }) => {
-  await page.goto('/');
+  const response = await page.goto('/');
 
+  expect(response?.status()).toBe(200);
+  await expect(page).toHaveTitle(/Tricentis Testim.*\| Tricentis Testim/);
   await expect(
     page.getByRole('heading', { name: /Tricentis Testim.*ユーザー制作日本語翻訳ドキュメント/ })
   ).toBeVisible();
   await page.getByRole('link', { name: 'ドキュメントを読む' }).click();
   await expect(page).toHaveURL(/\/docs\/overview\/testim-overview\/?$/);
   await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+});
+
+test('デスクトップのサイドバーからドキュメントへ遷移できる', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto('/docs/overview/testim-overview');
+
+  const navigation = page.getByRole('navigation', { name: 'ドキュメントナビゲーション' });
+  await expect(navigation).toBeVisible();
+  await navigation.getByRole('link', { name: 'Web とモバイルテスト', exact: true }).click();
+  await expect(page).toHaveURL(/\/docs\/overview\/testim-overview\/testim-automate\/?$/);
+  await expect(page.getByRole('heading', { level: 1, name: 'Web とモバイルテスト' })).toBeVisible();
 });
 
 test('既存のMarkdown拡張が本番ビルドで描画される', async ({ page }) => {
@@ -84,17 +106,37 @@ test('検索インデックスとキーボード操作が機能する', async ({
   await expect(page).toHaveURL(/\/docs\/administration\/api-access\/?$/);
 });
 
+test('モバイルのカテゴリナビゲーションからドキュメントへ遷移できる', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/docs/overview/testim-overview');
+
+  await expect(page.getByRole('navigation', { name: 'ドキュメントナビゲーション' })).toBeHidden();
+  const navigation = page.getByRole('combobox', { name: 'カテゴリナビゲーション' });
+  await expect(navigation).toBeVisible();
+  await navigation.selectOption('/docs/administration/api-access');
+  await expect(page).toHaveURL(/\/docs\/administration\/api-access\/?$/);
+  await expect(page.getByRole('heading', { level: 1, name: 'Testim REST API' })).toBeVisible();
+});
+
 test('リダイレクト、404、robots、sitemapが有効である', async ({ request }) => {
-  const deploymentConfig = JSON.parse(await readFile('.vercel/output/config.json', 'utf8')) as {
-    routes: Array<{ src?: string; status?: number; headers?: Record<string, string> }>;
-  };
-  expect(deploymentConfig.routes).toContainEqual(
-    expect.objectContaining({
-      src: '^/docs/applitools-integration$',
-      status: 301,
-      headers: { Location: '/docs/integrations/visual-validation' },
-    })
-  );
+  if (isRemoteTarget) {
+    const redirect = await request.get('/docs/applitools-integration', { maxRedirects: 0 });
+    expect(redirect.status()).toBe(301);
+    expect(new URL(redirect.headers().location, 'https://example.invalid').pathname).toBe(
+      '/docs/integrations/visual-validation'
+    );
+  } else {
+    const deploymentConfig = JSON.parse(await readFile('.vercel/output/config.json', 'utf8')) as {
+      routes: Array<{ src?: string; status?: number; headers?: Record<string, string> }>;
+    };
+    expect(deploymentConfig.routes).toContainEqual(
+      expect.objectContaining({
+        src: '^/docs/applitools-integration$',
+        status: 301,
+        headers: { Location: '/docs/integrations/visual-validation' },
+      })
+    );
+  }
 
   const notFound = await request.get('/this-page-does-not-exist');
   expect(notFound.status()).toBe(404);
@@ -108,28 +150,69 @@ test('リダイレクト、404、robots、sitemapが有効である', async ({ r
   expect(await sitemap.text()).toContain('<sitemapindex');
 });
 
-test('モバイル幅でページ全体が横にはみ出さない', async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 844 });
+test('公開ページにセキュリティヘッダーが付与される', async ({ request }) => {
+  if (isRemoteTarget) {
+    const response = await request.get('/');
 
-  const targets = [
-    {
-      path: '/',
-      primaryElement: page.getByRole('link', { name: 'ドキュメントを読む' }),
-    },
-    {
-      path: '/docs/administration/api-access',
-      primaryElement: page.getByRole('button', { name: '検索' }),
-    },
+    expect(response.status()).toBe(200);
+    expect(response.headers()).toMatchObject({
+      'x-frame-options': 'DENY',
+      'x-content-type-options': 'nosniff',
+      'referrer-policy': 'strict-origin-when-cross-origin',
+    });
+  } else {
+    const vercelConfig = JSON.parse(await readFile('vercel.json', 'utf8')) as {
+      headers: Array<{ source: string; headers: Array<{ key: string; value: string }> }>;
+    };
+    expect(vercelConfig.headers).toContainEqual({
+      source: '/(.*)',
+      headers: [
+        { key: 'X-Frame-Options', value: 'DENY' },
+        { key: 'X-Content-Type-Options', value: 'nosniff' },
+        { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+      ],
+    });
+  }
+});
+
+test('Noto Sans JPの4ウェイトを読み込める', async ({ page }) => {
+  await page.goto('/');
+
+  const loadedWeights = await page.evaluate(async () => {
+    const weights = [400, 500, 600, 700];
+    const fontFamily = getComputedStyle(document.documentElement)
+      .getPropertyValue('--font-noto-sans-jp')
+      .split(',')[0]
+      .trim();
+    const loaded = await Promise.all(
+      weights.map((weight) => document.fonts.load(`${weight} 16px ${fontFamily}`, 'Testim'))
+    );
+    return weights.filter((_, index) => loaded[index].length > 0);
+  });
+  expect(loadedWeights).toEqual([400, 500, 600, 700]);
+});
+
+test('desktopとmobileでページ全体が横にはみ出さない', async ({ page }, testInfo) => {
+  const viewports = [
+    { name: 'desktop-1440x900', width: 1440, height: 900 },
+    { name: 'mobile-390x844', width: 390, height: 844 },
   ];
 
-  for (const { path, primaryElement } of targets) {
-    await page.goto(path);
+  for (const viewport of viewports) {
+    await page.setViewportSize(viewport);
+
+    await page.goto('/');
     await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
-    await expect(primaryElement).toBeVisible();
-    const dimensions = await page.evaluate(() => ({
-      clientWidth: document.documentElement.clientWidth,
-      scrollWidth: document.documentElement.scrollWidth,
-    }));
-    expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+    await expect(page.getByRole('link', { name: 'ドキュメントを読む' })).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+
+    const screenshotPath = testInfo.outputPath(`${viewport.name}.png`);
+    await page.screenshot({ path: screenshotPath });
+    await testInfo.attach(viewport.name, { path: screenshotPath, contentType: 'image/png' });
+
+    await page.goto('/docs/administration/api-access');
+    await expect(page.getByRole('heading', { level: 1, name: 'Testim REST API' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '検索' })).toBeVisible();
+    await expectNoHorizontalOverflow(page);
   }
 });

--- a/tests/e2e/site-smoke.spec.ts
+++ b/tests/e2e/site-smoke.spec.ts
@@ -5,6 +5,10 @@ import { expect, test, type Page } from '@playwright/test';
 const runtimeIssues = new WeakMap<Page, string[]>();
 const checkedResourceTypes = new Set(['script', 'stylesheet', 'font', 'image']);
 const isRemoteTarget = Boolean(process.env.PLAYWRIGHT_BASE_URL);
+const visualViewports = [
+  { name: 'desktop-1440x900', width: 1440, height: 900 },
+  { name: 'mobile-390x844', width: 390, height: 844 },
+];
 
 async function expectNoHorizontalOverflow(page: Page) {
   const dimensions = await page.evaluate(() => ({
@@ -66,7 +70,7 @@ test('デスクトップのサイドバーからドキュメントへ遷移で�
   await expect(page.getByRole('heading', { level: 1, name: 'Web とモバイルテスト' })).toBeVisible();
 });
 
-test('既存のMarkdown拡張が本番ビルドで描画される', async ({ page }) => {
+test('APIドキュメントのMarkdown拡張と主要画像が本番ビルドで描画される', async ({ page }) => {
   await page.goto('/docs/administration/api-access');
 
   await expect(page.getByRole('heading', { level: 1, name: 'Testim REST API' })).toBeVisible();
@@ -74,9 +78,28 @@ test('既存のMarkdown拡張が本番ビルドで描画される', async ({ pag
   await expect(page.locator('.expressive-code').first()).toBeVisible();
   await expect(page.locator('.heading-link').first()).toBeVisible();
 
+  const contentImage = page.getByRole('img', {
+    name: 'API 設定ページと Generate API Key ボタン',
+  });
+  await expect(contentImage).toBeVisible();
+  await expect(contentImage).toHaveJSProperty('complete', true);
+  expect(
+    await contentImage.evaluate((image: HTMLImageElement) => image.naturalWidth)
+  ).toBeGreaterThan(0);
+});
+
+test('記録ドキュメントの表と主要画像が本番ビルドで描画される', async ({ page }) => {
   await page.goto('/docs/recording-tests/how-to-record-a-test');
+
   await expect(page.getByRole('heading', { level: 1, name: 'Web テストの記録方法' })).toBeVisible();
   await expect(page.locator('.overflow-x-auto > table').first()).toBeVisible();
+
+  const contentImage = page.getByRole('img', { name: 'New Test の作成' });
+  await expect(contentImage).toBeVisible();
+  await expect(contentImage).toHaveJSProperty('complete', true);
+  expect(
+    await contentImage.evaluate((image: HTMLImageElement) => image.naturalWidth)
+  ).toBeGreaterThan(0);
 });
 
 test('検索インデックスとキーボード操作が機能する', async ({ page }) => {
@@ -175,44 +198,57 @@ test('公開ページにセキュリティヘッダーが付与される', async
   }
 });
 
-test('Noto Sans JPの4ウェイトを読み込める', async ({ page }) => {
+test('設定済みのNoto Sans JP 4ウェイトを読み込める', async ({ page }) => {
   await page.goto('/');
 
   const loadedWeights = await page.evaluate(async () => {
     const weights = [400, 500, 600, 700];
+    // 現行のFontsource設定で配信されるLatin subsetを確実に要求するcanary。
+    const fontLoadCanary = 'Testim';
     const fontFamily = getComputedStyle(document.documentElement)
       .getPropertyValue('--font-noto-sans-jp')
       .split(',')[0]
       .trim();
     const loaded = await Promise.all(
-      weights.map((weight) => document.fonts.load(`${weight} 16px ${fontFamily}`, 'Testim'))
+      weights.map((weight) => document.fonts.load(`${weight} 16px ${fontFamily}`, fontLoadCanary))
     );
     return weights.filter((_, index) => loaded[index].length > 0);
   });
   expect(loadedWeights).toEqual([400, 500, 600, 700]);
 });
 
-test('desktopとmobileでページ全体が横にはみ出さない', async ({ page }, testInfo) => {
-  const viewports = [
-    { name: 'desktop-1440x900', width: 1440, height: 900 },
-    { name: 'mobile-390x844', width: 390, height: 844 },
-  ];
+test('desktopとmobileでトップページが横にはみ出さない', async ({ page }, testInfo) => {
+  await page.setViewportSize(visualViewports[0]);
+  await page.goto('/');
 
-  for (const viewport of viewports) {
+  for (const viewport of visualViewports) {
     await page.setViewportSize(viewport);
 
-    await page.goto('/');
     await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
     await expect(page.getByRole('link', { name: 'ドキュメントを読む' })).toBeVisible();
     await expectNoHorizontalOverflow(page);
 
-    const screenshotPath = testInfo.outputPath(`${viewport.name}.png`);
+    const screenshotName = `home-${viewport.name}`;
+    const screenshotPath = testInfo.outputPath(`${screenshotName}.png`);
     await page.screenshot({ path: screenshotPath });
-    await testInfo.attach(viewport.name, { path: screenshotPath, contentType: 'image/png' });
+    await testInfo.attach(screenshotName, { path: screenshotPath, contentType: 'image/png' });
+  }
+});
 
-    await page.goto('/docs/administration/api-access');
+test('desktopとmobileで代表ドキュメントが横にはみ出さない', async ({ page }, testInfo) => {
+  await page.setViewportSize(visualViewports[0]);
+  await page.goto('/docs/administration/api-access');
+
+  for (const viewport of visualViewports) {
+    await page.setViewportSize(viewport);
+
     await expect(page.getByRole('heading', { level: 1, name: 'Testim REST API' })).toBeVisible();
     await expect(page.getByRole('button', { name: '検索' })).toBeVisible();
     await expectNoHorizontalOverflow(page);
+
+    const screenshotName = `api-access-${viewport.name}`;
+    const screenshotPath = testInfo.outputPath(`${screenshotName}.png`);
+    await page.screenshot({ path: screenshotPath });
+    await testInfo.attach(screenshotName, { path: screenshotPath, contentType: 'image/png' });
   }
 });


### PR DESCRIPTION
## Summary

- allow the Playwright smoke suite to target the deployed site through `PLAYWRIGHT_BASE_URL`
- add a dedicated `npm run test:e2e:production` command for the canonical production alias
- extend E2E coverage for desktop sidebar navigation, mobile category navigation, search, redirects, rendered 404 UI, live HTTP behavior, and positive image rendering
- verify robots/sitemap responses, security headers, the exact configured Noto Sans JP Latin faces for four weights, and failed script/stylesheet/font/image requests
- capture home and representative documentation pages at 1440x900 and 390x844 as four Playwright report attachments
- reject focused tests globally and fail CI when a retry produces a flaky result

## Why

Issue #413 required post-merge production smoke evidence after the Astro 7 / Vite 8 migration. Playwright and CI were already introduced for #187, but the existing suite did not directly exercise sidebar navigation, mobile navigation, positive content-image rendering, rendered 404 content, or production-only HTTP behavior.

The configuration keeps local preview startup for normal E2E runs and skips `webServer` when an external base URL is supplied. The production command fixes the canonical HTTPS alias in a repository-local script, while `forbidOnly` and CI-only `failOnFlakyTests` prevent silently reduced or flaky coverage.

## Review fixes

- reproduced an intermittent false positive where a second `page.goto()` intentionally aborted an in-flight React module request, then split targets by page lifecycle
- added positive `complete` / `naturalWidth` assertions for representative content images
- expanded visual evidence to home and API documentation in both viewports
- changed 404 coverage from an API-only status check to status plus rendered headings and the recovery link
- limited the expected Chromium document-404 console error to one exact message from the exact 404 document URL
- verify one exact normal `FontFace` for each configured weight and require the same face to match the current Latin canary
- added `forbidOnly: true` and CI `failOnFlakyTests` so focused or retry-dependent results cannot pass silently
- kept the font check scoped to the currently configured Latin Fontsource subset; Japanese glyph delivery and its performance budget are tracked separately in #417

## Production smoke evidence

- Production URL: https://testim-docs-ja.vercel.app/ (HTTP 200)
- Deployment URL: https://testim-docs-q23hki2to-rymetry-projects-d14914e4.vercel.app/
- Deployment ID: `5469396797`
- Deployment commit: `8154ac6c925bd438602679825ddd545e1722842b`
- GitHub deployment state: `success`
- Confirmed: 2026-07-16 JST
- Candidate local smoke: 12/12 passed
- Focused production stability run: 10/10 passed (`--grep "404ページ|Noto Sans JP" --repeat-each=5 --workers=1`)
- Full production stability run: 60/60 passed (`--repeat-each=5 --workers=1`)
- Four desktop/mobile screenshots reviewed without layout regressions or unnatural Japanese spacing
- No unexpected `pageerror`, `console.error`, or failed script, stylesheet, font, or image requests
- The deployment-specific URL redirects to Vercel SSO; this is expected and does not affect the public production alias
- Three independent final re-review passes approved the candidate with no findings
- Diff-scoped security scan completed with no reportable findings
- No unresolved P0/P1 findings

## Validation

- `npm run build` (290 pages; zero diagnostics)
- `npm run test:e2e` (12 passed)
- `npm run test:e2e:production -- --grep "404ページ|Noto Sans JP" --repeat-each=5 --workers=1` (10 passed)
- `npm run test:e2e:production -- --repeat-each=5 --workers=1` (60 passed)
- `npx playwright test --list` (12 tests)
- `npx prettier --check playwright.config.ts package.json tests/e2e/site-smoke.spec.ts`
- `git diff --check`

Refs #413
Closes #187
