### PR TITLE
chore: npm パッケージの公開後7日間の待機ポリシーを追加

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
## 概要

- プロジェクト管理の `.npmrc` に `min-release-age=7` を追加
- 公開直後のパッケージバージョンを依存解決から7日間除外し、サプライチェーンリスクを抑制

## 影響と注意点

- この設定の強制には npm 11.10 以上が必要です
- 現在固定されている npm 11.8.0 では値は読み取れるものの `Unknown project config` 警告となり、待機ポリシーはまだ強制されません
- `ignore-scripts` は有効化していません
- 依存関係および `package-lock.json` の変更はありません

## 検証

- `.npmrc` が `min-release-age=7` の1行のみであることを確認
- `npm config get min-release-age`: `7`
- `npm config get ignore-scripts`: `false`
- `origin/main...HEAD` の差分が `.npmrc` のみであることを確認