### PR TITLE
chore: npm 11.18.0 を固定して公開後7日待機を有効化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,17 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
-          cache: 'npm'
       - name: Enable pinned npm
         run: |
           corepack enable npm
           npm --version
+      - name: Cache npm downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-npm-
       - run: npm ci
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -53,11 +59,17 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
-          cache: 'npm'
       - name: Enable pinned npm
         run: |
           corepack enable npm
           npm --version
+      - name: Cache npm downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-npm-
       - run: npm ci
       - run: npm run test:mjs
 
@@ -68,11 +80,17 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
-          cache: 'npm'
       - name: Enable pinned npm
         run: |
           corepack enable npm
           npm --version
+      - name: Cache npm downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-npm-
       - run: npm ci
       - name: Build static site
         run: npm run build
@@ -84,11 +102,17 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
-          cache: 'npm'
       - name: Enable pinned npm
         run: |
           corepack enable npm
           npm --version
+      - name: Cache npm downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-npm-
       - run: npm ci
       - name: Build Vercel SSR site with Basic Auth
         run: npm run build
@@ -102,11 +126,17 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
-          cache: 'npm'
       - name: Enable pinned npm
         run: |
           corepack enable npm
           npm --version
+      - name: Cache npm downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-npm-
       - run: npm ci
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,10 @@ jobs:
         working-directory: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
+          package-manager-cache: false
       - name: Enable pinned npm
         run: |
           corepack enable npm
@@ -56,9 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
+          package-manager-cache: false
       - name: Enable pinned npm
         run: |
           corepack enable npm
@@ -77,9 +79,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
+          package-manager-cache: false
       - name: Enable pinned npm
         run: |
           corepack enable npm
@@ -99,9 +102,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
+          package-manager-cache: false
       - name: Enable pinned npm
         run: |
           corepack enable npm
@@ -123,9 +127,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
+          package-manager-cache: false
       - name: Enable pinned npm
         run: |
           corepack enable npm
@@ -281,9 +286,10 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
+          package-manager-cache: false
       - name: Enable pinned npm
         run: |
           corepack enable npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '22'
+          node-version: '24'
           package-manager-cache: false
       - name: Enable pinned npm
         run: |
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '22'
+          node-version: '24'
           package-manager-cache: false
       - name: Enable pinned npm
         run: |
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '22'
+          node-version: '24'
           package-manager-cache: false
       - name: Enable pinned npm
         run: |
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '22'
+          node-version: '24'
           package-manager-cache: false
       - name: Enable pinned npm
         run: |
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '22'
+          node-version: '24'
           package-manager-cache: false
       - name: Enable pinned npm
         run: |
@@ -288,7 +288,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '22'
+          node-version: '24'
           package-manager-cache: false
       - name: Enable pinned npm
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+      - name: Enable pinned npm
+        run: |
+          corepack enable npm
+          npm --version
       - run: npm ci
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -50,6 +54,10 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+      - name: Enable pinned npm
+        run: |
+          corepack enable npm
+          npm --version
       - run: npm ci
       - run: npm run test:mjs
 
@@ -61,6 +69,10 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+      - name: Enable pinned npm
+        run: |
+          corepack enable npm
+          npm --version
       - run: npm ci
       - name: Build static site
         run: npm run build
@@ -73,6 +85,10 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+      - name: Enable pinned npm
+        run: |
+          corepack enable npm
+          npm --version
       - run: npm ci
       - name: Build Vercel SSR site with Basic Auth
         run: npm run build
@@ -87,6 +103,10 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+      - name: Enable pinned npm
+        run: |
+          corepack enable npm
+          npm --version
       - run: npm ci
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
@@ -231,6 +251,13 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+      - name: Enable pinned npm
+        run: |
+          corepack enable npm
+          npm --version
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version-file: scripts/python/.python-version

--- a/.github/workflows/deep-audit.yml
+++ b/.github/workflows/deep-audit.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+      - name: Enable pinned npm
+        run: |
+          corepack enable npm
+          npm --version
       - name: Install Node dependencies
         run: npm ci
       - name: Setup Python

--- a/.github/workflows/deep-audit.yml
+++ b/.github/workflows/deep-audit.yml
@@ -42,11 +42,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
       - name: Enable pinned npm
         run: |
           corepack enable npm
           npm --version
+      - name: Cache npm downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-npm-
       - name: Install Node dependencies
         run: npm ci
       - name: Setup Python

--- a/.github/workflows/deep-audit.yml
+++ b/.github/workflows/deep-audit.yml
@@ -39,9 +39,10 @@ jobs:
       # Phase 6b cutover: docs pipeline / parity CLI は全て Python (``uv run``)
       # 経由。Node は package.json orchestrator + markdownlint で残る。
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
+          package-manager-cache: false
       - name: Enable pinned npm
         run: |
           corepack enable npm

--- a/.github/workflows/deep-audit.yml
+++ b/.github/workflows/deep-audit.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '22'
+          node-version: '24'
           package-manager-cache: false
       - name: Enable pinned npm
         run: |

--- a/.github/workflows/scheduled-actionable.yml
+++ b/.github/workflows/scheduled-actionable.yml
@@ -41,6 +41,10 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+      - name: Enable pinned npm
+        run: |
+          corepack enable npm
+          npm --version
       - name: Install Node dependencies
         run: npm ci
       - name: Setup Python

--- a/.github/workflows/scheduled-actionable.yml
+++ b/.github/workflows/scheduled-actionable.yml
@@ -37,9 +37,10 @@ jobs:
       # actions/github-script runtime + sync-detection-issues.cjs (Phase 6.1
       # scope) で残る。
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '22'
+          package-manager-cache: false
       - name: Enable pinned npm
         run: |
           corepack enable npm

--- a/.github/workflows/scheduled-actionable.yml
+++ b/.github/workflows/scheduled-actionable.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
-          node-version: '22'
+          node-version: '24'
           package-manager-cache: false
       - name: Enable pinned npm
         run: |

--- a/.github/workflows/scheduled-actionable.yml
+++ b/.github/workflows/scheduled-actionable.yml
@@ -40,11 +40,17 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'npm'
       - name: Enable pinned npm
         run: |
           corepack enable npm
           npm --version
+      - name: Cache npm downloads
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-npm-
       - name: Install Node dependencies
         run: npm ci
       - name: Setup Python

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Tricentis Testim 公式英語ドキュメントのユーザー制作日本語翻訳",
   "type": "module",
   "version": "0.0.1",
+  "packageManager": "npm@11.19.0+sha512.48377f8478372aa1c4e47b763475b135836da82436a5700f2e5e8eb5084fc840f93c7b117eb3ad3b5f7d3194c81b6710a10d59448f6ddbcb21ac3fb672bdc003",
   "license": "MIT",
   "author": "rymetry",
   "homepage": "https://github.com/rymetry/testim-docs-ja#readme",
@@ -15,6 +16,13 @@
   },
   "engines": {
     "node": ">=22.12.0 <25"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.10.0",
+      "onFail": "error"
+    }
   },
   "scripts": {
     "dev": "astro dev",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Tricentis Testim 公式英語ドキュメントのユーザー制作日本語翻訳",
   "type": "module",
   "version": "0.0.1",
-  "packageManager": "npm@11.19.0+sha512.48377f8478372aa1c4e47b763475b135836da82436a5700f2e5e8eb5084fc840f93c7b117eb3ad3b5f7d3194c81b6710a10d59448f6ddbcb21ac3fb672bdc003",
+  "packageManager": "npm@11.18.0+sha512.4faecce0be70366d1c67b1012c4adc1246354a6cc45bf589f92003073b05518d547403df1475c542d67a4845e22b4fafcd7cac0af02c7a96cc6814f09eb003fb",
   "license": "MIT",
   "author": "rymetry",
   "homepage": "https://github.com/rymetry/testim-docs-ja#readme",


### PR DESCRIPTION
## 概要

先にマージ済みの `.npmrc` の `min-release-age=7` を、実際のインストール経路で有効にします。

変更前のCIは Node.js 22.23.1同梱の npm 10.9.8を使用しており、ローカルで確認した npm 11.8.0 と同様に、この設定を強制できませんでした。また、`actions/setup-node` の組み込み npm cache が Corepack より先に npm 10.9.8 で `npm config get cache` を実行し、`devEngines` の検証で失敗していました。

- `packageManager` で npm 11.18.0 を整合性ハッシュ付きで固定
- `devEngines.packageManager` で npm 11.10.0未満をエラーに設定
- CIのNode.jsを24へ更新（`package.json` / `package-lock.json` の engines 範囲内）
- npmを実行するCIジョブで `corepack enable npm` を実行し、固定版を有効化
- `actions/setup-node` を v6 の commit SHA で固定し、全 npm job で `package-manager-cache: false` を設定
- setup-node の自動 npm cache を無効にし、Corepack 有効化後に `actions/cache` で `~/.npm` を復元
- キャッシュキーを OS・CPU・`package-lock.json` に連動
- 暗黙のNode/npmに依存していた `parity` ジョブにも `actions/setup-node` を追加

## 影響

- npm 11.10.0未満では、依存関係のインストール・更新前に明示的に失敗します
- CIでは Node.js 24 + npm 11.18.0 が使われ、公開後7日未満のパッケージを除外する設定が有効になります
- Corepack 後の明示 `actions/cache` が唯一の npm キャッシュ機構になります
- npm のダウンロードキャッシュは維持されます
- `ignore-scripts` は有効化していません
- 依存パッケージ、`package-lock.json`、`.npmrc` の変更はありません

## 検証

- npm 11.8.0: `npm ci --dry-run` が `EBADDEVENGINES` で停止
- Corepack経由 npm 11.18.0: `min-release-age=7`、`ignore-scripts=false` を確認
- Node.js 24.13.1で `npm run test:mjs`: 21件成功
- Node.js 24.13.1で `npm run build`: 290ページのビルド成功
- `package.json` / `package-lock.json` の engines `>=22.12.0 <25` にNode.js 24が適合することを確認
- 3 workflow の YAML 構文を確認
- 8つの setup-node 利用 job すべてが `node-version: '24'` かつ自動 package-manager cache 無効であることを確認
- 7つの install job で `setup-node` → Corepack → 明示 cache → `npm ci` の順序と lockfile キーを確認
- `git diff --check`: 成功