### PR TITLE
fix: stop headings from rendering as blue underlined links

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -448,9 +448,11 @@
      削除した (EC の frame styling は astro.config.mjs の styleOverrides で
      調整する契約に移行)。*/
 
-  /* 見出しリンク */
-  .heading-link {
-    @apply no-underline hover:underline;
+  /* 見出しリンク: rehype-autolink-headings の behavior 'wrap' により見出し全体が
+     アンカーになるため、.docs-prose a (詳細度 0,1,1) の本文リンク用スタイルに
+     詳細度で勝つセレクタで色と下線を打ち消す。hover 時のみ下線でリンク可能と示す。 */
+  .docs-prose a.heading-link {
+    @apply text-inherit no-underline hover:underline;
   }
 
   /* 見出しのアンカー遷移時にヘッダー下に隠れないようオフセット */


### PR DESCRIPTION
## Summary

Documentation headings (h2 etc.) have rendered as blue underlined links since the initial commit. `rehype-autolink-headings` (`behavior: 'wrap'`) wraps every heading in an anchor with class `heading-link`, and the generic `.docs-prose a` rule (specificity 0,1,1) painted those anchors `text-blue-600 underline`. The intended override `.heading-link { no-underline }` (0,1,0) always lost the specificity contest and never reset the color at all.

Verified the same rendering exists on production main (`https://testim-docs-ja.vercel.app`), so this is a pre-existing bug unrelated to PR #432.

### Fix

Scope the override as `.docs-prose a.heading-link` (0,2,1):
- `color: inherit` — headings render in their normal text color
- `no-underline` with `hover:underline` — the hover underline remains as the affordance that headings are linkable
- On the specificity tie with `.docs-prose a:hover` (0,2,1), the override wins by source order (verified in built CSS)

Body links inside prose keep their existing blue underlined style (verified via computed styles in the built site).

## Test plan

- [x] `npm run build`
- [x] `npx playwright test` (12/12)
- [x] Prettier check on changed file
- [x] Browser verification on built dist: headings slate-900 / no underline; body links unchanged (blue-600 + underline)
- [x] Built CSS contains `.docs-prose a.heading-link{color:inherit;text-decoration-line:none}` + hover rule, positioned after `.docs-prose a:hover`

🤖 Generated with [Claude Code](https://claude.com/claude-code)